### PR TITLE
Retriable jobs with configurable intervals

### DIFF
--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -118,7 +118,9 @@ namespace FundsManager.Data.Repositories
             var map = new JobDataMap();
             map.Put("closeRequestId", closeRequest.Id);
             map.Put("forceClose", forceClose);
-            var job = RetriableJob.Create<ChannelCloseJob>(map, closeRequest.Id.ToString());
+
+            var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_CHANNEL_CLOSE");
+            var job = RetriableJob.Create<ChannelCloseJob>(map, closeRequest.Id.ToString(), retryList);
             await scheduler.ScheduleJob(job.Job, job.Trigger);
 
             // TODO: Check job id

--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -119,7 +119,7 @@ namespace FundsManager.Data.Repositories
             map.Put("closeRequestId", closeRequest.Id);
             map.Put("forceClose", forceClose);
 
-            var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
+            var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTERVAL_LIST_IN_MINUTES");
             var job = RetriableJob.Create<ChannelCloseJob>(map, closeRequest.Id.ToString(), retryList);
             await scheduler.ScheduleJob(job.Job, job.Trigger);
 

--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -119,7 +119,7 @@ namespace FundsManager.Data.Repositories
             map.Put("closeRequestId", closeRequest.Id);
             map.Put("forceClose", forceClose);
 
-            var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_CHANNEL_CLOSE");
+            var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
             var job = RetriableJob.Create<ChannelCloseJob>(map, closeRequest.Id.ToString(), retryList);
             await scheduler.ScheduleJob(job.Job, job.Trigger);
 

--- a/src/Helpers/JobTypes.cs
+++ b/src/Helpers/JobTypes.cs
@@ -5,6 +5,12 @@ namespace FundsManager.Helpers;
 
 public class SimpleJob
 {
+    /// <summary>
+    /// Creates a job that starts immediately when scheduled
+    /// </summary>
+    /// <param name="data">The data you want to have access to inside the Job</param>
+    /// <param name="identitySuffix">A suffix to identify a specific job, triggered from the same class</param>
+    /// <returns>An object with a job and a trigger to pass to a scheduler</returns>
     public static JobAndTrigger Create<T>(JobDataMap data, string identitySuffix) where T : IJob
     {
         var job = JobBuilder.Create<T>()
@@ -23,6 +29,13 @@ public class SimpleJob
 
 public class RetriableJob
 {
+    /// <summary>
+    /// Creates a job that can be retried if failed. Used in conjuntion with RetriablaJobScheduler
+    /// </summary>
+    /// <param name="data">The data you want to have access to inside the Job</param>
+    /// <param name="identitySuffix">A suffix to identify a specific job, triggered from the same class</param>
+    /// <param name="intervalListInMinutes">An optional list of retry intervals in minutes, defaults to { 1, 5, 10, 20 }</param>
+    /// <returns>An object with a job and a trigger to pass to a scheduler</returns>
     public static JobAndTrigger Create<T>(JobDataMap data, string identitySuffix, int[]? intervalListInMinutes = null) where T : IJob
     {
         intervalListInMinutes = intervalListInMinutes ?? new int[] { 1, 5, 10, 20 };
@@ -78,8 +91,12 @@ public class JobAndTrigger
     }
 }
 
-public class JobRescheduler
+public class RetriableJobRescheduler
 {
+    /// <summary>
+    /// Call this function at the start of your Retriable job to schedule the next interval in the array.
+    /// </summary>
+    /// <param name="context">The execution context of the job</param>
     public static async Task SetNextInterval(IJobExecutionContext context)
     {
         var data = context.JobDetail.JobDataMap;

--- a/src/Helpers/JobTypes.cs
+++ b/src/Helpers/JobTypes.cs
@@ -75,7 +75,7 @@ public class RetriableJob
     /// </summary>
     /// <param name="context">The execution context of the job</param>
     /// <param name="f">The action you want to perform inside the job</param>
-    public static async Task Execute(IJobExecutionContext context, Func<Task> f)
+    public static async Task Execute(IJobExecutionContext context, Func<Task> callback)
     {
         var token = context.CancellationToken;
         token.ThrowIfCancellationRequested();
@@ -101,7 +101,7 @@ public class RetriableJob
 
         await context.Scheduler.RescheduleJob(context.Trigger.Key, trigger);
 
-        await f();
+        await callback();
 
         var schedule = context.Scheduler.DeleteJob(context.JobDetail.Key, token);
     }

--- a/src/Helpers/JobTypes.cs
+++ b/src/Helpers/JobTypes.cs
@@ -71,7 +71,7 @@ public class RetriableJob
     }
 
     /// <summary>
-    /// Call this function at the start of your Retriable job to schedule the next interval in the array.
+    /// Call this function inside your Job's Execute method to set up retries and execute your action.
     /// </summary>
     /// <param name="context">The execution context of the job</param>
     /// <param name="f">The action you want to perform inside the job</param>

--- a/src/Jobs/ChannelAcceptorJob.cs
+++ b/src/Jobs/ChannelAcceptorJob.cs
@@ -46,7 +46,7 @@ public class ChannelAcceptorJob : IJob
         catch (Exception e)
         {
             _logger.LogError(e, "Error on {JobName}", nameof(ChannelAcceptorJob));
-            throw new JobExecutionException(e, true);
+            throw new JobExecutionException(e, false);
         }
 
         _logger.LogInformation("{JobName} ended", nameof(ChannelAcceptorJob));

--- a/src/Jobs/ChannelCloseJob.cs
+++ b/src/Jobs/ChannelCloseJob.cs
@@ -29,18 +29,14 @@ public class ChannelCloseJob : IJob
         _logger.LogInformation("Starting {JobName}... ", nameof(ChannelCloseJob));
         try
         {
-            var token = context.CancellationToken;
-            token.ThrowIfCancellationRequested();
-
-            await RetriableJobRescheduler.SetNextInterval(context);
-
-            var data = context.JobDetail.JobDataMap;
-            var closeRequestId = data.GetInt("closeRequestId");
-            var forceClose = data.GetBoolean("forceClose");
-            var closeRequest = await _channelOperationRequestRepository.GetById(closeRequestId);
-            await _lightningService.CloseChannel(closeRequest, forceClose);
-
-            var schedule = context.Scheduler.DeleteJob(context.JobDetail.Key, token);
+            await RetriableJob.Execute(context, async () =>
+            {
+                var data = context.JobDetail.JobDataMap;
+                var closeRequestId = data.GetInt("closeRequestId");
+                var forceClose = data.GetBoolean("forceClose");
+                var closeRequest = await _channelOperationRequestRepository.GetById(closeRequestId);
+                await _lightningService.CloseChannel(closeRequest, forceClose);
+            });
         }
         catch (Exception e)
         {

--- a/src/Jobs/ChannelCloseJob.cs
+++ b/src/Jobs/ChannelCloseJob.cs
@@ -32,7 +32,7 @@ public class ChannelCloseJob : IJob
             var token = context.CancellationToken;
             token.ThrowIfCancellationRequested();
 
-            await JobRescheduler.SetNextInterval(context);
+            await RetriableJobRescheduler.SetNextInterval(context);
 
             var data = context.JobDetail.JobDataMap;
             var closeRequestId = data.GetInt("closeRequestId");

--- a/src/Jobs/ChannelCloseJob.cs
+++ b/src/Jobs/ChannelCloseJob.cs
@@ -1,6 +1,6 @@
 using FundsManager.Data.Repositories.Interfaces;
-using FundsManager.Data.Models;
 using FundsManager.Services;
+using FundsManager.Helpers;
 using Quartz;
 
 namespace FundsManager.Jobs;
@@ -31,6 +31,8 @@ public class ChannelCloseJob : IJob
         {
             var token = context.CancellationToken;
             token.ThrowIfCancellationRequested();
+
+            await JobRescheduler.SetNextInterval(context);
 
             var data = context.JobDetail.JobDataMap;
             var closeRequestId = data.GetInt("closeRequestId");

--- a/src/Jobs/ChannelOpenJob.cs
+++ b/src/Jobs/ChannelOpenJob.cs
@@ -31,7 +31,7 @@ public class ChannelOpenJob : IJob
             var token = context.CancellationToken;
             token.ThrowIfCancellationRequested();
             
-            await JobRescheduler.SetNextInterval(context);
+            await RetriableJobRescheduler.SetNextInterval(context);
 
             var data = context.JobDetail.JobDataMap;
             var openRequestId = data.GetInt("openRequestId");

--- a/src/Jobs/PerformWithdrawalJob.cs
+++ b/src/Jobs/PerformWithdrawalJob.cs
@@ -1,6 +1,6 @@
 using FundsManager.Data.Repositories.Interfaces;
-using FundsManager.Data.Models;
 using FundsManager.Services;
+using FundsManager.Helpers;
 using Quartz;
 
 namespace FundsManager.Jobs;
@@ -31,6 +31,8 @@ public class PerformWithdrawalJob : IJob
         {
             var token = context.CancellationToken;
             token.ThrowIfCancellationRequested();
+
+            await JobRescheduler.SetNextInterval(context);
 
             var data = context.JobDetail.JobDataMap;
             var withdrawalRequestId = data.GetInt("withdrawalRequestId");

--- a/src/Jobs/PerformWithdrawalJob.cs
+++ b/src/Jobs/PerformWithdrawalJob.cs
@@ -32,7 +32,7 @@ public class PerformWithdrawalJob : IJob
             var token = context.CancellationToken;
             token.ThrowIfCancellationRequested();
 
-            await JobRescheduler.SetNextInterval(context);
+            await RetriableJobRescheduler.SetNextInterval(context);
 
             var data = context.JobDetail.JobDataMap;
             var withdrawalRequestId = data.GetInt("withdrawalRequestId");

--- a/src/Jobs/ProcessNodeChannelAcceptorJob.cs
+++ b/src/Jobs/ProcessNodeChannelAcceptorJob.cs
@@ -227,7 +227,7 @@ public class ProcessNodeChannelAcceptorJob : IJob
         catch (Exception e)
         {
             _logger.LogError(e, "Error on {JobName}", nameof(ProcessNodeChannelAcceptorJob));
-            throw new JobExecutionException(e, true);
+            throw new JobExecutionException(e, false);
         }
     }
 }

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -616,7 +616,7 @@
                         var map = new JobDataMap();
                         map.Put("openRequestId", _selectedRequest.Id);
                         
-                        var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_CHANNEL_OPEN");
+                        var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
                         var job = RetriableJob.Create<ChannelOpenJob>(map, _selectedRequest.Id.ToString(), retryList);
                         await scheduler.ScheduleJob(job.Job, job.Trigger);
 

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -615,7 +615,9 @@
             
                         var map = new JobDataMap();
                         map.Put("openRequestId", _selectedRequest.Id);
-                        var job = RetriableJob.Create<ChannelOpenJob>(map, _selectedRequest.Id.ToString());
+                        
+                        var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_CHANNEL_OPEN");
+                        var job = RetriableJob.Create<ChannelOpenJob>(map, _selectedRequest.Id.ToString(), retryList);
                         await scheduler.ScheduleJob(job.Job, job.Trigger);
 
                         // TODO: Check job id

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -616,7 +616,7 @@
                         var map = new JobDataMap();
                         map.Put("openRequestId", _selectedRequest.Id);
                         
-                        var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
+                        var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTERVAL_LIST_IN_MINUTES");
                         var job = RetriableJob.Create<ChannelOpenJob>(map, _selectedRequest.Id.ToString(), retryList);
                         await scheduler.ScheduleJob(job.Job, job.Trigger);
 

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -658,7 +658,7 @@
                                 var map = new JobDataMap();
                                 map.Put("withdrawalRequestId", _selectedRequest.Id);
 
-                                var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
+                                var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTERVAL_LIST_IN_MINUTES");
                                 var job = RetriableJob.Create<PerformWithdrawalJob>(map, _selectedRequest.Id.ToString(), retryList);
                                 await scheduler.ScheduleJob(job.Job, job.Trigger);
 

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -657,7 +657,9 @@
             
                                 var map = new JobDataMap();
                                 map.Put("withdrawalRequestId", _selectedRequest.Id);
-                                var job = RetriableJob.Create<PerformWithdrawalJob>(map, _selectedRequest.Id.ToString());
+
+                                var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_PERFORM_WITHDRAWAL");
+                                var job = RetriableJob.Create<PerformWithdrawalJob>(map, _selectedRequest.Id.ToString(), retryList);
                                 await scheduler.ScheduleJob(job.Job, job.Trigger);
 
                                 if (_selectedRequest != null)

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -658,7 +658,7 @@
                                 var map = new JobDataMap();
                                 map.Put("withdrawalRequestId", _selectedRequest.Id);
 
-                                var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_LIST_PERFORM_WITHDRAWAL");
+                                var retryList = RetriableJob.ParseRetryListFromEnvironmenVariable("JOB_RETRY_INTEVAL_LIST_IN_MINUTES");
                                 var job = RetriableJob.Create<PerformWithdrawalJob>(map, _selectedRequest.Id.ToString(), retryList);
                                 await scheduler.ScheduleJob(job.Job, job.Trigger);
 


### PR DESCRIPTION
Added some env variables for configuring intervals of jobs but they default to an array of  [1, 5, 10, 20] minutes.

The first time the job triggers without any delay, and then it starts consuming the array and rescheduling the interval.

For env variables, the format is a string of numbers separated by commas with no spaces. Example:
```
JOB_RETRY_LIST_CHANNEL_OPEN="2,4,8,16,32"
```
