### PR TITLE
Fixed #59

### DIFF
--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -108,7 +108,7 @@ namespace FundsManager.Data.Models
         /// Checks if all the threshold signatures are collected, including the internal wallet key (even if not signed yet)
         /// </summary>
         [NotMapped]
-        public bool AreAllRequiredSignaturesCollected => CheckSignatures();
+        public bool AreAllRequiredHumanSignaturesCollected => CheckSignatures();
 
         [NotMapped]
         public int NumberOfSignaturesCollected => ChannelOperationRequestPsbts == null ? 0 : ChannelOperationRequestPsbts.Count(x =>

--- a/src/Data/Models/WalletWithdrawalRequest.cs
+++ b/src/Data/Models/WalletWithdrawalRequest.cs
@@ -76,7 +76,7 @@ namespace FundsManager.Data.Models
         /// Checks if all the threshold signatures are collected, including the internal wallet key (even if not signed yet)
         /// </summary>
         [NotMapped]
-        public bool AreAllRequiredSignaturesCollected => CheckSignatures();
+        public bool AreAllRequiredHumanSignaturesCollected => CheckSignatures();
 
         [NotMapped]
         public int NumberOfSignaturesCollected =>
@@ -105,15 +105,15 @@ namespace FundsManager.Data.Models
 
             if (WalletWithdrawalRequestPSBTs != null && WalletWithdrawalRequestPSBTs.Any())
             {
-                var userPSBTsCount = NumberOfSignaturesCollected;
+                var numberOfSignaturesCollected = NumberOfSignaturesCollected;
 
                 //We add the internal Wallet signature
                 if (Wallet.RequiresInternalWalletSigning)
                 {
-                    userPSBTsCount++;
+                    numberOfSignaturesCollected++;
                 }
 
-                if (userPSBTsCount == Wallet.MofN)
+                if (numberOfSignaturesCollected == Wallet.MofN)
                 {
                     result = true;
                 }

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -547,7 +547,7 @@
     {
         _selectedRequest = channelOperationRequest;
         _psbt = string.Empty;
-        if (_selectedRequest != null && !_selectedRequest.AreAllRequiredSignaturesCollected) {
+        if (_selectedRequest != null && !_selectedRequest.AreAllRequiredHumanSignaturesCollected) {
             var (templatePsbt,noUtxosAvailable) = (await LightningService.GenerateTemplatePSBT(_selectedRequest));
             if (templatePsbt != null)
             {
@@ -605,7 +605,7 @@
                 _selectedRequest = await ChannelOperationRequestRepository.GetById(_selectedRequest.Id);
 
                 if (_selectedRequest != null
-                    && _selectedRequest.AreAllRequiredSignaturesCollected)
+                    && _selectedRequest.AreAllRequiredHumanSignaturesCollected)
                 {
                     var failedOpenChannelRequest = false;
                     try

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -62,7 +62,7 @@
                         }
                         else
                         {
-                            <Button Color="Color.Info" Disabled="@(context.Keys != null && context.Keys.Count >= context.MofN)" Clicked="@(() => LoadAndOpenModal(context))">Add key</Button>
+                            <Button Color="Color.Info" Disabled="@(context.Keys != null && context.Keys.Count > context.MofN)" Clicked="@(() => LoadAndOpenModal(context))">Add key</Button>
 
                         }
 

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -55,7 +55,7 @@
                             @*TODO Cancel / Reject  *@
 
                             @if (context.Wallet != null && context.Wallet.Keys != null && context.Wallet.Keys.Any(x => x.UserId == LoggedUser?.Id)
-                                 && !context.AreAllRequiredSignaturesCollected
+                                 && !context.AreAllRequiredHumanSignaturesCollected
                                  && context.WalletWithdrawalRequestPSBTs.All(x => x.SignerId != LoggedUser?.Id))
                             {
                                 <Button Color="Color.Success" Clicked="()=> ShowApprovalModal(context)">Approve</Button>
@@ -645,7 +645,7 @@
                 if (_selectedRequest != null
                    && PSBT.TryParse(walletWithdrawalRequestPsbt.PSBT, CurrentNetworkHelper.GetCurrentNetwork(), out _))
                 {
-                    if (_selectedRequest.AreAllRequiredSignaturesCollected)
+                    if (_selectedRequest.AreAllRequiredHumanSignaturesCollected)
                     {
                         var failedWithdrawalRequest = false;
                         try

--- a/src/Services/BitcoinService.cs
+++ b/src/Services/BitcoinService.cs
@@ -277,7 +277,7 @@ namespace FundsManager.Services
 
                 PSBT? signedCombinedPSBT = null;
                 //Check if the NodeGuard Internal Wallet needs to sign on his own
-                if (!walletWithdrawalRequest.AreAllRequiredSignaturesCollected &&
+                if (walletWithdrawalRequest.AreAllRequiredHumanSignaturesCollected &&
                     walletWithdrawalRequest.Wallet.RequiresInternalWalletSigning)
                 {
                     //Remote signer
@@ -290,6 +290,12 @@ namespace FundsManager.Services
                         signedCombinedPSBT = await SignPSBTWithEmbeddedSigner(walletWithdrawalRequest, nbxplorerClient,
                             derivationStrategyBase, combinedPSBT, network);
                     }
+                    
+                }
+                else
+                {
+                    //In this case, the combined PSBT is considered as the signed one
+                    signedCombinedPSBT = combinedPSBT;
                 }
 
                 if (signedCombinedPSBT == null)

--- a/test/FundsManager.Tests/WalletWithdrawalRequestTests.cs
+++ b/test/FundsManager.Tests/WalletWithdrawalRequestTests.cs
@@ -1,0 +1,109 @@
+using AutoFixture;
+using FluentAssertions;
+using FundsManager.Data.Models;
+
+namespace FundsManager.Tests;
+
+public class WalletWithdrawalRequestTests
+{
+    [Fact]
+    public async Task SignatureCounter_Positive_RequiresInternalwallet()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        var request = fixture.Create<WalletWithdrawalRequest>();
+        // Act
+
+        request.Wallet.MofN = 3;
+        
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+        
+        request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
+
+        // Assert
+        request.Wallet.RequiresInternalWalletSigning.Should().Be(true);
+        request.AreAllRequiredHumanSignaturesCollected.Should().Be(true);
+        request.NumberOfSignaturesCollected.Should().Be(2);
+    }
+    
+    [Fact]
+    public async Task SignatureCounter_Positive_NotRequiresInternalwallet()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        var request = fixture.Create<WalletWithdrawalRequest>();
+        // Act
+
+        request.Wallet.MofN = 2;
+        
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+        
+        request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
+
+        // Assert
+        request.Wallet.RequiresInternalWalletSigning.Should().Be(false);
+        request.AreAllRequiredHumanSignaturesCollected.Should().Be(true);
+        request.NumberOfSignaturesCollected.Should().Be(2);
+    }
+   
+    [Fact]
+    public async Task SignatureCount_Negative_NotRequiresInternalWallet()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        var request = fixture.Create<WalletWithdrawalRequest>();
+        // Act
+
+        request.Wallet.MofN = 2;
+        
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+
+        request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
+        request.WalletWithdrawalRequestPSBTs.Last().IsFinalisedPSBT = true;
+
+        // Assert
+        request.Wallet.RequiresInternalWalletSigning.Should().BeFalse();
+        request.AreAllRequiredHumanSignaturesCollected.Should().BeFalse();
+        request.NumberOfSignaturesCollected.Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task SignatureCount_Negative_RequiresInternalWallet()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        var request = fixture.Create<WalletWithdrawalRequest>();
+        // Act
+
+        request.Wallet.MofN = 3;
+        
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+
+        request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
+        request.WalletWithdrawalRequestPSBTs.Last().IsFinalisedPSBT = true;
+
+        // Assert
+        request.Wallet.RequiresInternalWalletSigning.Should().BeTrue();
+        request.AreAllRequiredHumanSignaturesCollected.Should().BeFalse();
+        request.NumberOfSignaturesCollected.Should().Be(1);
+    }
+    
+   
+    
+}


### PR DESCRIPTION
- Clarified that AreAllRequiredSignaturesCollected means Human signatures (from finance managers)
- Added 4 unit tests for checking this concept
- Added a missing if else condition in Bitcoinservice to allow the internal wallet to sign if all human signatures are gathered and enough to sign a transaction
- Allowed wallets to add more keys to support potential scenarios of lost keys