### PR TITLE
Proposal of refactor of LightningService

### DIFF
--- a/src/Jobs/ChannelCloseJob.cs
+++ b/src/Jobs/ChannelCloseJob.cs
@@ -18,11 +18,10 @@
  */
 
 using FundsManager.Data.Repositories.Interfaces;
-using FundsManager.Services;
 using FundsManager.Helpers;
 using FundsManager.Data.Models;
+using FundsManager.Services.Interfaces;
 using Quartz;
-using Quartz.Impl.Triggers;
 
 namespace FundsManager.Jobs;
 

--- a/src/Jobs/ChannelOpenJob.cs
+++ b/src/Jobs/ChannelOpenJob.cs
@@ -18,11 +18,10 @@
  */
 
 using FundsManager.Data.Repositories.Interfaces;
-using FundsManager.Services;
 using FundsManager.Helpers;
 using FundsManager.Data.Models;
+using FundsManager.Services.Interfaces;
 using Quartz;
-using Quartz.Impl.Triggers;
 
 namespace FundsManager.Jobs;
 

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -5,6 +5,7 @@
 @using Humanizer
 @using NBitcoin
 @using FundsManager.Jobs
+@using FundsManager.Services.Interfaces
 @attribute [Authorize(Roles = "FinanceManager, Superadmin, NodeManager")]
 
 <PageTitle>Channel Operation Requests</PageTitle>

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -26,7 +26,6 @@
 </head>
 <body>
     <div class="container">
-        <partial name="_CookieConsentPartial" optional />
         <main role="main" class="pb-1">
             @RenderBody()
         </main>

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -1,5 +1,6 @@
 @page "/wallets"
 @using System.Security.Claims
+@using FundsManager.Services.Interfaces
 @using Humanizer
 @using NBitcoin
 @using NBXplorer.DerivationStrategy

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -42,6 +42,7 @@ using Serilog.Events;
 using Serilog.Formatting.Json;
 using FundsManager.Helpers;
 using FundsManager.Rpc;
+using FundsManager.Services.Interfaces;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace FundsManager

--- a/src/Services/Interfaces/ILightningService.cs
+++ b/src/Services/Interfaces/ILightningService.cs
@@ -1,0 +1,61 @@
+using FundsManager.Data.Models;
+using Lnrpc;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
+
+namespace FundsManager.Services.Interfaces;
+
+/// <summary>
+/// Service to interact with LND
+/// </summary>
+public interface ILightningService
+{
+    /// <summary>
+    /// Opens a channel based on a request this method waits for I/O on the blockchain, therefore it can last its execution for minutes
+    /// </summary>
+    /// <param name="channelOperationRequest"></param>
+    /// <returns></returns>
+    // ReSharper disable once IdentifierTypo
+    public Task OpenChannel(ChannelOperationRequest channelOperationRequest);
+
+    /// <summary>
+    /// Generates a template PSBT with Sighash_NONE and some UTXOs from the wallet related to the request without signing, also returns if there are no utxos available at the request time
+    /// </summary>
+    /// <param name="channelOperationRequest"></param>
+    /// <param name="destinationAddress"></param>
+    /// <returns></returns>
+    public Task<(PSBT?, bool)> GenerateTemplatePSBT(ChannelOperationRequest channelOperationRequest);
+
+    /// <summary>
+    /// Based on a channel operation request of type close, requests the close of a channel to LND without acking the request.
+    /// This method waits for I/O on the blockchain, therefore it can last its execution for minutes
+    /// </summary>
+    /// <param name="channelOperationRequest"></param>
+    /// <param name="forceClose"></param>
+    /// <returns></returns>
+    public Task CloseChannel(ChannelOperationRequest channelOperationRequest, bool forceClose = false);
+
+    /// <summary>
+    /// Gets the wallet balance
+    /// </summary>
+    /// <param name="wallet"></param>
+    /// <returns></returns>
+    public Task<GetBalanceResponse?> GetWalletBalance(Wallet wallet);
+
+    /// <summary>
+    /// Gets the wallet balance
+    /// </summary>
+    /// <param name="wallet"></param>
+    /// <param name="derivationFeature"></param>
+    /// <returns></returns>
+    public Task<BitcoinAddress?> GetUnusedAddress(Wallet wallet,
+        DerivationFeature derivationFeature);
+
+    /// <summary>
+    /// Gets the info about a node in the lightning network graph
+    /// </summary>
+    /// <param name="pubkey"></param>
+    /// <returns></returns>
+    public Task<LightningNode?> GetNodeInfo(string pubkey);
+}

--- a/src/Services/ServiceHelpers/LightningServiceHelper.cs
+++ b/src/Services/ServiceHelpers/LightningServiceHelper.cs
@@ -1,0 +1,502 @@
+using AutoMapper;
+using FundsManager.Data;
+using FundsManager.Data.Models;
+using FundsManager.Data.Repositories.Interfaces;
+using FundsManager.Helpers;
+using Google.Protobuf;
+using Grpc.Core;
+using Lnrpc;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
+using Unmockable;
+using Channel = FundsManager.Data.Models.Channel;
+using Transaction = NBitcoin.Transaction;
+
+namespace FundsManager.Services.ServiceHelpers;
+
+public static class LightningServiceHelper
+{
+    public static PSBT GetCombinedPsbt(ChannelOperationRequest channelOperationRequest, ILogger? _logger = null)
+    {
+        //PSBT Combine
+        var signedPsbts = channelOperationRequest.ChannelOperationRequestPsbts.Where(x =>
+            !x.IsFinalisedPSBT && !x.IsInternalWalletPSBT && !x.IsTemplatePSBT);
+        var signedPsbts2 = signedPsbts.Select(x => x.PSBT);
+
+        var combinedPSBT = LightningHelper.CombinePSBTs(signedPsbts2, _logger);
+
+        if (combinedPSBT != null) return combinedPSBT;
+
+        var invalidPsbtNullToBeUsedForTheRequest = $"Invalid PSBT(null) to be used for the channel op request:{channelOperationRequest.Id}";
+        _logger?.LogError(invalidPsbtNullToBeUsedForTheRequest);
+
+        throw new ArgumentException(invalidPsbtNullToBeUsedForTheRequest, nameof(combinedPSBT));
+    }
+
+    public static async Task<KeyPathInformation?> GetCloseAddress(ChannelOperationRequest channelOperationRequest,
+        DerivationStrategyBase derivationStrategyBase, INBXplorerService nbXplorerService, ILogger? _logger = null)
+    {
+        var closeAddress = await
+            nbXplorerService.GetUnusedAsync(derivationStrategyBase, DerivationFeature.Deposit, 0, true, default);
+
+        if (closeAddress != null) return closeAddress;
+
+        var closeAddressNull = $"Closing address was null for an operation on wallet:{channelOperationRequest.Wallet.Id}";
+        _logger?.LogError(closeAddressNull);
+
+        throw new ArgumentException(closeAddressNull);
+    }
+
+    public static DerivationStrategyBase GetDerivationStrategyBase(ChannelOperationRequest channelOperationRequest, ILogger? _logger = null)
+    {
+        //Derivation strategy for the multisig address based on its wallet
+        var derivationStrategyBase = channelOperationRequest.Wallet.GetDerivationStrategy();
+
+        if (derivationStrategyBase != null) return derivationStrategyBase;
+
+        var derivationNull = $"Derivation scheme not found for wallet:{channelOperationRequest.Wallet.Id}";
+
+        _logger?.LogError(derivationNull);
+
+        throw new ArgumentException(derivationNull);
+    }
+
+    public static void CheckArgumentsAreValid(ChannelOperationRequest channelOperationRequest, OperationRequestType requestype, ILogger? _logger = null)
+    {
+        if (channelOperationRequest == null) throw new ArgumentNullException(nameof(channelOperationRequest));
+
+        if (channelOperationRequest.RequestType == requestype) return;
+
+        string requestInvalid = $"Invalid request. Requested ${channelOperationRequest.RequestType.ToString()} on ${requestype.ToString()} method";
+
+        _logger?.LogError(requestInvalid);
+
+        throw new ArgumentOutOfRangeException(requestInvalid);
+    }
+
+    public static (Node, Node) CheckNodesAreValid(ChannelOperationRequest channelOperationRequest, ILogger? _logger = null)
+    {
+        var source = channelOperationRequest.SourceNode;
+        var destination = channelOperationRequest.DestNode;
+
+        if (source == null || destination == null)
+        {
+            throw new ArgumentException("Source or destination null", nameof(source));
+        }
+
+        if (source.ChannelAdminMacaroon == null)
+        {
+            throw new UnauthorizedAccessException("Macaroon not set for source channel");
+        }
+
+        if (source.PubKey != destination.PubKey) return (source, destination);
+
+        const string aNodeCannotOpenAChannelToItself = "A node cannot open a channel to itself.";
+
+        _logger?.LogError(aNodeCannotOpenAChannelToItself);
+
+        throw new ArgumentException(aNodeCannotOpenAChannelToItself);
+    }
+
+
+    /// <summary>
+    /// Aux method when the fundsmanager is the one in change of signing the PSBTs
+    /// </summary>
+    /// <param name="channelOperationRequest"></param>
+    /// <param name="nbxplorerClient"></param>
+    /// <param name="derivationStrategyBase"></param>
+    /// <param name="channelfundingTx"></param>
+    /// <param name="source"></param>
+    /// <param name="client"></param>
+    /// <param name="pendingChannelId"></param>
+    /// <param name="network"></param>
+    /// <param name="changeFixedPSBT"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static async Task<PSBT> SignPSBT(
+        ChannelOperationRequest channelOperationRequest, INBXplorerService nbXplorerService,
+        DerivationStrategyBase derivationStrategyBase, Transaction channelfundingTx, Network network, PSBT changeFixedPSBT, ILogger? logger = null)
+
+    {
+        //We get the UTXO keyPath / derivation path from nbxplorer
+
+        var UTXOs = await nbXplorerService.GetUTXOsAsync(derivationStrategyBase, default);
+        UTXOs.RemoveDuplicateUTXOs();
+
+        var OutpointKeyPathDictionary =
+            UTXOs.Confirmed.UTXOs.ToDictionary(x => x.Outpoint, x => x.KeyPath);
+
+        var txInKeyPathDictionary =
+            channelfundingTx.Inputs.Where(x => OutpointKeyPathDictionary.ContainsKey(x.PrevOut))
+                .ToDictionary(x => x,
+                    x => OutpointKeyPathDictionary[x.PrevOut]);
+
+        if (!txInKeyPathDictionary.Any())
+        {
+            const string errorKeypathsForTheUtxosUsedInThisTxAreNotFound =
+                "Error, keypaths for the UTXOs used in this tx are not found, probably this UTXO is already used as input of another transaction";
+
+            logger?.LogError(errorKeypathsForTheUtxosUsedInThisTxAreNotFound);
+
+            throw new ArgumentException(
+                errorKeypathsForTheUtxosUsedInThisTxAreNotFound);
+        }
+
+
+        Dictionary<NBitcoin.OutPoint, NBitcoin.Key> privateKeysForUsedUTXOs;
+        if (channelOperationRequest.Wallet.IsHotWallet)
+        {
+            try
+            {
+                privateKeysForUsedUTXOs = txInKeyPathDictionary.ToDictionary(x => x.Key.PrevOut, x => channelOperationRequest.Wallet.InternalWallet.GetAccountKey(network)
+                    .Derive(UInt32.Parse(channelOperationRequest.Wallet.InternalWalletSubDerivationPath))
+                    .Derive(x.Value)
+                    .PrivateKey);
+            }
+            catch (Exception e)
+            {
+                var errorParsingSubderivationPath =
+                    $"Invalid Internal Wallet Subderivation Path for wallet:{channelOperationRequest.WalletId}";
+                logger?.LogError(errorParsingSubderivationPath);
+
+                throw new ArgumentException(
+                    errorParsingSubderivationPath);
+            }
+        }
+        else
+        {
+            privateKeysForUsedUTXOs = txInKeyPathDictionary.ToDictionary(x => x.Key.PrevOut, x => channelOperationRequest.Wallet.InternalWallet.GetAccountKey(network)
+                .Derive(x.Value)
+                .PrivateKey);
+        }
+
+        //We need to SIGHASH_ALL all inputs/outputs as fundsmanager to protect the tx from tampering by adding a signature
+        var partialSigsCount = changeFixedPSBT.Inputs.Sum(x => x.PartialSigs.Count);
+        foreach (var input in changeFixedPSBT.Inputs)
+        {
+            if (privateKeysForUsedUTXOs.TryGetValue(input.PrevOut, out var key))
+            {
+                input.Sign(key);
+            }
+        }
+
+        //We check that the partial signatures number has changed, otherwise finalize inmediately
+        var partialSigsCountAfterSignature =
+            changeFixedPSBT.Inputs.Sum(x => x.PartialSigs.Count);
+
+        if (partialSigsCountAfterSignature == 0 ||
+            partialSigsCountAfterSignature <= partialSigsCount)
+        {
+            var invalidNoOfPartialSignatures =
+                $"Invalid expected number of partial signatures after signing for the channel operation request:{channelOperationRequest.Id}";
+            logger?.LogError(invalidNoOfPartialSignatures);
+
+            throw new ArgumentException(
+                invalidNoOfPartialSignatures);
+        }
+
+        return changeFixedPSBT;
+    }
+
+    /// <summary>
+    /// Cancels a pending channel from LND PSBT-based funding of channels
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="client"></param>
+    /// <param optional="true" name="logger"></param>
+    /// <param name="pendingChannelId"></param>
+    public static void CancelPendingChannel(Node source, IUnmockable<Lightning.LightningClient> client, byte[] pendingChannelId, ILogger logger = null)
+    {
+        try
+        {
+            if (pendingChannelId != null)
+            {
+                var cancelRequest = new FundingShimCancel
+                {
+                    PendingChanId = ByteString.CopyFrom(pendingChannelId)
+                };
+
+                if (source.ChannelAdminMacaroon != null)
+                {
+                    var cancelResult = client.Execute(x => x.FundingStateStep(new FundingTransitionMsg
+                        {
+                            ShimCancel = cancelRequest,
+                        },
+                        new Metadata { { "macaroon", source.ChannelAdminMacaroon } }, null, default));
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            logger?.LogError(e, "Error while cancelling pending channel with id: {ChannelId} (hex)",
+                Convert.ToHexString(pendingChannelId));
+        }
+    }
+
+
+    /// <summary>
+    /// Gets UTXOs confirmed from the wallet of the request
+    /// </summary>
+    /// <param name="channelOperationRequest"></param>
+    /// <param name="nbxplorerClient"></param>
+    /// <param name="derivationStrategy"></param>
+    /// <returns></returns>
+    public static async Task<(List<ScriptCoin> coins, List<UTXO> selectedUTXOs)> GetTxInputCoins(
+        ChannelOperationRequest channelOperationRequest,
+        INBXplorerService nbXplorerService,
+        DerivationStrategyBase derivationStrategy,
+        IFMUTXORepository ifmutxoRepository,
+        ILogger logger,
+        IMapper mapper)
+    {
+        var utxoChanges = await nbXplorerService.GetUTXOsAsync(derivationStrategy, default);
+        utxoChanges.RemoveDuplicateUTXOs();
+
+        var satsAmount = channelOperationRequest.SatsAmount;
+        var lockedUTXOs = await ifmutxoRepository.GetLockedUTXOs(ignoredChannelOperationRequestId: channelOperationRequest.Id);
+
+        var (coins, selectedUTXOs) = await LightningHelper.SelectCoins(channelOperationRequest.Wallet,
+            satsAmount,
+            utxoChanges,
+            lockedUTXOs,
+            logger,
+            mapper);
+
+        return (coins, selectedUTXOs);
+    }
+
+    public static void HandleChannelPending(ChannelOperationRequest channelOperationRequest, string pendingChannelIdHex, OpenStatusUpdate response, IChannelOperationRequestRepository channelOperationRequestRepository, ILogger<LightningService>? logger = null)
+    {
+        //Channel funding tx on mempool and pending status on lnd
+
+        logger?.LogInformation(
+            "Channel pending for channel operation request id: {RequestId} for pending channel id: {ChannelId}",
+            channelOperationRequest.Id, pendingChannelIdHex);
+
+        channelOperationRequest.Status = ChannelOperationRequestStatus.OnChainConfirmationPending;
+        channelOperationRequest.TxId = LightningHelper.DecodeTxId(response.ChanPending.Txid);
+        channelOperationRequestRepository.Update(channelOperationRequest);
+    }
+
+    public static async Task HandleChannelOpen(ChannelOperationRequest channelOperationRequest, OpenStatusUpdate response, IUnmockable<Lightning.LightningClient> client, Node source, KeyPathInformation? closeAddress, ApplicationDbContext context, IChannelOperationRequestRepository channelOperationRequestRepository, ILogger<LightningService>? logger = null)
+    {
+        logger.LogInformation(
+            "Channel opened for channel operation request request id: {RequestId}, channel point: {ChannelPoint}",
+            channelOperationRequest.Id, response.ChanOpen.ChannelPoint.ToString());
+
+        channelOperationRequest.Status = ChannelOperationRequestStatus.OnChainConfirmed;
+        channelOperationRequestRepository.Update(channelOperationRequest);
+
+        var fundingTx = LightningHelper.DecodeTxId(response.ChanOpen.ChannelPoint.FundingTxidBytes);
+
+        //Get the channels to find the channelId, not the temporary one
+        var channels = await client.Execute(x => x.ListChannelsAsync(new ListChannelsRequest(),
+            new Metadata { { "macaroon", source.ChannelAdminMacaroon } }, null, default));
+        var currentChannel = channels.Channels.SingleOrDefault(x => x.ChannelPoint == $"{fundingTx}:{response.ChanOpen.ChannelPoint.OutputIndex}");
+
+        if (currentChannel == null)
+        {
+            logger.LogError("Error, channel not found for channel point: {ChannelPoint}",
+                response.ChanOpen.ChannelPoint.ToString());
+            throw new InvalidOperationException();
+        }
+
+        var channel = new Channel
+        {
+            ChanId = currentChannel.ChanId,
+            CreationDatetime = DateTimeOffset.Now,
+            FundingTx = fundingTx,
+            FundingTxOutputIndex = response.ChanOpen.ChannelPoint.OutputIndex,
+            BtcCloseAddress = closeAddress?.Address.ToString(),
+            SatsAmount = channelOperationRequest.SatsAmount,
+            UpdateDatetime = DateTimeOffset.Now,
+            Status = Channel.ChannelStatus.Open,
+            NodeId = channelOperationRequest.SourceNode.Id
+        };
+
+        await context.AddAsync(channel);
+
+        var addChannelResult = (await context.SaveChangesAsync()) > 0;
+
+        if (addChannelResult == false)
+        {
+            logger.LogError(
+                "Channel for channel operation request id: {RequestId} could not be created, reason: {Reason}",
+                channelOperationRequest.Id,
+                "Could not persist to db");
+        }
+
+        channelOperationRequest.ChannelId = channel.Id;
+        channelOperationRequest.DestNode = null;
+
+        var channelUpdate = channelOperationRequestRepository.Update(channelOperationRequest);
+
+        if (channelUpdate.Item1 == false)
+        {
+            logger.LogError(
+                "Could not assign channel id to channel operation request: {RequestId} reason: {Reason}",
+                channelOperationRequest.Id,
+                channelUpdate.Item2);
+        }
+    }
+
+    public static async Task HandlePSBTFund(ChannelOperationRequest channelOperationRequest, byte[] pendingChannelId,OpenStatusUpdate response, Network network, PSBT combinedPSBT, 
+        IUnmockable<Lightning.LightningClient> client, Node source, DerivationStrategyBase derivationStrategyBase, IRemoteSignerService remoteSignerService, INBXplorerService nbXplorerService,
+        IChannelOperationRequestPSBTRepository channelOperationRequestPsbtRepository, IChannelOperationRequestRepository channelOperationRequestRepository, ILogger logger)
+    {
+        //We got the funded PSBT, we need to tweak the tx outputs and mimick lnd-cli calls
+        var hexPSBT = Convert.ToHexString((response.PsbtFund.Psbt.ToByteArray()));
+        if (PSBT.TryParse(hexPSBT, network,
+                out var fundedPSBT))
+        {
+            fundedPSBT.AssertSanity();
+
+            //We ensure to SigHash.None
+            fundedPSBT.Settings.SigningOptions = new SigningOptions
+            {
+                SigHash = SigHash.None
+            };
+
+            var channelfundingTx = fundedPSBT.GetGlobalTransaction();
+
+            //We manually fix the change (it was wrong from the Base template due to nbitcoin requiring a change on a PSBT)
+
+            var totalIn = new Money(0L);
+
+            foreach (var input in fundedPSBT.Inputs)
+            {
+                totalIn += (input.GetTxOut()?.Value);
+            }
+
+            var totalOut = new Money(channelOperationRequest.SatsAmount, MoneyUnit.Satoshi);
+            var totalFees = combinedPSBT.GetFee();
+            channelfundingTx.Outputs[0].Value = totalIn - totalOut - totalFees;
+
+            //We merge changeFixedPSBT with the other PSBT with the change fixed
+
+            var changeFixedPSBT = channelfundingTx.CreatePSBT(network).UpdateFrom(fundedPSBT);
+
+            PSBT? finalSignedPSBT = null;
+            //We check the way the fundsmanager signs, with the remoteFundsManagerSigner or by itself.
+            if (Constants.ENABLE_REMOTE_SIGNER)
+            {
+                finalSignedPSBT = await remoteSignerService.Sign(changeFixedPSBT);
+                if (finalSignedPSBT == null)
+                {
+                    const string errorMessage = "The signed PSBT was null, something went wrong while signing with the remote signer";
+                    logger.LogError(errorMessage);
+                    throw new Exception(
+                        errorMessage);
+                }
+            }
+            else
+            {
+                finalSignedPSBT = await SignPSBT(channelOperationRequest,
+                    nbXplorerService,
+                    derivationStrategyBase,
+                    channelfundingTx,
+                    network,
+                    changeFixedPSBT,
+                    logger);
+
+                if (finalSignedPSBT == null)
+                {
+                    const string errorMessage = "The signed PSBT was null, something went wrong while signing with the embedded signer";
+                    logger.LogError(errorMessage);
+                    throw new Exception(
+                        errorMessage);
+                }
+            }
+
+            //We store the final signed PSBT without being finalized for debugging purposes
+            var signedChannelOperationRequestPsbt = new ChannelOperationRequestPSBT
+            {
+                ChannelOperationRequestId = channelOperationRequest.Id,
+                PSBT = finalSignedPSBT.ToBase64(),
+                CreationDatetime = DateTimeOffset.Now,
+                IsInternalWalletPSBT = true
+            };
+
+            var addResult = await channelOperationRequestPsbtRepository.AddAsync(signedChannelOperationRequestPsbt);
+
+            if (!addResult.Item1)
+            {
+                logger.LogError("Could not store the signed PSBT for channel operation request id: {RequestId} reason: {Reason}", channelOperationRequest.Id, addResult.Item2);
+            }
+
+            //Time to finalize the PSBT and broadcast the tx
+
+            var finalizedPSBT = finalSignedPSBT.Finalize();
+
+            //Sanity check
+            finalizedPSBT.AssertSanity();
+
+            channelfundingTx = finalizedPSBT.ExtractTransaction();
+
+            //Just a check of the tx based on the finalizedPSBT
+            var checkTx = channelfundingTx.Check();
+
+            if (checkTx == TransactionCheckResult.Success)
+            {
+                //We tell lnd to verify the psbt
+                client.Execute(x => x.FundingStateStep(
+                    new FundingTransitionMsg
+                    {
+                        PsbtVerify = new FundingPsbtVerify
+                        {
+                            FundedPsbt =
+                                ByteString.CopyFrom(Convert.FromHexString(finalizedPSBT.ToHex())),
+                            PendingChanId = ByteString.CopyFrom(pendingChannelId)
+                        }
+                    }, new Metadata { { "macaroon", source.ChannelAdminMacaroon } }, null, default));
+
+                //Saving the PSBT in the ChannelOperationRequest collection of PSBTs
+
+                channelOperationRequest =
+                    await channelOperationRequestRepository.GetById(channelOperationRequest.Id) ?? throw new InvalidOperationException();
+
+                if (channelOperationRequest.ChannelOperationRequestPsbts != null)
+                {
+                    var finalizedChannelOperationRequestPsbt = new ChannelOperationRequestPSBT
+                    {
+                        IsFinalisedPSBT = true,
+                        CreationDatetime = DateTimeOffset.Now,
+                        PSBT = finalizedPSBT.ToBase64(),
+                        ChannelOperationRequestId = channelOperationRequest.Id
+                    };
+
+                    var finalisedPSBTAdd = await
+                        channelOperationRequestPsbtRepository.AddAsync(finalizedChannelOperationRequestPsbt);
+
+                    if (!finalisedPSBTAdd.Item1)
+                    {
+                        logger.LogError(
+                            "Error while saving the finalised PSBT for channel operation request with id: {RequestId}",
+                            channelOperationRequest.Id);
+                    }
+                }
+
+                var fundingStateStepResp = await client.Execute(x => x.FundingStateStepAsync(
+                    new FundingTransitionMsg
+                    {
+                        PsbtFinalize = new FundingPsbtFinalize
+                        {
+                            PendingChanId = ByteString.CopyFrom(pendingChannelId),
+                            //FinalRawTx = ByteString.CopyFrom(Convert.FromHexString(finalTxHex)),
+                            SignedPsbt =
+                                ByteString.CopyFrom(Convert.FromHexString(finalizedPSBT.ToHex()))
+                        },
+                    }, new Metadata { { "macaroon", source.ChannelAdminMacaroon } }, null, default));
+            }
+            else
+            {
+                CancelPendingChannel(source, client, pendingChannelId, logger);
+            }
+        }
+        else
+        {
+            CancelPendingChannel(source, client, pendingChannelId, logger);
+        }
+    }
+}

--- a/test/FundsManager.Tests/Helpers/LightningHelperTests.cs
+++ b/test/FundsManager.Tests/Helpers/LightningHelperTests.cs
@@ -90,5 +90,28 @@ namespace FundsManager.Tests
 
             utxoChanges.Confirmed.UTXOs.Count.Should().Be(1);
         }
+        
+        [Fact]
+        public void CreateLightningClient_EndpointIsNull()
+        {
+            // Act
+            var act = () => LightningHelper.CreateLightningClient(null);
+
+            // Assert
+            act
+                .Should()
+                .Throw<ArgumentException>()
+                .WithMessage("Endpoint cannot be null");
+        }
+
+        [Fact]
+        public void CreateLightningClient_ReturnsLightningClient()
+        {
+            // Act
+            var result = LightningHelper.CreateLightningClient("10.0.0.1");
+
+            // Assert
+            result.Should().NotBeNull();
+        }
     }
 }

--- a/test/FundsManager.Tests/Services/LightningServiceTests.cs
+++ b/test/FundsManager.Tests/Services/LightningServiceTests.cs
@@ -17,61 +17,27 @@
  *
  */
 
-using AutoFixture;
-using AutoMapper;
 using Microsoft.Extensions.Logging;
 using FundsManager.Data;
 using FundsManager.Data.Models;
 using FundsManager.Data.Repositories.Interfaces;
 using FundsManager.TestHelpers;
-using NBXplorer;
 using NBXplorer.Models;
 using FluentAssertions;
 using FundsManager.Helpers;
+using FundsManager.Services.ServiceHelpers;
 using Google.Protobuf;
 using Lnrpc;
 using NBitcoin;
 using NBXplorer.DerivationStrategy;
 using Grpc.Core;
 using Microsoft.EntityFrameworkCore;
-using Unmockable.Exceptions;
 
 namespace FundsManager.Services
 {
     public class LightningServiceTests
     {
         ILogger<LightningService> _logger = new Mock<ILogger<LightningService>>().Object;
-
-        [Fact]
-        public void CheckArgumentsAreValid_ArgumentNull()
-        {
-            // Act
-            var act = () => LightningService.CheckArgumentsAreValid(null, OperationRequestType.Open);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentNullException>()
-                .WithMessage("Value cannot be null. (Parameter 'channelOperationRequest')");
-        }
-
-        [Fact]
-        public void CheckArgumentsAreValid_RequestTypeNotOpen()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Close
-            };
-
-            // Act
-            var act = () => LightningService.CheckArgumentsAreValid(operationRequest, OperationRequestType.Open);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentOutOfRangeException>()
-                .WithMessage(
-                    "Specified argument was out of the range of valid values. (Parameter 'Invalid request. Requested $Close on $Open method')");
-        }
 
         [Fact]
         public async void OpenChannel_ChannelOperationRequestNotFound()
@@ -99,284 +65,7 @@ namespace FundsManager.Services
             await act.Should()
                 .ThrowAsync<InvalidOperationException>()
                 .WithMessage("ChannelOperationRequest not found");
-        }
-
-        [Fact]
-        public void CheckNodesAreValid_SourceNodeNull()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Open,
-                DestNode = new Node()
-            };
-
-            // Act
-            var act = () => LightningService.CheckNodesAreValid(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Source or destination null (Parameter 'source')");
-        }
-
-        [Fact]
-        public void CheckNodesAreValid_DestinationNodeNull()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Open,
-                SourceNode = new Node()
-            };
-
-            // Act
-            var act = () => LightningService.CheckNodesAreValid(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Source or destination null (Parameter 'source')");
-        }
-
-        [Fact]
-        public void CheckNodesAreValid_MacaroonNotSet()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Open,
-                SourceNode = new Node(),
-                DestNode = new Node()
-            };
-
-            // Act
-            var act = () => LightningService.CheckNodesAreValid(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<UnauthorizedAccessException>()
-                .WithMessage("Macaroon not set for source channel");
-        }
-
-        [Fact]
-        public void CheckNodesAreValid_NodesAreValid()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Open,
-                SourceNode = new Node()
-                {
-                    PubKey = "a",
-                    ChannelAdminMacaroon = "abc"
-                },
-                DestNode = new Node()
-                {
-                    PubKey = "b",
-                    ChannelAdminMacaroon = "def"
-                }
-            };
-
-            // Act
-            var result = LightningService.CheckNodesAreValid(operationRequest);
-
-            // Assert
-            result.Should().NotBeNull();
-            result.Item1.Should().NotBeNull();
-            result.Item2.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void CheckNodesAreValid_SourceEqualsDestination()
-        {
-            // Arrange
-            var node = new Node
-            {
-                PubKey = "A",
-                ChannelAdminMacaroon = "abc"
-            };
-
-            var operationRequest = new ChannelOperationRequest
-            {
-                RequestType = OperationRequestType.Open,
-                SourceNode = node,
-                DestNode = node
-            };
-
-            // Act
-            var act = () => LightningService.CheckNodesAreValid(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("A node cannot open a channel to itself.");
-        }
-
-        [Fact]
-        public void GetDerivationStrategyBase_NoDerivationScheme()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                Wallet = new Wallet()
-            };
-
-            // Act
-            var act = () => LightningService.GetDerivationStrategyBase(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Derivation scheme not found for wallet:0");
-        }
-
-        [Fact]
-        public void GetDerivationStrategyBase_DerivationSchemeExists()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                Wallet = CreateWallet.CreateTestWallet()
-            };
-
-            // Act
-            var result = LightningService.GetDerivationStrategyBase(operationRequest);
-
-            // Assert
-            result.Should().NotBeNull();
-        }
-
-        [Fact]
-        public async Task GetCloseAddress_NoCloseAddress()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                Wallet = CreateWallet.CreateTestWallet()
-            };
-
-            var nbXplorerMock = new Mock<INBXplorerService>();
-
-            nbXplorerMock.Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(),
-                    It.IsAny<DerivationFeature>(),
-                    It.IsAny<int>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<KeyPathInformation?>(null));
-            // Act
-            var act = async () => await LightningService.GetCloseAddress(operationRequest,
-                operationRequest.Wallet.GetDerivationStrategy()!,
-                nbXplorerMock.Object);
-
-            // Assert
-            await act.Should()
-                .ThrowAsync<ArgumentException>()
-                .WithMessage("Closing address was null for an operation on wallet:0");
-        }
-
-        [Fact]
-        public async void GetCloseAddress_CloseAddressExists()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest
-            {
-                Wallet = CreateWallet.CreateTestWallet()
-            };
-
-            var nbXplorerMock = GetNBXplorerServiceFullyMocked(new UTXOChanges());
-
-            // Act
-            var result = await LightningService.GetCloseAddress(operationRequest,
-                operationRequest.Wallet.GetDerivationStrategy()!, nbXplorerMock.Object);
-
-            // Assert
-            result.Should().NotBeNull();
-        }
-
-        private static Mock<INBXplorerService> GetNBXplorerServiceFullyMocked(UTXOChanges utxoChanges)
-        {
-            var nbXplorerMock = new Mock<INBXplorerService>();
-            //Mock to return a wallet address
-            var keyPathInformation = new KeyPathInformation()
-                {Address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest)};
-
-            nbXplorerMock
-                .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<DerivationFeature>(),
-                    It.IsAny<int>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(keyPathInformation);
-
-            nbXplorerMock.Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
-                .ReturnsAsync(utxoChanges);
-
-
-            return nbXplorerMock;
-        }
-
-        [Fact]
-        public void GetCombinedPsbt_NoCombinedPSBT()
-        {
-            // Arrange
-            var operationRequest = new ChannelOperationRequest()
-            {
-                ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>()
-            };
-
-            // Act
-            var act = () => LightningService.GetCombinedPsbt(operationRequest);
-
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Invalid PSBT(null) to be used for the channel op request:0 (Parameter 'combinedPSBT')");
-        }
-
-        [Fact]
-        public void GetCombinedPsbt_CombinedPSBTExists()
-        {
-            // Arrange
-            var channelOpReqPsbts = new List<ChannelOperationRequestPSBT>
-            {
-                new ChannelOperationRequestPSBT()
-                {
-                    PSBT =
-                        "cHNidP8BAF4BAAAAAdz1PWN8JtwrX5q7aREhJbCmD0I/Xn/m84Znzoo0gPXfAQAAAAD/////AeRcqQAAAAAAIgAgmXpf0mpyCEyKLRK/kCrOwYZpkA3QmJHS6iSocRyj7G4AAAAATwEENYfPAy8RJCyAAAAB/DvuQjoBjOttImoGYyiO0Pte4PqdeQqzcNAw4Ecw5sgDgI4uHNSCvdBxlpQ8WoEz0WmvhgIra7A4F3FkTsB0RNcQH8zk3jAAAIABAACAAQAAgE8BBDWHzwNWrAP0gAAAAfkIrkpmsP+hqxS1WvDOSPKnAiXLkBCQLWkBr5C5Po+BAlGvFeBbuLfqwYlbP19H/+/s2DIaAu8iKY+J0KIDffBgEGDzoLMwAACAAQAAgAEAAIBPAQQ1h88DfblGjYAAAAH1InDHaHo6+zUe9PG5owwQ87bTkhcGg66pSIwTmhHJmAMiI4UjOOpn+/2Nw1KrJiXnmid2RiEja/HAITCQ00ienxDtAhDIMAAAgAEAAIABAACAAAEBK2BfqQAAAAAAIgAgVJ3hH2Yg78qcgDmp32ctQUv4oJjoMN3ec6mS0WQX25wBAwQCAAAAAQVpUiECDLxYLw6kodDiOHpRGyavsn3GStmnKi2POJgO1JpkJvAhA50d97FlqJDgPv5UO5W0ngY2C7pY0RIZfxntgg2EDZz7IQPL2Ji2egSgcGTHSj/xC/woKvb/Y0UYit/rjnrxqcih6VOuIgYCDLxYLw6kodDiOHpRGyavsn3GStmnKi2POJgO1JpkJvAYYPOgszAAAIABAACAAQAAgAAAAADHAAAAIgYDnR33sWWokOA+/lQ7lbSeBjYLuljREhl/Ge2CDYQNnPsYH8zk3jAAAIABAACAAQAAgAAAAADHAAAAIgYDy9iYtnoEoHBkx0o/8Qv8KCr2/2NFGIrf64568anIoekY7QIQyDAAAIABAACAAQAAgAAAAADHAAAAAAA="
-                }
-            };
-            var operationRequest = new ChannelOperationRequest()
-            {
-                ChannelOperationRequestPsbts = channelOpReqPsbts
-            };
-
-            // Act
-            var result = LightningService.GetCombinedPsbt(operationRequest);
-
-            // Assert
-            result.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void CreateLightningClient_EndpointIsNull()
-        {
-            // Act
-            var act = () => LightningService.CreateLightningClient(null);
-
-            // Assert
-            act
-                .Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Endpoint cannot be null");
-        }
-
-        [Fact]
-        public void CreateLightningClient_ReturnsLightningClient()
-        {
-            // Act
-            var result = LightningService.CreateLightningClient("10.0.0.1");
-
-            // Assert
-            result.Should().NotBeNull();
-        }
+        } 
 
         [Fact]
         public async void OpenChannel_Success()
@@ -456,7 +145,7 @@ namespace FundsManager.Services
                         }
                     }));
 
-            LightningService.CreateLightningClient = (_) => lightningClient;
+            LightningHelper.CreateLightningClient = (_) => lightningClient;
 
             lightningClient
                 .Setup(x => x.ConnectPeerAsync(
@@ -582,7 +271,7 @@ namespace FundsManager.Services
                 channelOperationRequestPsbtRepository.Object,
                 null,
                 null,
-                GetNBXplorerServiceFullyMocked(utxoChanges).Object);
+                LightningServiceHelperTests.GetNBXplorerServiceFullyMocked(utxoChanges).Object);
 
             // Act
             var act = async () => await lightningService.OpenChannel(operationRequest);

--- a/test/FundsManager.Tests/Services/ServiceHelpers/LightningServiceHelperTests.cs
+++ b/test/FundsManager.Tests/Services/ServiceHelpers/LightningServiceHelperTests.cs
@@ -1,0 +1,301 @@
+using FluentAssertions;
+using FundsManager.Data;
+using FundsManager.Data.Models;
+using FundsManager.Data.Repositories.Interfaces;
+using FundsManager.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
+
+namespace FundsManager.Services.ServiceHelpers;
+
+public class LightningServiceHelperTests
+{
+    ILogger<LightningService> _logger = new Mock<ILogger<LightningService>>().Object;
+    public static Mock<INBXplorerService> GetNBXplorerServiceFullyMocked(UTXOChanges utxoChanges)
+    {
+        var nbXplorerMock = new Mock<INBXplorerService>();
+        //Mock to return a wallet address
+        var keyPathInformation = new KeyPathInformation()
+            { Address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest) };
+
+        nbXplorerMock
+            .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<DerivationFeature>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(keyPathInformation);
+
+        nbXplorerMock.Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+            .ReturnsAsync(utxoChanges);
+
+
+        return nbXplorerMock;
+    }
+    
+    [Fact]
+    public void CheckArgumentsAreValid_ArgumentNull()
+    {
+        // Act
+        var act = () => LightningServiceHelper.CheckArgumentsAreValid(null, OperationRequestType.Open);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'channelOperationRequest')");
+    }
+
+    [Fact]
+    public void CheckArgumentsAreValid_RequestTypeNotOpen()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Close
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.CheckArgumentsAreValid(operationRequest, OperationRequestType.Open);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithMessage(
+                "Specified argument was out of the range of valid values. (Parameter 'Invalid request. Requested $Close on $Open method')");
+    }
+
+    [Fact]
+    public void CheckNodesAreValid_SourceNodeNull()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Open,
+            DestNode = new Node()
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.CheckNodesAreValid(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("Source or destination null (Parameter 'source')");
+    }
+
+    [Fact]
+    public void CheckNodesAreValid_DestinationNodeNull()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNode = new Node()
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.CheckNodesAreValid(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("Source or destination null (Parameter 'source')");
+    }
+
+    [Fact]
+    public void CheckNodesAreValid_MacaroonNotSet()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNode = new Node(),
+            DestNode = new Node()
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.CheckNodesAreValid(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<UnauthorizedAccessException>()
+            .WithMessage("Macaroon not set for source channel");
+    }
+
+    [Fact]
+    public void CheckNodesAreValid_NodesAreValid()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNode = new Node()
+            {
+                PubKey = "a",
+                ChannelAdminMacaroon = "abc"
+            },
+            DestNode = new Node()
+            {
+                PubKey = "b",
+                ChannelAdminMacaroon = "def"
+            }
+        };
+
+        // Act
+        var result = LightningServiceHelper.CheckNodesAreValid(operationRequest);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Item1.Should().NotBeNull();
+        result.Item2.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CheckNodesAreValid_SourceEqualsDestination()
+    {
+        // Arrange
+        var node = new Node
+        {
+            PubKey = "A",
+            ChannelAdminMacaroon = "abc"
+        };
+
+        var operationRequest = new ChannelOperationRequest
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNode = node,
+            DestNode = node
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.CheckNodesAreValid(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("A node cannot open a channel to itself.");
+    }
+
+    [Fact]
+    public void GetDerivationStrategyBase_NoDerivationScheme()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            Wallet = new Wallet()
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.GetDerivationStrategyBase(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("Derivation scheme not found for wallet:0");
+    }
+
+    [Fact]
+    public void GetDerivationStrategyBase_DerivationSchemeExists()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            Wallet = CreateWallet.CreateTestWallet()
+        };
+
+        // Act
+        var result = LightningServiceHelper.GetDerivationStrategyBase(operationRequest);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetCloseAddress_NoCloseAddress()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            Wallet = CreateWallet.CreateTestWallet()
+        };
+
+        var nbXplorerMock = new Mock<INBXplorerService>();
+
+        nbXplorerMock.Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(),
+                It.IsAny<DerivationFeature>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<KeyPathInformation?>(null));
+        // Act
+        var act = async () => await LightningServiceHelper.GetCloseAddress(operationRequest,
+            operationRequest.Wallet.GetDerivationStrategy()!,
+            nbXplorerMock.Object);
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("Closing address was null for an operation on wallet:0");
+    }
+
+    [Fact]
+    public async void GetCloseAddress_CloseAddressExists()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest
+        {
+            Wallet = CreateWallet.CreateTestWallet()
+        };
+
+        var nbXplorerMock = GetNBXplorerServiceFullyMocked(new UTXOChanges());
+
+        // Act
+        var result = await LightningServiceHelper.GetCloseAddress(operationRequest,
+            operationRequest.Wallet.GetDerivationStrategy()!, nbXplorerMock.Object);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetCombinedPsbt_NoCombinedPSBT()
+    {
+        // Arrange
+        var operationRequest = new ChannelOperationRequest()
+        {
+            ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>()
+        };
+
+        // Act
+        var act = () => LightningServiceHelper.GetCombinedPsbt(operationRequest);
+
+        // Assert
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("Invalid PSBT(null) to be used for the channel op request:0 (Parameter 'combinedPSBT')");
+    }
+
+    [Fact]
+    public void GetCombinedPsbt_CombinedPSBTExists()
+    {
+        // Arrange
+        var channelOpReqPsbts = new List<ChannelOperationRequestPSBT>
+        {
+            new ChannelOperationRequestPSBT()
+            {
+                PSBT =
+                    "cHNidP8BAF4BAAAAAdz1PWN8JtwrX5q7aREhJbCmD0I/Xn/m84Znzoo0gPXfAQAAAAD/////AeRcqQAAAAAAIgAgmXpf0mpyCEyKLRK/kCrOwYZpkA3QmJHS6iSocRyj7G4AAAAATwEENYfPAy8RJCyAAAAB/DvuQjoBjOttImoGYyiO0Pte4PqdeQqzcNAw4Ecw5sgDgI4uHNSCvdBxlpQ8WoEz0WmvhgIra7A4F3FkTsB0RNcQH8zk3jAAAIABAACAAQAAgE8BBDWHzwNWrAP0gAAAAfkIrkpmsP+hqxS1WvDOSPKnAiXLkBCQLWkBr5C5Po+BAlGvFeBbuLfqwYlbP19H/+/s2DIaAu8iKY+J0KIDffBgEGDzoLMwAACAAQAAgAEAAIBPAQQ1h88DfblGjYAAAAH1InDHaHo6+zUe9PG5owwQ87bTkhcGg66pSIwTmhHJmAMiI4UjOOpn+/2Nw1KrJiXnmid2RiEja/HAITCQ00ienxDtAhDIMAAAgAEAAIABAACAAAEBK2BfqQAAAAAAIgAgVJ3hH2Yg78qcgDmp32ctQUv4oJjoMN3ec6mS0WQX25wBAwQCAAAAAQVpUiECDLxYLw6kodDiOHpRGyavsn3GStmnKi2POJgO1JpkJvAhA50d97FlqJDgPv5UO5W0ngY2C7pY0RIZfxntgg2EDZz7IQPL2Ji2egSgcGTHSj/xC/woKvb/Y0UYit/rjnrxqcih6VOuIgYCDLxYLw6kodDiOHpRGyavsn3GStmnKi2POJgO1JpkJvAYYPOgszAAAIABAACAAQAAgAAAAADHAAAAIgYDnR33sWWokOA+/lQ7lbSeBjYLuljREhl/Ge2CDYQNnPsYH8zk3jAAAIABAACAAQAAgAAAAADHAAAAIgYDy9iYtnoEoHBkx0o/8Qv8KCr2/2NFGIrf64568anIoekY7QIQyDAAAIABAACAAQAAgAAAAADHAAAAAAA="
+            }
+        };
+        var operationRequest = new ChannelOperationRequest()
+        {
+            ChannelOperationRequestPsbts = channelOpReqPsbts
+        };
+
+        // Act
+        var result = LightningServiceHelper.GetCombinedPsbt(operationRequest);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
I made this so we can think about doing some more work on refactoring services.

The changes in question basically remove from the LightningService class all methods that are not part of the interface, and move them to a LightningServiceHelper class.
This allows us to maintain this helper functions public, since they should be private now but for testing purposes we needed them to be public.

This changes still violate the single responsibility principle on most methods, but it will help us start to move more stuff to the LightningServiceHelper so we can test smaller and smaller functions. From there we should separate this helper into classes related by responsibility.

All changes were on tested functions and tests still pass, so this should be straighforward