### PR TITLE
refactor(appsettings.json): remove ConnectionStrings and Logging sections, add quartz.threadPool.maxConcurrency setting

### DIFF
--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,13 +1,3 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-FundsManager-66F1BF9B-21F9-40C4-8380-C86E94E1BCAC;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+  "quartz.threadPool.maxConcurrency": 500
 }


### PR DESCRIPTION
This commit removes the unused ConnectionStrings and Logging sections from the appsettings.json file and adds a new setting for quartz.threadPool.maxConcurrency to configure the maximum number of concurrent threads for the Quartz scheduler.
