### PR TITLE
Hide columns dropdown

### DIFF
--- a/src/Helpers/ColumnHelpers.cs
+++ b/src/Helpers/ColumnHelpers.cs
@@ -1,0 +1,32 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+namespace FundsManager.Helpers;
+
+public class ColumnDefault
+{
+    public string Name { get; }
+    public bool Visibility { get; }
+
+    public ColumnDefault(string name, bool visibility = true)
+    {
+        Name = name;
+        Visibility = visibility;
+    }
+}

--- a/src/Helpers/ColumnHelpers.cs
+++ b/src/Helpers/ColumnHelpers.cs
@@ -22,7 +22,7 @@ namespace FundsManager.Helpers;
 public class ColumnDefault
 {
     public string Name { get; }
-    public bool Visibility { get; }
+    public bool Visibility { get;  }
 
     public ColumnDefault(string name, bool visibility = true)
     {
@@ -33,6 +33,11 @@ public class ColumnDefault
 
 public static class ColumnHelpers
 {
+    /// <summary>
+    /// This method gets the fields from a class and returns a dictionary with the name of the field and the visibility of the column
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
     public static Dictionary<string, bool> GetColumnsDictionary<T>()
     {
         return typeof(T).GetFields().Select(p => (ColumnDefault)p.GetValue(null)).ToDictionary((c) => c.Name, (c) => c.Visibility);

--- a/src/Helpers/ColumnHelpers.cs
+++ b/src/Helpers/ColumnHelpers.cs
@@ -30,3 +30,11 @@ public class ColumnDefault
         Visibility = visibility;
     }
 }
+
+public static class ColumnHelpers
+{
+    public static Dictionary<string, bool> GetColumnsDictionary<T>()
+    {
+        return typeof(T).GetFields().Select(p => (ColumnDefault)p.GetValue(null)).ToDictionary((c) => c.Name, (c) => c.Visibility);
+    }
+}

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -487,11 +487,11 @@
         await FetchRequests();
         await LoadData();
     }
-    
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender)
-        {        
+        {
             await LoadColumnLayout();
 
         }

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -47,7 +47,24 @@
         </PopupTitleTemplate>
         <ChildContent>
             <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Id)" Caption="#" Sortable="false" Displayable="true"/>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="true" PopupFieldColumnSize="ColumnSize.Is12" Editable="true"
+            <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SourceNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+                <EditTemplate>
+                    <Validation Validator="ValidationRule.IsSelected" @ref="_sourceNodeValidation">
+                        <SelectList TItem="Node"
+                                    TValue="int"
+                                    Data="@_manageableNodes"
+                                    TextField="@((item) => item.Name)"
+                                    ValueField="@((item) => item.Id)"
+                                    SelectedValueChanged="@OnSelectedSourceNode"
+                                    DefaultItemText="Choose the source node">
+                            <Feedback>
+                                <ValidationError/>
+                            </Feedback>
+                        </SelectList>
+                    </Validation>
+                </EditTemplate>
+            </DataGridColumn>
+            <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.RemoteNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true"
                             Validator="ValidationRule.IsAlphanumeric">
                 <EditTemplate>
                     <Validation Validator="@((ValidatorEventArgs obj) => ValidationHelper.validateDestNode(obj, _selectedDestNode))" @ref="_destNodeValidation">
@@ -65,24 +82,7 @@
                     </Validation>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="true" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
-                <EditTemplate>
-                    <Validation Validator="ValidationRule.IsSelected" @ref="_sourceNodeValidation">
-                        <SelectList TItem="Node"
-                                    TValue="int"
-                                    Data="@_manageableNodes"
-                                    TextField="@((item) => item.Name)"
-                                    ValueField="@((item) => item.Id)"
-                                    SelectedValueChanged="@OnSelectedSourceNode"
-                                    DefaultItemText="Choose the source node">
-                            <Feedback>
-                                <ValidationError/>
-                            </Feedback>
-                        </SelectList>
-                    </Validation>
-                </EditTemplate>
-            </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="true" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SourceOfFunds)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
                 <DisplayTemplate>
                     @if (context.Wallet != null)
                     {
@@ -117,7 +117,7 @@
                     </Validation>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="true" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Capacity)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
                 <DisplayTemplate>
                     @{
                         @($"{context.Amount:f8} BTC")
@@ -151,33 +151,33 @@
                     }
                 </EditTemplate>
             </DataGridColumn>
-                <DataGridColumn TItem="ChannelOperationRequest" Displayable="true" Editable="true" Caption="Fees" PopupFieldColumnSize="ColumnSize.Is12">
-                    <EditTemplate>
-                        <div class="d-flex">
-                            <Select TValue="MempoolRecommendedFeesTypes" SelectedValueChanged="async (value) => await OnChangeFeeSelection(value)">
-                                <SelectGroup Label="Default">
-                                    <SelectItem Value="MempoolRecommendedFeesTypes.EconomyFee">Economy Fee</SelectItem>
-                                    <SelectItem Value="MempoolRecommendedFeesTypes.FastestFee">Fastest Fee</SelectItem>
-                                    <SelectItem Value="MempoolRecommendedFeesTypes.HourFee">Hour Fee</SelectItem>
-                                    <SelectItem Value="MempoolRecommendedFeesTypes.HalfHourFee">Half Hour Fee</SelectItem>
-                                </SelectGroup>
-                                <SelectItem Value="MempoolRecommendedFeesTypes.CustomFee">Custom</SelectItem>
-                            </Select>
-                            <NumericPicker TValue="long" @bind-Value="@FeeAmount" CurrencySymbolPlacement="CurrencySymbolPlacement.Suffix" CurrencySymbol=" sats/vbyte" Min="1" Disabled="@(FeesSelection != MempoolRecommendedFeesTypes.CustomFee)">
-                                <Feedback>
-                                    <ValidationError/>
-                                </Feedback>
-                            </NumericPicker>
-                        </div>
-                    </EditTemplate>
-                </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="true" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.FeeRates)" Editable="true" Caption="Fee Rates" PopupFieldColumnSize="ColumnSize.Is12">
+                <EditTemplate>
+                    <div class="d-flex">
+                        <Select TValue="MempoolRecommendedFeesTypes" SelectedValueChanged="async (value) => await OnChangeFeeSelection(value)">
+                            <SelectGroup Label="Default">
+                                <SelectItem Value="MempoolRecommendedFeesTypes.EconomyFee">Economy Fee</SelectItem>
+                                <SelectItem Value="MempoolRecommendedFeesTypes.FastestFee">Fastest Fee</SelectItem>
+                                <SelectItem Value="MempoolRecommendedFeesTypes.HourFee">Hour Fee</SelectItem>
+                                <SelectItem Value="MempoolRecommendedFeesTypes.HalfHourFee">Half Hour Fee</SelectItem>
+                            </SelectGroup>
+                            <SelectItem Value="MempoolRecommendedFeesTypes.CustomFee">Custom</SelectItem>
+                        </Select>
+                        <NumericPicker TValue="long" @bind-Value="@FeeAmount" CurrencySymbolPlacement="CurrencySymbolPlacement.Suffix" CurrencySymbol=" sats/vbyte" Min="1" Disabled="@(FeesSelection != MempoolRecommendedFeesTypes.CustomFee)">
+                            <Feedback>
+                                <ValidationError/>
+                            </Feedback>
+                        </NumericPicker>
+                    </div>
+                </EditTemplate>
+            </DataGridColumn>
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Private)" Editable="true">
                 <EditTemplate>
                     <Check TValue="bool" @bind-Checked="_selectedPrivate"></Check>
                     <FieldHelp>Check to make this channel private</FieldHelp>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SignaturesCollected)">
                 <DisplayTemplate>
                     @{
                         if (context.RequestType == OperationRequestType.Open)
@@ -193,7 +193,7 @@
                     }
                 </DisplayTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Status)">
                 <DisplayTemplate>
                     @context?.Status.Humanize()
                 </DisplayTemplate>
@@ -217,7 +217,7 @@
                     }
                 </EditCommandTemplate>
                 <NewCommandTemplate>
-                    <Button hidden/>
+                    <ColumnLayout @ref="PendingRequestsColumnLayout" ColumnType="PendingRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
                 </NewCommandTemplate>
                 <DeleteCommandTemplate>
                     <Button Color="Color.Primary" hidden></Button>
@@ -254,10 +254,10 @@
           Striped="true">
     <ChildContent>
         <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Id)" Caption="#" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="true">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SourceNode)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.RemoteNode)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SourceOfFunds)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Capacity)">
             <DisplayTemplate>
                 @{
                     @($"{context.Amount:f8} BTC")
@@ -265,7 +265,7 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.FeeRate)" Caption="Fees" Displayable="true">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.FeeRate)" Caption="Fee Rate" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.FeeRates)">
             <DisplayTemplate>
                 @{
                     if (context.FeeRate != null)
@@ -275,8 +275,8 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="true"></DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="true">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Private)"></DataGridColumn>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SignaturesCollected)">
             <DisplayTemplate>
                 @{
                     if (context.RequestType == OperationRequestType.Open)
@@ -292,18 +292,18 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Status)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.CreationDate)">
             <DisplayTemplate>
                 @context.CreationDatetime.Humanize()
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.UpdateDatetime)" Caption="Update date" Sortable="true">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.UpdateDatetime)" Caption="Update date" Sortable="true" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.UpdateDate)">
             <DisplayTemplate>
                 @context.UpdateDatetime.Humanize()
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.TxId)" Caption="Links" Sortable="false" Displayable="true">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.TxId)" Caption="Links" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Links)">
             <DisplayTemplate>
                 @if (mempoolUrl != null && !context.TxId.IsNullOrEmpty())
                 {
@@ -311,23 +311,23 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        @if (_isNodeManager)
-        {
-            <DataGridColumn Caption="Actions">
-                <DisplayTemplate>
-                    @if (ShowActionDrowpdown(context))
-                    {
-                        <Dropdown>
-                            <DropdownToggle Color="Color.Primary">
-                            </DropdownToggle>
-                            <DropdownMenu>
-                                <DropdownItem Clicked="() => ShowMarkRequestAsFailedConfirmationModal(context)">Mark as failed</DropdownItem>
-                            </DropdownMenu>
-                        </Dropdown>
-                    }
-                </DisplayTemplate>
-            </DataGridColumn>
-        }
+        <DataGridColumn TItem="ChannelOperationRequest" Caption="Actions" Displayable="true">
+            <FilterTemplate>
+                <ColumnLayout @ref="AllRequestsColumnLayout" ColumnType="AllRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+            </FilterTemplate>
+            <DisplayTemplate>
+                @if (_isNodeManager && ShowActionDrowpdown(context))
+                {
+                    <Dropdown>
+                        <DropdownToggle Color="Color.Primary">
+                        </DropdownToggle>
+                        <DropdownMenu>
+                            <DropdownItem Clicked="() => ShowMarkRequestAsFailedConfirmationModal(context)">Mark as failed</DropdownItem>
+                        </DropdownMenu>
+                    </Dropdown>
+                }
+            </DisplayTemplate>
+        </DataGridColumn>
     </ChildContent>
     <EmptyTemplate>
         <div class="box">
@@ -375,8 +375,7 @@
 
 <UTXOSelectorModal
     @ref="_utxoSelectorModalRef"
-    OnClose="@OnCloseCoinSelectionModal"
-/>
+    OnClose="@OnCloseCoinSelectionModal"/>
 
 @inject IChannelOperationRequestRepository ChannelOperationRequestRepository
 @inject IChannelOperationRequestPSBTRepository ChannelOperationRequestPsbtRepository
@@ -408,6 +407,8 @@
     private MempoolRecommendedFeesTypes FeesSelection;
     private long FeeAmount = 1;
     private MempoolRecommendedFees? _recommendedFees;
+    private ColumnLayout<PendingRequestsColumnName> PendingRequestsColumnLayout;
+    private ColumnLayout<AllRequestsColumnName> AllRequestsColumnLayout;
 
     // New Request integration
     private List<Wallet> _allWallets = new List<Wallet>();
@@ -441,6 +442,35 @@
     [CascadingParameter]
     private ClaimsPrincipal? ClaimsPrincipal { get; set; }
 
+    private bool layoutInitialized;
+
+    public abstract class PendingRequestsColumnName
+    {
+        public static readonly ColumnDefault SourceNode = new("Source Node");
+        public static readonly ColumnDefault RemoteNode = new("Remote Node");
+        public static readonly ColumnDefault SourceOfFunds = new("Source of Funds");
+        public static readonly ColumnDefault Capacity = new("Capacity");
+        public static readonly ColumnDefault FeeRates = new("Fee Rates");
+        public static readonly ColumnDefault Private = new("Private");
+        public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
+        public static readonly ColumnDefault Status = new("Status");
+    }
+
+    public abstract class AllRequestsColumnName
+    {
+        public static readonly ColumnDefault SourceNode = new("Source Node");
+        public static readonly ColumnDefault RemoteNode = new("Remote Node");
+        public static readonly ColumnDefault SourceOfFunds = new("Source of Funds");
+        public static readonly ColumnDefault Capacity = new("Capacity");
+        public static readonly ColumnDefault FeeRates = new("Fee Rates");
+        public static readonly ColumnDefault Private = new("Private");
+        public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
+        public static readonly ColumnDefault Status = new("Status");
+        public static readonly ColumnDefault CreationDate = new("Creation Date");
+        public static readonly ColumnDefault UpdateDate = new("Update Date");
+        public static readonly ColumnDefault Links = new("Links");
+    }
+
     protected override async Task OnInitializedAsync()
     {
         if (LoggedUser == null) return;
@@ -455,6 +485,17 @@
         }
         await FetchRequests();
         await LoadData();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (PendingRequestsColumnLayout != null && AllRequestsColumnLayout != null && !layoutInitialized)
+        {
+            await PendingRequestsColumnLayout.InitializeColumnLayout();
+            await AllRequestsColumnLayout.InitializeColumnLayout();
+            OnColumnLayoutUpdate();
+            layoutInitialized = true;
+        }
     }
 
     private async Task OnShowNewChannelRequestModal()
@@ -949,5 +990,28 @@
                 FeeAmount = 1;
                 break;
         }
+    }
+
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsPendingRequestsColumnVisible(ColumnDefault column)
+    {
+        if (PendingRequestsColumnLayout	== null)
+        {
+            return true;
+        }
+        return PendingRequestsColumnLayout.IsColumnVisible(column);
+    }
+
+    private bool IsAllRequestsColumnVisible(ColumnDefault column)
+    {
+        if (AllRequestsColumnLayout	== null)
+        {
+            return true;
+        }
+        return AllRequestsColumnLayout.IsColumnVisible(column);
     }
 }

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -484,9 +484,17 @@
         {
             ToastService.ShowError("Bitcoin price in USD could not be retrieved.");
         }
-        await LoadColumnLayout();
         await FetchRequests();
         await LoadData();
+    }
+    
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {        
+            await LoadColumnLayout();
+
+        }
     }
 
     private async Task LoadColumnLayout()

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -217,7 +217,7 @@
                     }
                 </EditCommandTemplate>
                 <NewCommandTemplate>
-                    <ColumnLayout @ref="PendingRequestsColumnLayout" ColumnType="PendingRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    <ColumnLayout @ref="PendingRequestsColumnLayout" Columns="@PendingRequestsColumns" ColumnType="PendingRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
                 </NewCommandTemplate>
                 <DeleteCommandTemplate>
                     <Button Color="Color.Primary" hidden></Button>
@@ -313,7 +313,7 @@
         </DataGridColumn>
         <DataGridColumn TItem="ChannelOperationRequest" Caption="Actions" Displayable="true">
             <FilterTemplate>
-                <ColumnLayout @ref="AllRequestsColumnLayout" ColumnType="AllRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                <ColumnLayout @ref="AllRequestsColumnLayout" Columns="@AllRequestsColumns" ColumnType="AllRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
             </FilterTemplate>
             <DisplayTemplate>
                 @if (_isNodeManager && ShowActionDrowpdown(context))
@@ -386,6 +386,7 @@
 @inject INodeRepository NodeRepository
 @inject ICoinSelectionService CoinSelectionService
 @inject INBXplorerService NBXplorerService
+@inject LocalStorageService LocalStorageService
 
 @code {
     private List<ChannelOperationRequest>? _channelRequests;
@@ -409,6 +410,8 @@
     private MempoolRecommendedFees? _recommendedFees;
     private ColumnLayout<PendingRequestsColumnName> PendingRequestsColumnLayout;
     private ColumnLayout<AllRequestsColumnName> AllRequestsColumnLayout;
+    private Dictionary<string, bool> PendingRequestsColumns = new();
+    private Dictionary<string, bool> AllRequestsColumns = new();
 
     // New Request integration
     private List<Wallet> _allWallets = new List<Wallet>();
@@ -481,8 +484,16 @@
         {
             ToastService.ShowError("Bitcoin price in USD could not be retrieved.");
         }
+        await LoadColumnLayout();
         await FetchRequests();
         await LoadData();
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        AllRequestsColumns = await LocalStorageService.LoadStorage(nameof(AllRequestsColumnName), ColumnHelpers.GetColumnsDictionary<AllRequestsColumnName>());
+        PendingRequestsColumns = await LocalStorageService.LoadStorage(nameof(PendingRequestsColumnName), ColumnHelpers.GetColumnsDictionary<PendingRequestsColumnName>());
+        StateHasChanged();
     }
 
     private async Task OnShowNewChannelRequestModal()

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -47,7 +47,7 @@
         </PopupTitleTemplate>
         <ChildContent>
             <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Id)" Caption="#" Sortable="false" Displayable="true"/>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SourceNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.SourceNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
                 <EditTemplate>
                     <Validation Validator="ValidationRule.IsSelected" @ref="_sourceNodeValidation">
                         <SelectList TItem="Node"
@@ -64,7 +64,7 @@
                     </Validation>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.RemoteNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true"
+            <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.RemoteNode)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true"
                             Validator="ValidationRule.IsAlphanumeric">
                 <EditTemplate>
                     <Validation Validator="@((ValidatorEventArgs obj) => ValidationHelper.validateDestNode(obj, _selectedDestNode))" @ref="_destNodeValidation">
@@ -82,7 +82,7 @@
                     </Validation>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SourceOfFunds)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.SourceOfFunds)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
                 <DisplayTemplate>
                     @if (context.Wallet != null)
                     {
@@ -117,7 +117,7 @@
                     </Validation>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Capacity)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.Capacity)" PopupFieldColumnSize="ColumnSize.Is12" Editable="true">
                 <DisplayTemplate>
                     @{
                         @($"{context.Amount:f8} BTC")
@@ -151,7 +151,7 @@
                     }
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.FeeRates)" Editable="true" Caption="Fee Rate" PopupFieldColumnSize="ColumnSize.Is12">
+            <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.FeeRates)" Editable="true" Caption="Fee Rate" PopupFieldColumnSize="ColumnSize.Is12">
                 <EditTemplate>
                     <div class="d-flex">
                         <Select TValue="MempoolRecommendedFeesTypes" SelectedValueChanged="async (value) => await OnChangeFeeSelection(value)">
@@ -171,13 +171,13 @@
                     </div>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Private)" Editable="true">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.Private)" Editable="true">
                 <EditTemplate>
                     <Check TValue="bool" @bind-Checked="_selectedPrivate"></Check>
                     <FieldHelp>Check to make this channel private</FieldHelp>
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.SignaturesCollected)">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.SignaturesCollected)">
                 <DisplayTemplate>
                     @{
                         if (context.RequestType == OperationRequestType.Open)
@@ -193,7 +193,7 @@
                     }
                 </DisplayTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.Status)">
+            <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.Status)">
                 <DisplayTemplate>
                     @context?.Status.Humanize()
                 </DisplayTemplate>
@@ -217,7 +217,7 @@
                     }
                 </EditCommandTemplate>
                 <NewCommandTemplate>
-                    <ColumnLayout @ref="PendingRequestsColumnLayout" Columns="@PendingRequestsColumns" ColumnType="PendingRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    <ColumnLayout @ref="PendingRequestsColumnLayout" Columns="@PendingRequestsColumns" ColumnType="PendingChannelsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
                 </NewCommandTemplate>
                 <DeleteCommandTemplate>
                     <Button Color="Color.Primary" hidden></Button>
@@ -254,10 +254,10 @@
           Striped="true">
     <ChildContent>
         <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Id)" Caption="#" Sortable="false" Displayable="true"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SourceNode)"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.RemoteNode)"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SourceOfFunds)"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Capacity)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="SourceNode.Name" Caption="Source Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.SourceNode)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="DestNode.Name" Caption="Remote Node" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.RemoteNode)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="Wallet.Name" Caption="Source of Funds" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.SourceOfFunds)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Amount)" Caption="Capacity" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Capacity)">
             <DisplayTemplate>
                 @{
                     @($"{context.Amount:f8} BTC")
@@ -265,7 +265,7 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.FeeRate)" Caption="Fee Rate" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.FeeRates)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.FeeRate)" Caption="Fee Rate" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.FeeRates)">
             <DisplayTemplate>
                 @{
                     if (context.FeeRate != null)
@@ -275,8 +275,8 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Private)"></DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.SignaturesCollected)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Private)"></DataGridColumn>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.SignaturesCollected)">
             <DisplayTemplate>
                 @{
                     if (context.RequestType == OperationRequestType.Open)
@@ -292,18 +292,18 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Status)"/>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.CreationDate)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Status)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.CreationDate)">
             <DisplayTemplate>
                 @context.CreationDatetime.Humanize()
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.UpdateDatetime)" Caption="Update date" Sortable="true" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.UpdateDate)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.UpdateDatetime)" Caption="Update date" Sortable="true" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.UpdateDate)">
             <DisplayTemplate>
                 @context.UpdateDatetime.Humanize()
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.TxId)" Caption="Links" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllRequestsColumnName.Links)">
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.TxId)" Caption="Links" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Links)">
             <DisplayTemplate>
                 @if (mempoolUrl != null && !context.TxId.IsNullOrEmpty())
                 {
@@ -313,7 +313,7 @@
         </DataGridColumn>
         <DataGridColumn TItem="ChannelOperationRequest" Caption="Actions" Displayable="true">
             <FilterTemplate>
-                <ColumnLayout @ref="AllRequestsColumnLayout" Columns="@AllRequestsColumns" ColumnType="AllRequestsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                <ColumnLayout @ref="AllRequestsColumnLayout" Columns="@AllRequestsColumns" ColumnType="AllChannelsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
             </FilterTemplate>
             <DisplayTemplate>
                 @if (_isNodeManager && ShowActionDrowpdown(context))
@@ -408,8 +408,8 @@
     private MempoolRecommendedFeesTypes FeesSelection;
     private long FeeAmount = 1;
     private MempoolRecommendedFees? _recommendedFees;
-    private ColumnLayout<PendingRequestsColumnName> PendingRequestsColumnLayout;
-    private ColumnLayout<AllRequestsColumnName> AllRequestsColumnLayout;
+    private ColumnLayout<PendingChannelsColumnName> PendingRequestsColumnLayout;
+    private ColumnLayout<AllChannelsColumnName> AllRequestsColumnLayout;
     private Dictionary<string, bool> PendingRequestsColumns = new();
     private Dictionary<string, bool> AllRequestsColumns = new();
 
@@ -445,7 +445,7 @@
     [CascadingParameter]
     private ClaimsPrincipal? ClaimsPrincipal { get; set; }
 
-    public abstract class PendingRequestsColumnName
+    public abstract class PendingChannelsColumnName
     {
         public static readonly ColumnDefault SourceNode = new("Source Node");
         public static readonly ColumnDefault RemoteNode = new("Remote Node");
@@ -457,7 +457,7 @@
         public static readonly ColumnDefault Status = new("Status");
     }
 
-    public abstract class AllRequestsColumnName
+    public abstract class AllChannelsColumnName
     {
         public static readonly ColumnDefault SourceNode = new("Source Node");
         public static readonly ColumnDefault RemoteNode = new("Remote Node");
@@ -499,8 +499,8 @@
 
     private async Task LoadColumnLayout()
     {
-        AllRequestsColumns = await LocalStorageService.LoadStorage(nameof(AllRequestsColumnName), ColumnHelpers.GetColumnsDictionary<AllRequestsColumnName>());
-        PendingRequestsColumns = await LocalStorageService.LoadStorage(nameof(PendingRequestsColumnName), ColumnHelpers.GetColumnsDictionary<PendingRequestsColumnName>());
+        AllRequestsColumns = await LocalStorageService.LoadStorage(nameof(AllChannelsColumnName), ColumnHelpers.GetColumnsDictionary<AllChannelsColumnName>());
+        PendingRequestsColumns = await LocalStorageService.LoadStorage(nameof(PendingChannelsColumnName), ColumnHelpers.GetColumnsDictionary<PendingChannelsColumnName>());
         StateHasChanged();
     }
 

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -386,7 +386,7 @@
 @inject INodeRepository NodeRepository
 @inject ICoinSelectionService CoinSelectionService
 @inject INBXplorerService NBXplorerService
-@inject LocalStorageService LocalStorageService
+@inject ILocalStorageService LocalStorageService
 
 @code {
     private List<ChannelOperationRequest>? _channelRequests;

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -442,8 +442,6 @@
     [CascadingParameter]
     private ClaimsPrincipal? ClaimsPrincipal { get; set; }
 
-    private bool layoutInitialized;
-
     public abstract class PendingRequestsColumnName
     {
         public static readonly ColumnDefault SourceNode = new("Source Node");
@@ -485,17 +483,6 @@
         }
         await FetchRequests();
         await LoadData();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (PendingRequestsColumnLayout != null && AllRequestsColumnLayout != null && !layoutInitialized)
-        {
-            await PendingRequestsColumnLayout.InitializeColumnLayout();
-            await AllRequestsColumnLayout.InitializeColumnLayout();
-            OnColumnLayoutUpdate();
-            layoutInitialized = true;
-        }
     }
 
     private async Task OnShowNewChannelRequestModal()

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -151,7 +151,7 @@
                     }
                 </EditTemplate>
             </DataGridColumn>
-            <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.FeeRates)" Editable="true" Caption="Fee Rates" PopupFieldColumnSize="ColumnSize.Is12">
+            <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingRequestsColumnName.FeeRates)" Editable="true" Caption="Fee Rate" PopupFieldColumnSize="ColumnSize.Is12">
                 <EditTemplate>
                     <div class="d-flex">
                         <Select TValue="MempoolRecommendedFeesTypes" SelectedValueChanged="async (value) => await OnChangeFeeSelection(value)">
@@ -163,7 +163,7 @@
                             </SelectGroup>
                             <SelectItem Value="MempoolRecommendedFeesTypes.CustomFee">Custom</SelectItem>
                         </Select>
-                        <NumericPicker TValue="long" @bind-Value="@FeeAmount" CurrencySymbolPlacement="CurrencySymbolPlacement.Suffix" CurrencySymbol=" sats/vbyte" Min="1" Disabled="@(FeesSelection != MempoolRecommendedFeesTypes.CustomFee)">
+                        <NumericPicker TValue="long" @bind-Value="@FeeAmount" CurrencySymbolPlacement="CurrencySymbolPlacement.Suffix" CurrencySymbol=" sats/vb" Min="1" Disabled="@(FeesSelection != MempoolRecommendedFeesTypes.CustomFee)">
                             <Feedback>
                                 <ValidationError/>
                             </Feedback>
@@ -451,7 +451,7 @@
         public static readonly ColumnDefault RemoteNode = new("Remote Node");
         public static readonly ColumnDefault SourceOfFunds = new("Source of Funds");
         public static readonly ColumnDefault Capacity = new("Capacity");
-        public static readonly ColumnDefault FeeRates = new("Fee Rates");
+        public static readonly ColumnDefault FeeRates = new("Fee Rate");
         public static readonly ColumnDefault Private = new("Private");
         public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
         public static readonly ColumnDefault Status = new("Status");
@@ -463,7 +463,7 @@
         public static readonly ColumnDefault RemoteNode = new("Remote Node");
         public static readonly ColumnDefault SourceOfFunds = new("Source of Funds");
         public static readonly ColumnDefault Capacity = new("Capacity");
-        public static readonly ColumnDefault FeeRates = new("Fee Rates");
+        public static readonly ColumnDefault FeeRates = new("Fee Rate");
         public static readonly ColumnDefault Private = new("Private");
         public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
         public static readonly ColumnDefault Status = new("Status");

--- a/src/Pages/Channels.razor
+++ b/src/Pages/Channels.razor
@@ -47,7 +47,7 @@
                         </Dropdown>
                     </DeleteCommandTemplate>
                 </DataGridCommandColumn>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.SourceNodeId)" Caption="Source node" CustomFilter="OnSourceNodeIdFilter" Filterable="true" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.SourceNodeId)" Caption="Source node" CustomFilter="OnSourceNodeIdFilter" Filterable="true" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.SourceNode)">
                     <FilterTemplate>
                         <Select TValue="int" SelectedValue="@((int) _sourceNodeIdFilter)" SelectedValueChanged="@(value => { _sourceNodeIdFilter = value; context.TriggerFilterChange(_sourceNodeIdFilter); })">
                             <SelectItem Value="@(0)">All</SelectItem>
@@ -64,7 +64,7 @@
                         }
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.DestinationNodeId)" Caption="Destination node" CustomFilter="OnDestinationNodeIdFilter" Filterable="true" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.DestinationNodeId)" Caption="Destination node" CustomFilter="OnDestinationNodeIdFilter" Filterable="true" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.DestinationNode)">
                     <FilterTemplate>
                         <Select TValue="int" SelectedValue="@((int) _destinationNodeIdFilter)" SelectedValueChanged="@(value => { _destinationNodeIdFilter = value; context.TriggerFilterChange(_destinationNodeIdFilter); })">
                             <SelectItem Value="@(0)">All</SelectItem>
@@ -81,7 +81,7 @@
                         }
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.Status)" Caption="@nameof(Channel.Status)" CustomFilter="OnStatusFilter" Filterable="true" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.Status)" Caption="@nameof(Channel.Status)" CustomFilter="OnStatusFilter" Filterable="true" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.Status)">
                     <FilterTemplate>
                         <Select TValue="string" SelectedValue="@((string) _statusFilter)" SelectedValueChanged="@(value => { _statusFilter = value; context.TriggerFilterChange(_statusFilter); })">
                             <SelectItem Value="@("")">All</SelectItem>
@@ -94,7 +94,7 @@
                     </DisplayTemplate>
                 </DataGridColumn>
 
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.FundingTx)" Caption="OutPoint" Filterable="false" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.FundingTx)" Caption="OutPoint" Filterable="false" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.Outpoint)">
                     <DisplayTemplate>
                         @StringHelper.TruncateHeadAndTail(context.FundingTx, 5):@context.FundingTxOutputIndex
                         <Button Color="Color.Primary" Clicked="@(() => CopyStrToClipboard($"{context.FundingTx}:{context.FundingTxOutputIndex}"))">
@@ -102,7 +102,7 @@
                         </Button>
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridNumericColumn TItem="Channel" Field="@nameof(Channel.SatsAmount)" Caption="Capacity (BTC)" Filterable="false" Sortable="true">
+                <DataGridNumericColumn TItem="Channel" Field="@nameof(Channel.SatsAmount)" Caption="Capacity (BTC)" Filterable="false" Sortable="true" Displayable="@IsColumnVisible(ChannelsColumnName.Capacity)">
                     <DisplayTemplate>
                         @{
                             var btcAmount = new Money(context.SatsAmount, MoneyUnit.Satoshi).ToUnit(MoneyUnit.BTC);
@@ -111,8 +111,8 @@
                         }
                     </DisplayTemplate>
                 </DataGridNumericColumn>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.IsPrivate)" Caption="Private" Filterable="false" Sortable="true"/>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.BtcCloseAddress)" Caption="Close address" Filterable="false" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.IsPrivate)" Caption="Private" Filterable="false" Sortable="true" Displayable="@IsColumnVisible(ChannelsColumnName.Private)"/>
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.BtcCloseAddress)" Caption="Close address" Filterable="false" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.CloseAddress)">
 
                     <DisplayTemplate>
                         @if (!string.IsNullOrEmpty(context.BtcCloseAddress))
@@ -125,7 +125,7 @@
                     </DisplayTemplate>
 
                 </DataGridColumn>
-                <DataGridColumn TItem="Channel" Caption="Channel Balance" Filterable="false">
+                <DataGridColumn TItem="Channel" Caption="Channel Balance" Filterable="false" Displayable="@IsColumnVisible(ChannelsColumnName.ChannelBalance)">
                     <DisplayTemplate>
                         @{
                             var balance = Task.Run(() => GetPercentageBalance(context)).Result;
@@ -152,14 +152,19 @@
 
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.CreationDatetime)" Caption="@nameof(Channel.CreationDatetime).Humanize(LetterCasing.Sentence)" Sortable="true"/>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.UpdateDatetime)" Caption="@nameof(Channel.UpdateDatetime).Humanize(LetterCasing.Sentence)" Sortable="true"/>
-                <DataGridColumn TItem="Channel" Field="@nameof(Channel.ChanId)" Caption="Channel Id" Sortable="false">
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.CreationDatetime)" Caption="@nameof(Channel.CreationDatetime).Humanize(LetterCasing.Sentence)" Sortable="true" Displayable="@IsColumnVisible(ChannelsColumnName.CreationDate)"/>
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.UpdateDatetime)" Caption="@nameof(Channel.UpdateDatetime).Humanize(LetterCasing.Sentence)" Sortable="true" Displayable="@IsColumnVisible(ChannelsColumnName.UpdateDate)"/>
+                <DataGridColumn TItem="Channel" Field="@nameof(Channel.ChanId)" Caption="Channel Id" Sortable="false" Displayable="@IsColumnVisible(ChannelsColumnName.ChannelId)">
                     <DisplayTemplate>
                         <a href="@(Constants.AMBOSS_ENDPOINT + "/edge/" + context.ChanId)" target="_blank">
                             @context.ChanId
                         </a>
                     </DisplayTemplate>
+                </DataGridColumn>
+                <DataGridColumn TItem="Channel" Displayable="true">
+                    <FilterTemplate>
+                        <ColumnLayout @ref="ChannelsColumnLayout" Columns="@ChannelsColumns" ColumnType="ChannelsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    </FilterTemplate>
                 </DataGridColumn>
             </DataGridColumns>
         </DataGrid>
@@ -311,6 +316,7 @@
 @inject ILiquidityRuleRepository LiquidityRuleRepository
 @inject IWalletRepository WalletRepository
 @inject INodeRepository NodeRepository
+@inject ILocalStorageService LocalStorageService
 
 @code {
     private List<Channel>? _channels = new List<Channel>();
@@ -335,6 +341,24 @@
 
     private decimal _btcPrice;
 
+    private ColumnLayout<ChannelsColumnName> ChannelsColumnLayout;
+    private Dictionary<string, bool> ChannelsColumns = new();
+
+    public abstract class ChannelsColumnName
+    {
+        public static readonly ColumnDefault SourceNode = new("Source Node");
+        public static readonly ColumnDefault DestinationNode = new("Destination Node");
+        public static readonly ColumnDefault Status = new("Status");
+        public static readonly ColumnDefault Outpoint = new("Outpoint");
+        public static readonly ColumnDefault Capacity = new("Capacity (BTC)");
+        public static readonly ColumnDefault Private = new("Private");
+        public static readonly ColumnDefault CloseAddress = new("Close Address");
+        public static readonly ColumnDefault ChannelBalance = new("Channel Balance");
+        public static readonly ColumnDefault CreationDate = new("Creation Date");
+        public static readonly ColumnDefault UpdateDate = new("Update Date");
+        public static readonly ColumnDefault ChannelId = new("Channel Id");
+    }
+
     protected override async Task OnInitializedAsync()
     {
         _btcPrice = PriceConversionHelper.GetBtcToUsdPrice();
@@ -358,6 +382,21 @@
         _channels = await ChannelRepository.GetAllManagedByUserNodes(LoggedUser.Id);
         _nodes = await NodeRepository.GetAll();
         _channelsDataGridRef.FilterData();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            await LoadColumnLayout();
+
+        }
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        ChannelsColumns = await LocalStorageService.LoadStorage(nameof(ChannelsColumnName), ColumnHelpers.GetColumnsDictionary<ChannelsColumnName>());
+        StateHasChanged();
     }
 
     private async Task ShowConfirmedClose(Channel channel, bool forceClose = false)
@@ -700,5 +739,19 @@
         return channel.Status == Channel.ChannelStatus.Closed|| (lastRequest.RequestType == OperationRequestType.Close
                                                                  && lastRequest.Status == ChannelOperationRequestStatus.OnChainConfirmed
                                                                  || lastRequest.Status == ChannelOperationRequestStatus.OnChainConfirmationPending);
+    }
+
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsColumnVisible(ColumnDefault column)
+    {
+        if (ChannelsColumnLayout	== null)
+        {
+            return true;
+        }
+        return ChannelsColumnLayout.IsColumnVisible(column);
     }
 }

--- a/src/Pages/Nodes.razor
+++ b/src/Pages/Nodes.razor
@@ -21,12 +21,13 @@
                   UseInternalEditing="true"
                   RowInserted="OnRowInserted"
                   RowUpdated="OnRowUpdated"
+                  Filterable="true"
                   UseValidation="true">
             <PopupTitleTemplate>
                 <h2>@(context.EditState) node</h2>
             </PopupTitleTemplate>
             <DataGridColumns>
-                <DataGridCommandColumn TItem="Node" Width="120px">
+                <DataGridCommandColumn TItem="Node" Filterable="false" Width="120px">
                     <NewCommandTemplate>
                         <Button Color="Color.Success" TextColor="TextColor.Light" Clicked="@context.Clicked" Block>New</Button>
                     </NewCommandTemplate>
@@ -37,8 +38,8 @@
                         <Button Color="Color.Danger" hidden="@_hideDelete" Clicked="@(()=> ShowDeleteDialog(context.Item))" Size="Size.Small" Block>Delete</Button>
                     </DeleteCommandTemplate>
                 </DataGridCommandColumn>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.Name)" Validator="ValidationHelper.ValidateName" Caption="@nameof(Node.Name)" Sortable="false"/>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.PubKey)" Caption="@nameof(Node.PubKey)" Sortable="false" Width="220px">
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.Name)" Validator="ValidationHelper.ValidateName" Caption="@nameof(Node.Name)" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.Name)"/>
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.PubKey)" Caption="@nameof(Node.PubKey)" Sortable="false" Width="220px" Displayable="@IsColumnVisible(NodesColumnName.PubKey)">
                     <DisplayTemplate>
                         @StringHelper.TruncateHeadAndTail(context.PubKey, 6)&nbsp;
                         @{State state = new("Copy", "oi oi-clipboard");}
@@ -56,10 +57,10 @@
                         </Validation>
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.Description)" Caption="@nameof(Node.Description)" Sortable="false"/>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.ChannelAdminMacaroon)" Validator="ValidationRule.IsNotEmpty" Caption="Macaroon" CellsEditableOnNewCommand="true" CellsEditableOnEditCommand="false" Displayable="false" Sortable="false"/>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.Endpoint)" Validator="ValidationRule.IsNotEmpty" Caption="@nameof(Node.Endpoint)" Sortable="false"/>
-                <DataGridNumericColumn TItem="Node" Editable="false" Caption="Outbound Open Channels" Sortable="false">
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.Description)" Caption="@nameof(Node.Description)" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.Description)"/>
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.ChannelAdminMacaroon)" Validator="ValidationRule.IsNotEmpty" Caption="Macaroon" CellsEditableOnNewCommand="true" CellsEditableOnEditCommand="false" Displayable="false" Sortable="false"/>
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.Endpoint)" Validator="ValidationRule.IsNotEmpty" Caption="@nameof(Node.Endpoint)" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.Endpoint)"/>
+                <DataGridNumericColumn TItem="Node" Filterable="false" Editable="false" Caption="Outbound Open Channels" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.OutboundOpenChannels)">
                     <DisplayTemplate>
                         @{
                             IEnumerable<int?> associatedChannels = context?.ChannelOperationRequestsAsDestination?
@@ -70,7 +71,7 @@
                         }
                     </DisplayTemplate>
                 </DataGridNumericColumn>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.ReturningFundsWalletId)" Caption="Returning funds wallet" Sortable="false">
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.ReturningFundsWalletId)" Caption="Returning funds wallet" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.ReturningFundsWallet)">
                     <DisplayTemplate>
                         @if (context.ReturningFundsWallet != null)
                         {
@@ -101,21 +102,26 @@
 
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Node" Editable="true" Field="@nameof(Node.AutosweepEnabled)" Caption="Autosweep" Sortable="false"></DataGridColumn>
-                <DataGridColumn TItem="Node" Field="@nameof(Node.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending">
+                <DataGridColumn TItem="Node" Filterable="false" Editable="true" Field="@nameof(Node.AutosweepEnabled)" Caption="Autosweep" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.Autosweep)"></DataGridColumn>
+                <DataGridColumn TItem="Node" Filterable="false" Field="@nameof(Node.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsColumnVisible(NodesColumnName.CreationDate)">
                     <DisplayTemplate>
                         @context.CreationDatetime.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Node" Field="@nameof(Node.UpdateDatetime)" Caption="Update date" Sortable="false">
+                <DataGridColumn TItem="Node" Filterable="false" Field="@nameof(Node.UpdateDatetime)" Caption="Update date" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.UpdateDate)">
                     <DisplayTemplate>
                         @context.UpdateDatetime.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Node" Caption="@nameof(Node.Users)" Editable="false" CellsEditableOnEditCommand="false" Sortable="false">
+                <DataGridColumn TItem="Node" Filterable="false" Caption="@nameof(Node.Users)" Editable="false" CellsEditableOnEditCommand="false" Sortable="false" Displayable="@IsColumnVisible(NodesColumnName.Users)">
                     <DisplayTemplate>
                         <Button Color="Color.Primary" Clicked="@ShowModal" Block>Display Users</Button>
                     </DisplayTemplate>
+                </DataGridColumn>
+                <DataGridColumn TItem="Node" Displayable="true">
+                    <FilterTemplate>
+                        <ColumnLayout @ref="NodesColumnLayout" Columns="@NodesColumns" ColumnType="NodesColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    </FilterTemplate>
                 </DataGridColumn>
             </DataGridColumns>
         </DataGrid>
@@ -147,7 +153,7 @@
 @inject IMessageService MessageService
 @inject IWalletRepository WalletRepository
 @inject ISchedulerFactory  SchedulerFactory
-@inject ILightningService LightningService
+@inject ILocalStorageService LocalStorageService
 @implements IDisposable
 @code {
     private List<Node>? _nodes;
@@ -164,6 +170,23 @@
 
     [CascadingParameter]
     private ClaimsPrincipal? ClaimsPrincipal { get; set; }
+
+    private ColumnLayout<NodesColumnName> NodesColumnLayout;
+    private Dictionary<string, bool> NodesColumns = new();
+
+    public abstract class NodesColumnName
+    {
+        public static readonly ColumnDefault Name = new("Name");
+        public static readonly ColumnDefault PubKey = new("PubKey");
+        public static readonly ColumnDefault Description = new("Description");
+        public static readonly ColumnDefault Endpoint = new("Endpoint");
+        public static readonly ColumnDefault OutboundOpenChannels = new("Outbound Open Channels");
+        public static readonly ColumnDefault ReturningFundsWallet = new("Returning Funds Wallet");
+        public static readonly ColumnDefault Autosweep = new("Autosweep");
+        public static readonly ColumnDefault CreationDate = new("Creation Date");
+        public static readonly ColumnDefault UpdateDate = new("Update Date");
+        public static readonly ColumnDefault Users = new("Users");
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -185,6 +208,21 @@
     {
         _nodes = await NodeRepository.GetAllManagedByNodeGuard();
         _availableWallets = await WalletRepository.GetAvailableWallets();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            await LoadColumnLayout();
+
+        }
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        NodesColumns = await LocalStorageService.LoadStorage(nameof(NodesColumnName), ColumnHelpers.GetColumnsDictionary<NodesColumnName>());
+        StateHasChanged();
     }
 
     private async Task OnRowInserted(SavedRowItem<Node, Dictionary<string, object>> arg)
@@ -319,4 +357,17 @@
 
     record State(string Text, string ClassName, bool IsDisabled = false);
 
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsColumnVisible(ColumnDefault column)
+    {
+        if (NodesColumnLayout	== null)
+        {
+            return true;
+        }
+        return NodesColumnLayout.IsColumnVisible(column);
+    }
 }

--- a/src/Pages/Users.razor
+++ b/src/Pages/Users.razor
@@ -24,7 +24,7 @@
                   ShowPager="true"
                   ShowPageSizes="true"
                   PageSize="25"
-                  Filterable="false"
+                  Filterable="true"
                   ShowValidationFeedback="true"
                   ShowValidationsSummary="false"
                   UseValidation="true">
@@ -59,7 +59,7 @@
 
                 </DataGridCommandColumn>
 
-                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.UserName)" Caption="Username" Sortable="false">
+                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.UserName)" Caption="Username" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Username)">
                     <EditTemplate>
                         <Validation Validator="@((ValidatorEventArgs obj) => @ValidationHelper.ValidateUsername(obj, _users, context.Item.Id))">
                             <TextEdit Text="@((string)context.CellValue)" TextChanged="(text) => { context.CellValue = text; }">
@@ -70,13 +70,13 @@
                         </Validation>
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="ApplicationUser" Editable="true"  Caption="Roles" Sortable="false">
+                <DataGridColumn TItem="ApplicationUser" Editable="true"  Caption="Roles" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Roles)">
                     <DisplayTemplate>
                         @{
-                            
+
                             <span>@(GetUserRolesString(context))</span>
                         }
-                        
+
                     </DisplayTemplate>
                     <EditTemplate>
                         <Validation Validator="@ValidateRole">
@@ -93,34 +93,37 @@
                                 </Feedback>
                             </Select>
                         </Validation>
-                        
-                        
-                        
+
+
+
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.Nodes)" Caption="Managed nodes" Sortable="false">
+                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.Nodes)" Caption="Managed nodes" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.ManagedNodes)">
                     <DisplayTemplate>
                         @{
                             <span>@context?.Nodes?.Select(x=> x.Name).Humanize()</span>
                         }
-                        
+
                     </DisplayTemplate>
-                    
+
                     <EditTemplate>
                         <Select Multiple="true" TValue="int" @bind-SelectedValues="_selectedManagedNodes">
-                            
+
                             @foreach (var node in _nodesList)
                             {
                                 <SelectItem Value="node.Id">@node.Name</SelectItem>
 
                             }
                         </Select>
-                        
+
                     </EditTemplate>
                 </DataGridColumn>
-            
+                <DataGridColumn TItem="ApplicationUser" Displayable="true">
+                    <FilterTemplate>
+                        <ColumnLayout @ref="UsersColumnLayout" Columns="@UsersColumns" ColumnType="UsersColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    </FilterTemplate>
+                </DataGridColumn>
             </DataGridColumns>
-           
         </DataGrid>
     </Column>
 </Row>
@@ -135,10 +138,11 @@
 @inject IToastService ToastService
 @inject INodeRepository NodeRepository
 @inject IDbContextFactory<ApplicationDbContext> DbContextFactory
+@inject ILocalStorageService LocalStorageService
 @attribute [Authorize(Roles = "Superadmin")]
 @code {
     private List<ApplicationUser> _users = new();
-    
+
     [CascadingParameter]
     private ApplicationUser? LoggedUser { get; set; }
 
@@ -146,13 +150,22 @@
     private ClaimsPrincipal? ClaimsPrincipal { get; set; }
 
     private IReadOnlyList<ApplicationUserRole> _selectedRoles = new List<ApplicationUserRole> {};
-    
+
     private List<ApplicationUserRole> availableRoles = Enum.GetValues(typeof(ApplicationUserRole)).Cast<ApplicationUserRole>().ToList();
 
     private List<Node> _nodesList = new();
 
     private IReadOnlyList<int> _selectedManagedNodes = new List<int> {};
 
+    private ColumnLayout<UsersColumnName> UsersColumnLayout;
+    private Dictionary<string, bool> UsersColumns = new();
+
+    public abstract class UsersColumnName
+    {
+        public static readonly ColumnDefault Username = new("Username");
+        public static readonly ColumnDefault Roles = new("Roles");
+        public static readonly ColumnDefault ManagedNodes = new("Managed Nodes");
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -160,8 +173,6 @@
         {
             await GetData();
         }
-
-
     }
 
     private async Task GetData()
@@ -171,6 +182,21 @@
 
         _nodesList = await NodeRepository.GetAllManagedByNodeGuard();
 
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            await LoadColumnLayout();
+
+        }
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        UsersColumns = await LocalStorageService.LoadStorage(nameof(UsersColumnName), ColumnHelpers.GetColumnsDictionary<UsersColumnName>());
+        StateHasChanged();
     }
 
     private async Task OnRowInserted(SavedRowItem<ApplicationUser, Dictionary<string, object>> arg)
@@ -199,7 +225,7 @@
 
 
             var updateResult = ApplicationUserRepository.Update(arg.Item);
-        
+
             //Roles
             var updateUserRoles = await ApplicationUserRepository.UpdateUserRoles(_selectedRoles,arg.Item);
             if (updateResult.Item1 && updateUserRoles.Item1)
@@ -215,7 +241,7 @@
             }
 
         }
-     
+
         else
         {
             ToastService.ShowError("Something went wrong");
@@ -257,13 +283,13 @@
             var node= await NodeRepository.GetById(selectedManagedNode);
 
             node = Mapper.Map<Node, Node>(node);
-            
+
             arg.Item.Nodes.Add(node);
         }
 
 
         var updateResult2 = ApplicationUserRepository.Update(arg.Item);
-        
+
         //Roles
         var updateUserRoles = await ApplicationUserRepository.UpdateUserRoles(_selectedRoles,arg.Item);
 
@@ -308,10 +334,10 @@
 
         await contextClicked.InvokeAsync();
     }
-    
+
     private async Task CopyStrToClipboard(string arg)
     {
-        await ClipboardService.WriteTextAsync(arg); 
+        await ClipboardService.WriteTextAsync(arg);
         ToastService.ShowSuccess("Text copied");
     }
 
@@ -321,7 +347,7 @@
 
         if (link != null)
         {
-            await ClipboardService.WriteTextAsync(link); 
+            await ClipboardService.WriteTextAsync(link);
             ToastService.ShowSuccess("Text copied");
         }
         else
@@ -329,7 +355,7 @@
             ToastService.ShowError("Something went wrong");
 
         }
-       
+
     }
 
     private async Task OnUnlockUserClicked(ApplicationUser contextItem)
@@ -383,4 +409,17 @@
         }
     }
 
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsColumnVisible(ColumnDefault column)
+    {
+        if (UsersColumnLayout	== null)
+        {
+            return true;
+        }
+        return UsersColumnLayout.IsColumnVisible(column);
+    }
 }

--- a/src/Pages/Users.razor
+++ b/src/Pages/Users.razor
@@ -32,7 +32,7 @@
                 <h2>@(context.EditState) user</h2>
             </PopupTitleTemplate>
             <DataGridColumns>
-                <DataGridCommandColumn TItem="ApplicationUser">
+                <DataGridCommandColumn TItem="ApplicationUser" Filterable="false">
                     <NewCommandTemplate>
                         <Button Color="Color.Success" TextColor="TextColor.Light" Clicked="@context.Clicked">New</Button>
                     </NewCommandTemplate>
@@ -43,23 +43,18 @@
                             @if (context.Item.IsLocked)
                             {
                                 <Button Color="Color.Danger" Clicked="@(()=>OnUnlockUserClicked(context.Item))">Unlock</Button>
-
                             }
                             else
                             {
                                 <Button Color="Color.Danger" Clicked="@(()=>OnLockUserClicked(context.Item))">Lock</Button>
-
                             }
                         </Buttons>
-
                     </EditCommandTemplate>
                     <DeleteCommandTemplate>
                         @*Button Color="Color.Danger" Clicked="@context.Clicked">Delete</Button>*@
                     </DeleteCommandTemplate>
-
                 </DataGridCommandColumn>
-
-                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.UserName)" Caption="Username" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Username)">
+                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.UserName)" Caption="Username" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Username)" Filterable="false">
                     <EditTemplate>
                         <Validation Validator="@((ValidatorEventArgs obj) => @ValidationHelper.ValidateUsername(obj, _users, context.Item.Id))">
                             <TextEdit Text="@((string)context.CellValue)" TextChanged="(text) => { context.CellValue = text; }">
@@ -70,13 +65,11 @@
                         </Validation>
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="ApplicationUser" Editable="true"  Caption="Roles" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Roles)">
+                <DataGridColumn TItem="ApplicationUser" Editable="true"  Caption="Roles" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.Roles)" Filterable="false">
                     <DisplayTemplate>
                         @{
-
                             <span>@(GetUserRolesString(context))</span>
                         }
-
                     </DisplayTemplate>
                     <EditTemplate>
                         <Validation Validator="@ValidateRole">
@@ -85,7 +78,6 @@
                                     @foreach (var role in availableRoles)
                                     {
                                         <SelectItem Value="role">@role.Humanize()</SelectItem>
-
                                     }
                                 </ChildContent>
                                 <Feedback>
@@ -93,29 +85,21 @@
                                 </Feedback>
                             </Select>
                         </Validation>
-
-
-
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.Nodes)" Caption="Managed nodes" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.ManagedNodes)">
+                <DataGridColumn TItem="ApplicationUser" Editable="true" Field="@nameof(ApplicationUser.Nodes)" Caption="Managed nodes" Sortable="false" Displayable="@IsColumnVisible(UsersColumnName.ManagedNodes)" Filterable="false">
                     <DisplayTemplate>
                         @{
                             <span>@context?.Nodes?.Select(x=> x.Name).Humanize()</span>
                         }
-
                     </DisplayTemplate>
-
                     <EditTemplate>
                         <Select Multiple="true" TValue="int" @bind-SelectedValues="_selectedManagedNodes">
-
                             @foreach (var node in _nodesList)
                             {
                                 <SelectItem Value="node.Id">@node.Name</SelectItem>
-
                             }
                         </Select>
-
                     </EditTemplate>
                 </DataGridColumn>
                 <DataGridColumn TItem="ApplicationUser" Displayable="true">
@@ -129,15 +113,9 @@
 </Row>
 
 @page "/users"
-@using System.Security.Claims
-@using Blazorise.Extensions
-@using Humanizer
-@using Microsoft.AspNetCore.Identity
 @inject IApplicationUserRepository ApplicationUserRepository
-@inject UserManager<ApplicationUser> UserManager
 @inject IToastService ToastService
 @inject INodeRepository NodeRepository
-@inject IDbContextFactory<ApplicationDbContext> DbContextFactory
 @inject ILocalStorageService LocalStorageService
 @attribute [Authorize(Roles = "Superadmin")]
 @code {

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -11,6 +11,7 @@
 @inject IApplicationUserRepository ApplicationUserRepository
 @inject IKeyRepository KeyRepository
 @inject ILightningService LightningService
+@inject ILocalStorageService LocalStorageService
 @attribute [Authorize(Roles = "NodeManager, FinanceManager, Superadmin")]
 
 <h3 class="custom-primary">Treasury Wallets</h3>
@@ -91,7 +92,7 @@
                         }
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.Name)" Caption="@nameof(Wallet.Name)" Sortable="false">
+                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.Name)" Caption="@nameof(Wallet.Name)" Sortable="false" Displayable="@IsColumnVisible(WalletsColumnName.Name)">
                     <EditTemplate>
                         <Validation Validator="@ValidationHelper.ValidateName">
                             <TextEdit Text="@((string) context.CellValue)" TextChanged="(text) => { context.CellValue = text; }">
@@ -102,7 +103,7 @@
                         </Validation>
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.Description)" Caption="@nameof(Wallet.Description)" Sortable="false"/>
+                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.Description)" Caption="@nameof(Wallet.Description)" Sortable="false"  Displayable="@IsColumnVisible(WalletsColumnName.Description)"/>
                 <DataGridColumn TItem="Wallet" Displayable="false" Filterable="true" Caption="Hot Wallet" Field="@nameof(Wallet.IsHotWallet)" Editable="true" CustomFilter="((searchItem, searchValue) => OnCustomFilter(searchItem, _hotWalletFilter))">
                     <EditTemplate>
                         <Check TValue="bool" Disabled="@(context.Item.IsFinalised)" Checked="@((bool) context.CellValue)" CheckedChanged="(value) => OnCheckedChanged(context, value)" @ref="_hotWalletCheckComponent"/>
@@ -112,7 +113,7 @@
                 <DataGridColumn TItem="Wallet" Displayable="false" Filterable="true" Caption="Finalized" Field="@nameof(Wallet.IsFinalised)" Editable="false" CustomFilter="((searchItem, searchValue) => OnCustomFilter(searchItem, _finalizedWalletFilter))"/>
                 <DataGridColumn TItem="Wallet" Displayable="false" Filterable="true" Caption="Archived" Field="@nameof(Wallet.IsArchived)" Editable="true" CellsEditableOnNewCommand="false" CustomFilter="((searchItem, searchValue) => OnCustomFilter(searchItem, _archivedWalletFilter))"/>
                 <DataGridColumn TItem="Wallet" Displayable="false" Filterable="true" Caption="Compromised" Field="@nameof(Wallet.IsCompromised)" Editable="true" CellsEditableOnNewCommand="false" CustomFilter="((searchItem, searchValue) => OnCustomFilter(searchItem, _compromisedWalletFilter))"/>
-                <DataGridSelectColumn TItem="Wallet" Sortable="false" Filterable="true">
+                <DataGridSelectColumn TItem="Wallet" Sortable="false" Filterable="true"  Displayable="@IsColumnVisible(WalletsColumnName.WalletProperties)">
                     <FilterTemplate>
                         <Dropdown>
                             <DropdownToggle>Select</DropdownToggle>
@@ -147,7 +148,7 @@
                         }
                     </DisplayTemplate>
                 </DataGridSelectColumn>
-                <DataGridNumericColumn TItem="Wallet" Decimals="0" Editable="true" Field="@nameof(Wallet.MofN)" Caption="Threshold" Sortable="false">
+                <DataGridNumericColumn TItem="Wallet" Decimals="0" Editable="true" Field="@nameof(Wallet.MofN)" Caption="Threshold" Sortable="false"  Displayable="@IsColumnVisible(WalletsColumnName.Threshold)">
                     <EditTemplate>
                         <Validation Validator="@ValidateThreshold">
                             <NumericEdit TValue="int" Value="@(IsHotWallet(_hotWalletCheckComponent) ? 1 : (int) context.CellValue)" Disabled="@(context.Item.IsFinalised || IsHotWallet(_hotWalletCheckComponent))" ValueChanged="(value) => { context.CellValue = value; }">
@@ -158,16 +159,21 @@
                         </Validation>
                     </EditTemplate>
                 </DataGridNumericColumn>
-                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.ReferenceId)" Caption="Reference Id" Sortable="true"/>
-                <DataGridColumn TItem="Wallet" Field="@nameof(Wallet.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending">
+                <DataGridColumn TItem="Wallet" Editable="true" Field="@nameof(Wallet.ReferenceId)" Caption="Reference Id" Sortable="true"  Displayable="@IsColumnVisible(WalletsColumnName.ReferenceId)"/>
+                <DataGridColumn TItem="Wallet" Field="@nameof(Wallet.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending"  Displayable="@IsColumnVisible(WalletsColumnName.CreationDate)">
                     <DisplayTemplate>
                         @context.CreationDatetime.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="Wallet" Field="@nameof(Wallet.UpdateDatetime)" Caption="Update date" Sortable="true">
+                <DataGridColumn TItem="Wallet" Field="@nameof(Wallet.UpdateDatetime)" Caption="Update date" Sortable="true"  Displayable="@IsColumnVisible(WalletsColumnName.UpdateDate)">
                     <DisplayTemplate>
                         @context.UpdateDatetime.Humanize()
                     </DisplayTemplate>
+                </DataGridColumn>
+                <DataGridColumn TItem="Wallet" Displayable="true">
+                    <FilterTemplate>
+                        <ColumnLayout @ref="WalletsColumnLayout" Columns="@WalletsColumns" ColumnType="WalletsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    </FilterTemplate>
                 </DataGridColumn>
             </DataGridColumns>
             <DetailRowTemplate>
@@ -416,6 +422,20 @@
     private bool _archivedWalletFilter = false;
     private bool _compromisedWalletFilter = false;
 
+    private ColumnLayout<WalletsColumnName> WalletsColumnLayout;
+    private Dictionary<string, bool> WalletsColumns = new();
+
+    public abstract class WalletsColumnName
+    {
+        public static readonly ColumnDefault Name = new("Name");
+        public static readonly ColumnDefault Description = new("Description");
+        public static readonly ColumnDefault WalletProperties = new("Wallet Properties");
+        public static readonly ColumnDefault Threshold = new("Threshold");
+        public static readonly ColumnDefault ReferenceId = new("ReferenceId");
+        public static readonly ColumnDefault CreationDate = new("CreationDate");
+        public static readonly ColumnDefault UpdateDate = new("UpdateDate");
+    }
+
     protected override async Task OnInitializedAsync()
     {
         _btcPrice = PriceConversionHelper.GetBtcToUsdPrice();
@@ -431,6 +451,21 @@
             }
             await GetData();
         }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            await LoadColumnLayout();
+
+        }
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        WalletsColumns = await LocalStorageService.LoadStorage(nameof(WalletsColumnName), ColumnHelpers.GetColumnsDictionary<WalletsColumnName>());
+        StateHasChanged();
     }
 
     private async Task GetData()
@@ -879,5 +914,19 @@
             return (bool)item == (bool)value;
         }
         return true;
+    }
+
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsColumnVisible(ColumnDefault column)
+    {
+        if (WalletsColumnLayout	== null)
+        {
+            return true;
+        }
+        return WalletsColumnLayout.IsColumnVisible(column);
     }
 }

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -26,6 +26,7 @@
                   ShowPageSizes="true"
                   PageSize="25"
                   Narrow="true"
+                  Filterable="true"
                   ShowValidationFeedback="true"
                   ShowValidationsSummary="false"
                   UseValidation="true">
@@ -33,7 +34,7 @@
                     <h2>@(context.EditState) withdrawal</h2>
                 </PopupTitleTemplate>
                 <DataGridColumns>
-                    <DataGridCommandColumn TItem="WalletWithdrawalRequest">
+                    <DataGridCommandColumn TItem="WalletWithdrawalRequest" Filterable="false" >
                         <NewCommandTemplate>
                             <Button Color="Color.Success" TextColor="TextColor.Light" Clicked="@context.Clicked">New</Button>
                         </NewCommandTemplate>
@@ -46,7 +47,7 @@
                         </DeleteCommandTemplate>
 
                     </DataGridCommandColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.Id)" Caption="#" Sortable="false" Displayable="true" />
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.Id)" Caption="#" Sortable="false" Displayable="true" />
                     <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Caption="Actions" Sortable="false" Displayable="true">
                         <DisplayTemplate>
                             @*TODO Cancel / Reject  *@
@@ -74,7 +75,7 @@
                             }
                         </DisplayTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Description)" Caption="@nameof(WalletWithdrawalRequest.Description)" Sortable="false" Displayable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Description)" Caption="@nameof(WalletWithdrawalRequest.Description)" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Description)">
                         <DisplayTemplate>
                             <Tooltip Text="@context.Description" Placement="TooltipPlacement.Top">
                                 @context.Description.Truncate(40)
@@ -90,7 +91,7 @@
                             </Validation>
                         </EditTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Validator="@ValidationRule.IsSelected" Editable="true" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="@nameof(WalletWithdrawalRequest.Wallet)" Sortable="false" Displayable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Validator="@ValidationRule.IsSelected" Editable="true" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="@nameof(WalletWithdrawalRequest.Wallet)" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Wallet)">
                         <DisplayTemplate>
                             @if (context.Wallet != null)
                             {
@@ -130,12 +131,12 @@
                             </Validation>
                         </EditTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Editable="false" Field="@nameof(WalletWithdrawalRequest.UserRequestor)" Caption="Requestor" Sortable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Editable="false" Field="@nameof(WalletWithdrawalRequest.UserRequestor)" Caption="Requestor" Sortable="true" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Requestor)">
                         <DisplayTemplate>
                             @context?.UserRequestor?.UserName
                         </DisplayTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Validator="DestinationAddressValidator" Field="@nameof(WalletWithdrawalRequest.DestinationAddress)" Caption="@nameof(WalletWithdrawalRequest.DestinationAddress).Humanize()" Sortable="false" Displayable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Validator="DestinationAddressValidator" Field="@nameof(WalletWithdrawalRequest.DestinationAddress)" Caption="@nameof(WalletWithdrawalRequest.DestinationAddress).Humanize()" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.DestinationAddress)">
                         <DisplayTemplate>
                             @StringHelper.TruncateHeadAndTail(context.DestinationAddress,10)
                             @* TODO Copy and explorer buttons *@
@@ -157,36 +158,34 @@
                             }
                         </EditTemplate>
                     </DataGridColumn>
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount (BTC)" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Amount)" >
+                        <DisplayTemplate>
+                            @{
+                                @($"{context.Amount:f8} BTC ({Math.Round(PriceConversionHelper.BtcToUsdConversion(context.Amount, _btcPrice), 2)} USD)")
+                            }
+                        </DisplayTemplate>
+                        <EditTemplate>
+                            @if (!_isAmountDisabled)
+                            {
+                                <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args, _isAmountDisabled)">
+                                    <NumericPicker TValue="decimal" Disabled="_isAmountDisabled" Value="@((decimal)context.CellValue)" ValueChanged="(value) => { context.CellValue = value; }" CurrencySymbol="₿ " Max="@(_maxWithdrawal)" Min="_minWithdrawal" Decimals="8">
+                                        <Feedback>
+                                            <ValidationError />
+                                        </Feedback>
+                                    </NumericPicker>
+                                    <FieldHelp>
 
-                <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Displayable="true" Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount (BTC)" Sortable="false" >
-                    <DisplayTemplate>
-                        @{
-                            @($"{context.Amount:f8} BTC ({Math.Round(PriceConversionHelper.BtcToUsdConversion(context.Amount, _btcPrice), 2)} USD)")
-                        }
-                    </DisplayTemplate>
-                    <EditTemplate>
-                        @if (!_isAmountDisabled)
-                        {
-                            <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args, _isAmountDisabled)">
-                                <NumericPicker TValue="decimal" Disabled="_isAmountDisabled" Value="@((decimal)context.CellValue)" ValueChanged="(value) => { context.CellValue = value; }" CurrencySymbol="₿ " Max="@(_maxWithdrawal)" Min="_minWithdrawal" Decimals="8">
-                                    <Feedback>
-                                        <ValidationError />
-                                    </Feedback>
-                                </NumericPicker>
-                                <FieldHelp>
-
-                                    @($"Current amount: {Math.Round(PriceConversionHelper.BtcToUsdConversion((decimal)context.CellValue, _btcPrice), 2)} USD")
-                                </FieldHelp>
-                            </Validation>
-                        }
-                        else
-                        {
-                            <NumericPicker TValue="decimal" Disabled="_isAmountDisabled" Value="@((decimal)context.CellValue)" ValueChanged="(value) => { context.CellValue = value; }" CurrencySymbol="SAT "/>
-                        }
-                        </EditTemplate>
-                </DataGridColumn>
-
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="true">
+                                        @($"Current amount: {Math.Round(PriceConversionHelper.BtcToUsdConversion((decimal)context.CellValue, _btcPrice), 2)} USD")
+                                    </FieldHelp>
+                                </Validation>
+                            }
+                            else
+                            {
+                                <NumericPicker TValue="decimal" Disabled="_isAmountDisabled" Value="@((decimal)context.CellValue)" ValueChanged="(value) => { context.CellValue = value; }" CurrencySymbol="SAT "/>
+                            }
+                            </EditTemplate>
+                    </DataGridColumn>
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.SignaturesCollected)">
                         <DisplayTemplate>
                             @{
                                 if (context.Wallet != null)
@@ -199,20 +198,25 @@
                             }
                         </DisplayTemplate>
                     </DataGridColumn>
-                  <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Status)">
                         <DisplayTemplate>
                             @context?.Status.Humanize()
                         </DisplayTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.CreationDate)">
                         <DisplayTemplate>
                             @context.CreationDatetime.Humanize()
                         </DisplayTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.UpdateDatetime)" Caption="Update date" Sortable="true">
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.UpdateDatetime)" Caption="Update date" Sortable="true" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.UpdateDate)">
                         <DisplayTemplate>
                             @context.UpdateDatetime.Humanize()
                         </DisplayTemplate>
+                    </DataGridColumn>
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Displayable="true">
+                        <FilterTemplate>
+                            <ColumnLayout @ref="PendingRequestsColumnLayout" Columns="@PendingRequestsColumns" ColumnType="PendingWithdrawalsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                        </FilterTemplate>
                     </DataGridColumn>
                 </DataGridColumns>
                 <EmptyTemplate>
@@ -246,14 +250,14 @@
                   PageSize="25">
             <DataGridColumns>
                 <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.Id)" Caption="#" Sortable="false" Displayable="true" />
-                <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Description)" Caption="@nameof(WalletWithdrawalRequest.Description)" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Description)" Caption="@nameof(WalletWithdrawalRequest.Description)" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Description)">
                     <DisplayTemplate>
                         <Tooltip Text="@context.Description" Placement="TooltipPlacement.Top">
                             @context.Description.Truncate(40)
                         </Tooltip>
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="@nameof(WalletWithdrawalRequest.Wallet)" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="@nameof(WalletWithdrawalRequest.Wallet)" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Wallet)">
                     <DisplayTemplate>
                         @if (context.Wallet != null)
                         {
@@ -283,18 +287,18 @@
                         }
                     </EditTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="false" Field="@nameof(WalletWithdrawalRequest.UserRequestor)" Caption="Requestor" Sortable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="false" Field="@nameof(WalletWithdrawalRequest.UserRequestor)" Caption="Requestor" Sortable="true" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Requestor)">
                     <DisplayTemplate>
                         @context?.UserRequestor?.UserName
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true" Validator="DestinationAddressValidator" Field="@nameof(WalletWithdrawalRequest.DestinationAddress)" Caption="@nameof(WalletWithdrawalRequest.DestinationAddress).Humanize()" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true" Validator="DestinationAddressValidator" Field="@nameof(WalletWithdrawalRequest.DestinationAddress)" Caption="@nameof(WalletWithdrawalRequest.DestinationAddress).Humanize()" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.DestinationAddress)">
                     <DisplayTemplate>
                         @StringHelper.TruncateHeadAndTail(context.DestinationAddress,10)
                         @* TODO Copy and explorer buttons *@
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true"  Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount (BTC)" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Editable="true"  Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount (BTC)" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Amount)">
                     <DisplayTemplate>
                         @{
                             @($"{context.Amount:f8} BTC ({Math.Round(PriceConversionHelper.BtcToUsdConversion(context.Amount, _btcPrice), 2)} USD)")
@@ -302,7 +306,7 @@
                     </DisplayTemplate>
 
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.SignaturesCollected)">
                     <DisplayTemplate>
                         @{
                             if (context.Wallet != null)
@@ -314,28 +318,33 @@
                         }
                     </DisplayTemplate>
                 </DataGridColumn>
-              <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Status)">
                     <DisplayTemplate>
                         @context?.Status.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.CreationDate)">
                     <DisplayTemplate>
                         @context.CreationDatetime.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.UpdateDatetime)" Caption="Update date" Sortable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.UpdateDatetime)" Caption="Update date" Sortable="true" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.UpdateDate)">
                     <DisplayTemplate>
                         @context.UpdateDatetime.Humanize()
                     </DisplayTemplate>
                 </DataGridColumn>
-                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.TxId)" Caption="Links" Sortable="false" Displayable="true">
+                <DataGridColumn TItem="WalletWithdrawalRequest" Field="@nameof(WalletWithdrawalRequest.TxId)" Caption="Links" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllWithdrawalsColumnName.Links)">
                     <DisplayTemplate>
                         @if (mempoolUrl != null && !string.IsNullOrEmpty(context.TxId))
                         {
                             <a href="@(mempoolUrl + "/tx/" + context.TxId)" target="_blank">See in explorer</a>
                         }
                     </DisplayTemplate>
+                </DataGridColumn>
+                <DataGridColumn TItem="WalletWithdrawalRequest" Displayable="true">
+                    <FilterTemplate>
+                        <ColumnLayout @ref="AllRequestsColumnLayout" Columns="@AllRequestsColumns" ColumnType="AllWithdrawalsColumnName" OnUpdate="@OnColumnLayoutUpdate"/>
+                    </FilterTemplate>
                 </DataGridColumn>
             </DataGridColumns>
             <EmptyTemplate>
@@ -387,7 +396,7 @@
 @inject IWalletRepository WalletRepository
 @inject IBitcoinService BitcoinService
 @inject ISchedulerFactory SchedulerFactory
-
+@inject ILocalStorageService LocalStorageService
 
 @code {
     [CascadingParameter]
@@ -423,6 +432,38 @@
     private decimal _minWithdrawal = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _btcPrice;
 
+    private ColumnLayout<PendingWithdrawalsColumnName> PendingRequestsColumnLayout;
+    private ColumnLayout<AllWithdrawalsColumnName> AllRequestsColumnLayout;
+    private Dictionary<string, bool> PendingRequestsColumns = new();
+    private Dictionary<string, bool> AllRequestsColumns = new();
+
+    public abstract class PendingWithdrawalsColumnName
+    {
+        public static readonly ColumnDefault Description = new("Description");
+        public static readonly ColumnDefault Wallet = new("Wallet");
+        public static readonly ColumnDefault Requestor = new("Requestor");
+        public static readonly ColumnDefault DestinationAddress = new("Destination Address");
+        public static readonly ColumnDefault Amount = new("Amount (BTC)");
+        public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
+        public static readonly ColumnDefault Status = new("Status");
+        public static readonly ColumnDefault CreationDate = new("Creation Date");
+        public static readonly ColumnDefault UpdateDate = new("Update Date");
+    }
+
+    public abstract class AllWithdrawalsColumnName
+    {
+        public static readonly ColumnDefault Description = new("Description");
+        public static readonly ColumnDefault Wallet = new("Wallet");
+        public static readonly ColumnDefault Requestor = new("Requestor");
+        public static readonly ColumnDefault DestinationAddress = new("Destination Address");
+        public static readonly ColumnDefault Amount = new("Amount (BTC)");
+        public static readonly ColumnDefault SignaturesCollected = new("Signatures Collected");
+        public static readonly ColumnDefault Status = new("Status");
+        public static readonly ColumnDefault CreationDate = new("Creation Date");
+        public static readonly ColumnDefault UpdateDate = new("Update Date");
+        public static readonly ColumnDefault Links = new("Links");
+    }
+
     protected override async Task OnInitializedAsync()
     {
         if (LoggedUser == null) return;
@@ -435,6 +476,22 @@
 
         _isFinanceManager = ClaimsPrincipal != null && ClaimsPrincipal.IsInRole(ApplicationUserRole.FinanceManager.ToString());
         await GetData();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            await LoadColumnLayout();
+
+        }
+    }
+
+    private async Task LoadColumnLayout()
+    {
+        AllRequestsColumns = await LocalStorageService.LoadStorage(nameof(AllWithdrawalsColumnName), ColumnHelpers.GetColumnsDictionary<AllWithdrawalsColumnName>());
+        PendingRequestsColumns = await LocalStorageService.LoadStorage(nameof(PendingWithdrawalsColumnName), ColumnHelpers.GetColumnsDictionary<PendingWithdrawalsColumnName>());
+        StateHasChanged();
     }
 
     private async Task GetData()
@@ -848,4 +905,26 @@
         }
     }
 
+    private void OnColumnLayoutUpdate()
+    {
+        StateHasChanged();
+    }
+
+    private bool IsPendingRequestsColumnVisible(ColumnDefault column)
+    {
+        if (PendingRequestsColumnLayout	== null)
+        {
+            return true;
+        }
+        return PendingRequestsColumnLayout.IsColumnVisible(column);
+    }
+
+    private bool IsAllRequestsColumnVisible(ColumnDefault column)
+    {
+        if (AllRequestsColumnLayout	== null)
+        {
+            return true;
+        }
+        return AllRequestsColumnLayout.IsColumnVisible(column);
+    }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -112,6 +112,7 @@ namespace FundsManager
 
             //Service DI
             builder.Services.AddTransient<ClipboardService>();
+            builder.Services.AddTransient<LocalStorageService>();
             builder.Services.AddTransient<ILightningService, LightningService>();
             builder.Services.AddTransient<IBitcoinService, BitcoinService>();
             builder.Services.AddTransient<NotificationService, NotificationService>();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -112,7 +112,7 @@ namespace FundsManager
 
             //Service DI
             builder.Services.AddTransient<ClipboardService>();
-            builder.Services.AddTransient<LocalStorageService>();
+            builder.Services.AddTransient<ILocalStorageService, LocalStorageService>();
             builder.Services.AddTransient<ILightningService, LightningService>();
             builder.Services.AddTransient<IBitcoinService, BitcoinService>();
             builder.Services.AddTransient<NotificationService, NotificationService>();

--- a/src/Services/LocalStorageService.cs
+++ b/src/Services/LocalStorageService.cs
@@ -2,7 +2,13 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace FundsManager.Services;
 
-public class LocalStorageService
+public interface  ILocalStorageService
+{
+    Task<T> LoadStorage<T>(string name, T? defaultValue = default);
+    Task SetStorage<T>(string name, T value);
+}
+
+public class LocalStorageService: ILocalStorageService
 {
     private ProtectedLocalStorage ProtectedLocalStorage;
 

--- a/src/Services/LocalStorageService.cs
+++ b/src/Services/LocalStorageService.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace FundsManager.Services;
+
+public class LocalStorageService
+{
+    private ProtectedLocalStorage ProtectedLocalStorage;
+
+    public LocalStorageService(ProtectedLocalStorage protectedLocalStorage)
+    {
+        ProtectedLocalStorage = protectedLocalStorage;
+    }
+
+    public async Task<T> LoadStorage<T>(string name, T? defaultValue = default)
+    {
+        var result = await ProtectedLocalStorage.GetAsync<T>(name);
+        if (result.Success)
+        {
+            return result.Value;
+        }
+        if (defaultValue != null)
+        {
+            await ProtectedLocalStorage.SetAsync(name, defaultValue);
+        }
+        return defaultValue;
+    }
+
+    public async Task SetStorage<T>(string name, T value)
+    {
+        await ProtectedLocalStorage.SetAsync(name, value);
+    }
+}

--- a/src/Shared/ColumnLayout.razor
+++ b/src/Shared/ColumnLayout.razor
@@ -14,8 +14,7 @@
     </DropdownMenu>
 </Dropdown>
 
-@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
-@inject LocalStorageService LocalStorageService
+@inject ILocalStorageService LocalStorageService
 @typeparam ColumnType
 @code {
     [Parameter, EditorRequired]

--- a/src/Shared/ColumnLayout.razor
+++ b/src/Shared/ColumnLayout.razor
@@ -15,41 +15,20 @@
 </Dropdown>
 
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
-@inject ProtectedLocalStorage ProtectedLocalStorage
+@inject LocalStorageService LocalStorageService
 @typeparam ColumnType
 @code {
-    [Parameter]
+    [Parameter, EditorRequired]
     public Dictionary<string, bool> Columns { get; set; } = new();
 
     [Parameter]
     public Action OnUpdate { private get; set; } = () => { };
 
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadStateAsync();
-        OnUpdate();
-    }
-
-    private async Task LoadStateAsync()
-    {
-        var result = await ProtectedLocalStorage.GetAsync<Dictionary<string, bool>>(typeof(ColumnType).Name);
-        if (result.Success)
-        {
-            Columns = result.Value;
-        }
-        else
-        {
-            Columns = GetColumnsDictionary();
-            await ProtectedLocalStorage.SetAsync(typeof(ColumnType).Name, Columns);
-        }
-    }
-
     private async Task OnColumnChanged(string key, bool value)
     {
         Columns[key] = value;
-        await ProtectedLocalStorage.SetAsync(typeof(ColumnType).Name, Columns);
+        await LocalStorageService.SetStorage(typeof(ColumnType).Name, Columns);
         OnUpdate();
-        StateHasChanged();
     }
 
     public bool IsColumnVisible(ColumnDefault column)
@@ -59,10 +38,5 @@
             return value;
         }
         return true;
-    }
-
-    private Dictionary<string, bool> GetColumnsDictionary()
-    {
-        return typeof(ColumnType).GetFields().Select(p => (ColumnDefault)p.GetValue(null)).ToDictionary((c) => c.Name, (c) => c.Visibility);
     }
 }

--- a/src/Shared/ColumnLayout.razor
+++ b/src/Shared/ColumnLayout.razor
@@ -1,5 +1,5 @@
-<Dropdown>
-    <DropdownToggle Color="Color.Primary" ToggleIconVisible="false">
+<Dropdown Visible="Visible">
+    <DropdownToggle Color="Color.Primary" ToggleIconVisible="false" Clicked="OnVisibleChanged">
         <Icon Name="IconName.AngleDown"></Icon>
     </DropdownToggle>
     <DropdownMenu>
@@ -22,6 +22,13 @@
 
     [Parameter]
     public Action OnUpdate { private get; set; } = () => { };
+
+    private bool Visible { get; set; }
+
+    private void OnVisibleChanged(MouseEventArgs _)
+    {
+        Visible = !Visible;
+    }
 
     private async Task OnColumnChanged(string key, bool value)
     {

--- a/src/Shared/ColumnLayout.razor
+++ b/src/Shared/ColumnLayout.razor
@@ -1,0 +1,62 @@
+<Dropdown>
+    <DropdownToggle Color="Color.Primary" ToggleIconVisible="false">
+        <Icon Name="IconName.AngleDown"></Icon>
+    </DropdownToggle>
+    <DropdownMenu>
+        @foreach(var Column in Columns)
+        {
+            <DropdownItem>
+                <Check TValue="bool" Checked="@Column.Value" CheckedChanged="@((value) => OnColumnChanged(Column.Key, value))">
+                    @Column.Key
+                </Check>
+            </DropdownItem>
+        }
+    </DropdownMenu>
+</Dropdown>
+
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@inject ProtectedLocalStorage ProtectedLocalStorage
+@typeparam ColumnType
+@code {
+    [Parameter]
+    public Dictionary<string, bool> Columns { get; set; } = new();
+
+    [Parameter]
+    public Action OnUpdate { private get; set; } = () => { };
+
+    public async Task InitializeColumnLayout()
+    {
+        var result = await ProtectedLocalStorage.GetAsync<Dictionary<string, bool>>(typeof(ColumnType).Name);
+        if (result.Success)
+        {
+            Columns = result.Value;
+        }
+        else
+        {
+            Columns = GetColumnsDictionary();
+            await ProtectedLocalStorage.SetAsync(typeof(ColumnType).Name, Columns);
+        }
+    }
+
+    private async Task OnColumnChanged(string key, bool value)
+    {
+        Columns[key] = value;
+        await ProtectedLocalStorage.SetAsync(typeof(ColumnType).Name, Columns);
+        OnUpdate();
+        StateHasChanged();
+    }
+
+    public bool IsColumnVisible(ColumnDefault column)
+    {
+        if (Columns.TryGetValue(column.Name, out bool value))
+        {
+            return value;
+        }
+        return true;
+    }
+
+    private Dictionary<string, bool> GetColumnsDictionary()
+    {
+        return typeof(ColumnType).GetFields().Select(p => (ColumnDefault)p.GetValue(null)).ToDictionary((c) => c.Name, (c) => c.Visibility);
+    }
+}

--- a/src/Shared/ColumnLayout.razor
+++ b/src/Shared/ColumnLayout.razor
@@ -24,7 +24,13 @@
     [Parameter]
     public Action OnUpdate { private get; set; } = () => { };
 
-    public async Task InitializeColumnLayout()
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStateAsync();
+        OnUpdate();
+    }
+
+    private async Task LoadStateAsync()
     {
         var result = await ProtectedLocalStorage.GetAsync<Dictionary<string, bool>>(typeof(ColumnType).Name);
         if (result.Success)


### PR DESCRIPTION
- Changed order of Source and Remote node columns in the first table to match the table below
- Dropdowns are implemented in the "Filters" row most of the time, except in the channel requests table because it has the new button in the top right instead of the top left and was too much of a change to do here.
- Dropdown doesn't hide on focus lost, same thing that happens with the hot wallet filters