### PR TITLE
Show user channel opening failure reason

### DIFF
--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -18,7 +18,9 @@
  */
 
 using System.ComponentModel.DataAnnotations.Schema;
+using FundsManager.Helpers;
 using NBitcoin;
+using System.Text.Json;
 
 namespace FundsManager.Data.Models
 {
@@ -100,6 +102,8 @@ namespace FundsManager.Data.Models
         public string? ClosingReason { get; set; }
 
         public decimal? FeeRate { get; set; }
+
+        [Column(TypeName = "jsonb")] public List<ChannelStatusLog> StatusLogs { get; set; } = new();
 
         #region Relationships
 

--- a/src/Helpers/ChannelStatusLog.cs
+++ b/src/Helpers/ChannelStatusLog.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace FundsManager.Helpers;
+
+public class ChannelStatusLog
+{
+    public DateTime DateTime { get; set; }
+    public LogLevel Level { get; set; }
+    public string Description { get; set; }
+    
+    [JsonConstructor]
+    public ChannelStatusLog(DateTime dateTime, LogLevel level, string description)
+    {
+        DateTime = dateTime;
+        Level = level;
+        Description = description;
+    }
+    
+    public ChannelStatusLog(LogLevel level, string description)
+    {
+        DateTime = DateTime.Now;
+        Level = level;
+        Description = description;
+    }
+           
+    public static ChannelStatusLog Info(string description)
+    {
+        return new ChannelStatusLog(LogLevel.Information, description);
+    }
+        
+    public static ChannelStatusLog Error(string description)
+    {
+        return new ChannelStatusLog(LogLevel.Error, description);
+    }
+        
+    public static ChannelStatusLog Warning(string description)
+    {
+        return new ChannelStatusLog(LogLevel.Warning, description);
+    }
+}

--- a/src/Helpers/CustomExceptions.cs
+++ b/src/Helpers/CustomExceptions.cs
@@ -13,3 +13,13 @@ public class ShowToUserException : Exception
 {
    public ShowToUserException(string? message): base(message) {}
 }
+
+public class PeerNotOnlineException : Exception
+{
+   public PeerNotOnlineException(string? message = null): base(message) {}
+}
+
+public class RemoteCanceledFundingException : Exception
+{
+   public RemoteCanceledFundingException(string? message = null): base(message) {}
+}

--- a/src/Helpers/JobTypes.cs
+++ b/src/Helpers/JobTypes.cs
@@ -144,6 +144,29 @@ public class RetriableJob
             await callback();
         }
     }
+    
+    /// <summary>
+    /// Get the next interval time
+    /// </summary>
+    /// <param name="context">The execution context of the job</param>
+    public static int? GetNextInterval(IJobExecutionContext context)
+    {
+        var data = context.JobDetail.JobDataMap;
+        var intervals = data.Get("intervalListInMinutes") as int[];
+        if (intervals == null)
+        {
+            throw new Exception("No interval list found, make sure you're using the RetriableJob class");
+        };
+
+        var trigger = context.Trigger as SimpleTriggerImpl;
+
+        if (trigger!.TimesTriggered <= intervals.Length)
+        {
+            return intervals[trigger!.TimesTriggered - 1];
+        }
+
+        return null;
+    } 
 }
 
 public class JobAndTrigger

--- a/src/Migrations/20230704133231_StatusLogsForChannelRequests.Designer.cs
+++ b/src/Migrations/20230704133231_StatusLogsForChannelRequests.Designer.cs
@@ -5,6 +5,7 @@ using FundsManager.Data;
 using FundsManager.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FundsManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230704133231_StatusLogsForChannelRequests")]
+    partial class StatusLogsForChannelRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20230704133231_StatusLogsForChannelRequests.cs
+++ b/src/Migrations/20230704133231_StatusLogsForChannelRequests.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using FundsManager.Helpers;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FundsManager.Migrations
+{
+    public partial class StatusLogsForChannelRequests : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<ChannelStatusLog>>(
+                name: "StatusLogs",
+                table: "ChannelOperationRequests",
+                type: "jsonb",
+                nullable: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StatusLogs",
+                table: "ChannelOperationRequests");
+        }
+    }
+}

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -292,7 +292,14 @@
                 }
             </DisplayTemplate>
         </DataGridColumn>
-        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status).Humanize(LetterCasing.Sentence)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Status)"/>
+        <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.Status)" Caption="Status" Sortable="false" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Status)">
+            <DisplayTemplate>
+                <Row Style="white-space: nowrap;">
+                    @context.Status.Humanize(LetterCasing.Sentence)
+                    <ChannelStatusLogsTooltip ChannelStatusLogs="@context.StatusLogs"/> 
+                </Row>
+            </DisplayTemplate>
+        </DataGridColumn>
         <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Caption="Creation Date" Sortable="true" SortDirection="SortDirection.Descending" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.CreationDate)">
             <DisplayTemplate>
                 @context.CreationDatetime.Humanize()

--- a/src/Pages/ChannelRequestsComponents/ChannelStatusLogsTooltip.razor
+++ b/src/Pages/ChannelRequestsComponents/ChannelStatusLogsTooltip.razor
@@ -1,0 +1,38 @@
+@namespace FundsManager.Pages
+
+@if (ChannelStatusLogs?.Count > 0)
+{
+    <Tooltip Class="ml-2" Text="@GetTooltipText(ChannelStatusLogs)">
+        <Icon TextColor="TextColor.Danger" Name="IconName.InfoCircle"></Icon>
+    </Tooltip>
+}
+
+@code {
+   [Parameter, EditorRequired]
+   public List<ChannelStatusLog>? ChannelStatusLogs { get; set; }
+    
+    
+    private string GetTooltipText(List<ChannelStatusLog> channelStatusLogs)
+    {
+        var text = "<ul>";
+        foreach (var channelStatusLog in channelStatusLogs)
+        {
+            var emoji = "";
+            switch (channelStatusLog.Level)
+            {
+                case LogLevel.Information:
+                    emoji = "ℹ️";
+                    break;
+                case LogLevel.Warning:
+                    emoji = "⚠️";
+                    break;
+                case LogLevel.Error:
+                    emoji = "❌";
+                    break;
+            }
+            text += $"<li>{emoji} {channelStatusLog.DateTime:dd/MM/yyyy HH:mm:ss} - {channelStatusLog.Description}</li>";
+        }
+        text += "</ul>";
+        return text;
+    }
+}

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -265,6 +265,10 @@ namespace FundsManager.Services
                 //We avoid to stop the method if the peer is already connected
                 catch (RpcException e)
                 {
+                    if (e.Message.Contains("is not online"))
+                    {
+                        throw new PeerNotOnlineException($"$peer {destination.PubKey} is not online");
+                    }
                     if (!e.Message.Contains("already connected to peer"))
                     {
                         throw;
@@ -601,6 +605,11 @@ namespace FundsManager.Services
 
                 //TODO: We have to separate the exceptions between the ones that are retriable and the ones that are not
                 //TODO: and mark the channel operation request as failed automatically when they are not retriable
+                if (e.Message.Contains("remote canceled funding"))
+                {
+                    // TODO: Make exception message pretty
+                    throw new RemoteCanceledFundingException(e.Message);
+                }
                 throw;
             }
         }


### PR DESCRIPTION
- Added logs in UI for "peer not online" and remote canceling funding
- Added Not retrying in case that the remote node cancels funding
- Added a directory inside "Pages" called "ChannelRequestsComponents" where we would put all non-shared components that are used in the ChannelRequests page.