### PR TITLE
Check upfront shutdown script opt

### DIFF
--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -255,8 +255,8 @@ namespace FundsManager.Services
                 if (upfrontShutdownScriptOpt && remoteNodeInfo.Features[(uint)FeatureBit.UpfrontShutdownScriptOpt] is { IsKnown: true } ||
                     upfrontShutdownScriptReq && remoteNodeInfo.Features[(uint)FeatureBit.UpfrontShutdownScriptReq] is { IsKnown: true })
                 {
-                    var keyPathInformation = await GetCloseAddress(channelOperationRequest, derivationStrategyBase, _nbXplorerService, _logger);
-                    closeAddress = keyPathInformation?.Address?.ToString();
+                    var address = await GetCloseAddress(channelOperationRequest, derivationStrategyBase, _nbXplorerService, _logger);
+                    closeAddress = address.Address.ToString();
                     openChannelRequest.CloseAddress = closeAddress;
                 }
 
@@ -682,7 +682,7 @@ namespace FundsManager.Services
             throw new ArgumentException(invalidPsbtNullToBeUsedForTheRequest, nameof(combinedPSBT));
         }
 
-        public static async Task<KeyPathInformation?> GetCloseAddress(ChannelOperationRequest channelOperationRequest,
+        public static async Task<KeyPathInformation> GetCloseAddress(ChannelOperationRequest channelOperationRequest,
             DerivationStrategyBase derivationStrategyBase, INBXplorerService nbXplorerService, ILogger? _logger = null)
         {
             var closeAddress = await

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -252,7 +252,8 @@ namespace FundsManager.Services
                 var upfrontShutdownScriptOpt = remoteNodeInfo.Features.ContainsKey((uint)FeatureBit.UpfrontShutdownScriptOpt);
                 var upfrontShutdownScriptReq = remoteNodeInfo.Features.ContainsKey((uint)FeatureBit.UpfrontShutdownScriptReq);
                 string? closeAddress = null;
-                if (upfrontShutdownScriptOpt || upfrontShutdownScriptReq)
+                if (upfrontShutdownScriptOpt && remoteNodeInfo.Features[(uint)FeatureBit.UpfrontShutdownScriptOpt] is { IsKnown: true } ||
+                    upfrontShutdownScriptReq && remoteNodeInfo.Features[(uint)FeatureBit.UpfrontShutdownScriptReq] is { IsKnown: true })
                 {
                     var keyPathInformation = await GetCloseAddress(channelOperationRequest, derivationStrategyBase, _nbXplorerService, _logger);
                     closeAddress = keyPathInformation?.Address?.ToString();

--- a/test/FundsManager.Tests/Services/LightningServiceTests.cs
+++ b/test/FundsManager.Tests/Services/LightningServiceTests.cs
@@ -17,6 +17,7 @@
  *
  */
 
+using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using FundsManager.Data;
 using FundsManager.Data.Models;
@@ -297,7 +298,7 @@ namespace FundsManager.Services
             var nbXplorerMock = new Mock<INBXplorerService>();
             //Mock to return a wallet address
             var keyPathInformation = new KeyPathInformation()
-                {Address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest)};
+                { Address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest) };
 
             nbXplorerMock
                 .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<DerivationFeature>(),
@@ -426,7 +427,7 @@ namespace FundsManager.Services
                 .Setup(x => x.GetById(It.IsAny<int>()))
                 .ReturnsAsync(operationRequest);
 
-            var nodes = new List<Node> {destinationNode};
+            var nodes = new List<Node> { destinationNode };
 
             nodeRepository
                 .Setup(x => x.GetAllManagedByNodeGuard())
@@ -527,7 +528,7 @@ namespace FundsManager.Services
                 },
             };
 
-            utxoChanges.Confirmed = new UTXOChange() {UTXOs = utxoList};
+            utxoChanges.Confirmed = new UTXOChange() { UTXOs = utxoList };
 
             var channelOperationRequestPsbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
             channelOperationRequestPsbtRepository
@@ -654,7 +655,7 @@ namespace FundsManager.Services
                 .Setup(x => x.GetById(It.IsAny<int>()))
                 .ReturnsAsync(operationRequest);
 
-            var nodes = new List<Node> {destinationNode};
+            var nodes = new List<Node> { destinationNode };
 
             nodeRepository
                 .Setup(x => x.GetAllManagedByNodeGuard())
@@ -755,7 +756,7 @@ namespace FundsManager.Services
                 },
             };
 
-            utxoChanges.Confirmed = new UTXOChange() {UTXOs = utxoList};
+            utxoChanges.Confirmed = new UTXOChange() { UTXOs = utxoList };
 
             var channelOperationRequestPsbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
             channelOperationRequestPsbtRepository
@@ -882,7 +883,7 @@ namespace FundsManager.Services
                 .Setup(x => x.GetById(It.IsAny<int>()))
                 .ReturnsAsync(operationRequest);
 
-            var nodes = new List<Node> {destinationNode};
+            var nodes = new List<Node> { destinationNode };
 
             nodeRepository
                 .Setup(x => x.GetAllManagedByNodeGuard())
@@ -983,7 +984,7 @@ namespace FundsManager.Services
                 },
             };
 
-            utxoChanges.Confirmed = new UTXOChange() {UTXOs = utxoList};
+            utxoChanges.Confirmed = new UTXOChange() { UTXOs = utxoList };
 
             var channelOperationRequestPsbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
             channelOperationRequestPsbtRepository
@@ -1059,7 +1060,7 @@ namespace FundsManager.Services
             //TODO Remove hack
             LightningService.CreateLightningClient = originalCreateLightningClient;
         }
-        
+
         /// <summary>
         /// This tests makes sure that if a multisig wallet is used, the number of signatures is correct.
         /// This means that we need in in a m-of-n multisig, m-1 signatures so nodeguard is that last one to sign to avoid leaking signatures with SIGHASH_NONE
@@ -1086,9 +1087,9 @@ namespace FundsManager.Services
             {
                 PSBT = userSignedPSBT,
             });
-            
+
             //Lets add a second signed "human" PSBT
-            
+
             channelOpReqPsbts.Add(new ChannelOperationRequestPSBT()
             {
                 PSBT = userSignedPSBT,
@@ -1120,7 +1121,7 @@ namespace FundsManager.Services
                 .Setup(x => x.GetById(It.IsAny<int>()))
                 .ReturnsAsync(operationRequest);
 
-            var nodes = new List<Node> {destinationNode};
+            var nodes = new List<Node> { destinationNode };
 
             nodeRepository
                 .Setup(x => x.GetAllManagedByNodeGuard())
@@ -1221,7 +1222,7 @@ namespace FundsManager.Services
                 },
             };
 
-            utxoChanges.Confirmed = new UTXOChange() {UTXOs = utxoList};
+            utxoChanges.Confirmed = new UTXOChange() { UTXOs = utxoList };
 
             var channelOperationRequestPsbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
             channelOperationRequestPsbtRepository
@@ -1347,7 +1348,7 @@ namespace FundsManager.Services
                 .Setup(x => x.GetById(It.IsAny<int>()))
                 .ReturnsAsync(operationRequest);
 
-            var nodes = new List<Node> {destinationNode};
+            var nodes = new List<Node> { destinationNode };
 
             nodeRepository
                 .Setup(x => x.GetAllManagedByNodeGuard())
@@ -1448,7 +1449,7 @@ namespace FundsManager.Services
                 },
             };
 
-            utxoChanges.Confirmed = new UTXOChange() {UTXOs = utxoList};
+            utxoChanges.Confirmed = new UTXOChange() { UTXOs = utxoList };
 
             var channelOperationRequestPsbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
             channelOperationRequestPsbtRepository
@@ -1611,6 +1612,104 @@ namespace FundsManager.Services
 
             //TODO Remove hack
             LightningService.CreateLightningClient = originalCreateLightningClient;
+        }
+
+        [Fact]
+        public async Task? CreateOpenChannelRequest_CreatesRequestWithoutClosingAddress()
+        {
+            // Arrange
+            var wallet = CreateWallet.SingleSig(_internalWallet);
+            var channelOperationRequest = new ChannelOperationRequest
+            {
+                Wallet = wallet
+            };
+            var psbt =
+                "cHNidP8BAFIBAAAAAeh7YDXyZE11vXb0yRqCkrxY7VpHH1WVMHwaCWYMv/pCAQAAAAD/////AUjf9QUAAAAAFgAULTCtUNMojFQZ8oa6fpbXbDhK2EYAAAAATwEENYfPA325Ro0AAAABg9H86IDUttPPFss+9te+0DByQgbeD7RPXNuVH9mh1qIDnMEWyKA+kvyG038on8+HxI+9AD8r6ZI1dNIDSGC8824Q7QIQyDAAAIABAACAAQAAAAABAR8A4fUFAAAAABYAFOk69QEyo0x+Xs/zV62OLrHh9eszAQMEAgAAAAAA";
+
+            var combinedPsbt = LightningHelper.CombinePSBTs(new[] { psbt });
+            var lightningService = new LightningService(_logger, null, null, null, null, null, null, null, null);
+            var pendingChannelId = RandomNumberGenerator.GetBytes(32);
+            var derivationStrategyBase = LightningService.GetDerivationStrategyBase(channelOperationRequest);
+            var node = new LightningNode()
+            {
+                PubKey = "03650f49929d84d9a6d9b5a66235c603a1a0597dd609f7cd3b15052382cf9bb1b4"
+            };
+
+            // Act
+            var openChannelRequest = await lightningService.CreateOpenChannelRequest(channelOperationRequest, combinedPsbt, node, 1000, pendingChannelId, derivationStrategyBase);
+
+            // Assert
+            openChannelRequest.Should().Be(new OpenChannelRequest()
+            {
+                FundingShim = new FundingShim
+                {
+                    PsbtShim = new PsbtShim
+                    {
+                        BasePsbt = ByteString.FromBase64(combinedPsbt.ToBase64()),
+                        NoPublish = false,
+                        PendingChanId = ByteString.CopyFrom(pendingChannelId)
+                    }
+                },
+                LocalFundingAmount = 1000,
+                Private = false,
+                NodePubkey = ByteString.CopyFrom(Convert.FromHexString("03650f49929d84d9a6d9b5a66235c603a1a0597dd609f7cd3b15052382cf9bb1b4")),
+                CloseAddress = ""
+            });
+        }
+
+        [Fact]
+        public async Task? CreateOpenChannelRequest_CreatesRequestWithClosingAddress()
+        {
+            // Arrange
+            var nbXplorerMock = new Mock<INBXplorerService>();
+
+            nbXplorerMock.Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<DerivationFeature>(),
+                    It.IsAny<int>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<KeyPathInformation?>(new KeyPathInformation() { Address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest) }));
+
+
+            var wallet = CreateWallet.SingleSig(_internalWallet);
+            var channelOperationRequest = new ChannelOperationRequest
+            {
+                Wallet = wallet
+            };
+            var psbt =
+                "cHNidP8BAFIBAAAAAeh7YDXyZE11vXb0yRqCkrxY7VpHH1WVMHwaCWYMv/pCAQAAAAD/////AUjf9QUAAAAAFgAULTCtUNMojFQZ8oa6fpbXbDhK2EYAAAAATwEENYfPA325Ro0AAAABg9H86IDUttPPFss+9te+0DByQgbeD7RPXNuVH9mh1qIDnMEWyKA+kvyG038on8+HxI+9AD8r6ZI1dNIDSGC8824Q7QIQyDAAAIABAACAAQAAAAABAR8A4fUFAAAAABYAFOk69QEyo0x+Xs/zV62OLrHh9eszAQMEAgAAAAAA";
+
+            var combinedPsbt = LightningHelper.CombinePSBTs(new[] { psbt });
+            var lightningService = new LightningService(_logger, null, null, null, null, null, null, nbXplorerMock.Object, null);
+            var pendingChannelId = RandomNumberGenerator.GetBytes(32);
+            var derivationStrategyBase = LightningService.GetDerivationStrategyBase(channelOperationRequest);
+
+            var node = new LightningNode()
+            {
+                PubKey = "03650f49929d84d9a6d9b5a66235c603a1a0597dd609f7cd3b15052382cf9bb1b4",
+            };
+            node.Features.Add((uint)FeatureBit.UpfrontShutdownScriptOpt, new Feature() { Name = "upfront-shutdown-script", IsKnown = true, IsRequired = false });
+
+            // Act
+            var openChannelRequest = await lightningService.CreateOpenChannelRequest(channelOperationRequest, combinedPsbt, node, 1000, pendingChannelId, derivationStrategyBase);
+
+            // Assert
+            openChannelRequest.Should().Be(new OpenChannelRequest()
+            {
+                FundingShim = new FundingShim
+                {
+                    PsbtShim = new PsbtShim
+                    {
+                        BasePsbt = ByteString.FromBase64(combinedPsbt.ToBase64()),
+                        NoPublish = false,
+                        PendingChanId = ByteString.CopyFrom(pendingChannelId)
+                    }
+                },
+                LocalFundingAmount = 1000,
+                Private = false,
+                NodePubkey = ByteString.CopyFrom(Convert.FromHexString("03650f49929d84d9a6d9b5a66235c603a1a0597dd609f7cd3b15052382cf9bb1b4")),
+                CloseAddress = "bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal"
+            });
         }
     }
 }


### PR DESCRIPTION
I was unable to test this locally since doing `lncli getnodeinfo` on an eclair wallet doesn't show the features. Tested with c-lightning and it does show features, but c-lightning supports closing script.
<img width="707" alt="Screenshot 2023-07-14 at 17 56 54" src="https://github.com/Elenpay/NodeGuard/assets/39995243/77a99a56-d592-47da-b435-93db8158d453">
