### PR TITLE
Simultaneous operations in channels with same source and destination

### DIFF
--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -145,7 +145,7 @@ namespace FundsManager.Data.Repositories
 
             if (!closeRequestAddResult.Item1)
             {
-                _logger.LogError("Error while saving close request for channel with id: {RequestId}: " + closeRequestAddResult.Item2, type.Id);
+                _logger.LogError("Error while saving close request for channel with id: {RequestId}: {error}", type.Id, closeRequestAddResult.Item2);
                 return (false, closeRequestAddResult.Item2);
             }
 

--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -145,7 +145,7 @@ namespace FundsManager.Data.Repositories
 
             if (!closeRequestAddResult.Item1)
             {
-                _logger.LogError("Error while saving close request for channel with id: {RequestId}", type.Id);
+                _logger.LogError("Error while saving close request for channel with id: {RequestId}: " + closeRequestAddResult.Item2, type.Id);
                 return (false, closeRequestAddResult.Item2);
             }
 

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -28,6 +28,10 @@ public class Constants
     public static readonly bool PUSH_NOTIFICATIONS_ONESIGNAL_ENABLED;
     public static readonly bool ENABLE_HW_SUPPORT;
     public static readonly bool NBXPLORER_ENABLE_CUSTOM_BACKEND = false;
+    /// <summary>
+    /// Allow simultaneous channel opening operations using the same source and destination nodes
+    /// </summary>
+    public static bool ALLOW_SIMULTANEOUS_CHANNEL_OPENING_OPERATIONS; // Not readonly so we can change it in tests
 
     // Connections
     public static readonly string POSTGRES_CONNECTIONSTRING = "Host=localhost;Port=5432;Database=fundsmanager;Username=rw_dev;Password=rw_dev";
@@ -104,6 +108,8 @@ public class Constants
         ENABLE_HW_SUPPORT = Environment.GetEnvironmentVariable("ENABLE_HW_SUPPORT") != "false"; // We default to true
 
         NBXPLORER_ENABLE_CUSTOM_BACKEND = Environment.GetEnvironmentVariable("NBXPLORER_ENABLE_CUSTOM_BACKEND") == "true";
+
+        ALLOW_SIMULTANEOUS_CHANNEL_OPENING_OPERATIONS = Environment.GetEnvironmentVariable("ALLOW_SIMULTANEOUS_CHANNEL_OPENING_OPERATIONS") == "true";
 
         // Connections
         POSTGRES_CONNECTIONSTRING =  Environment.GetEnvironmentVariable("POSTGRES_CONNECTIONSTRING") ?? POSTGRES_CONNECTIONSTRING;
@@ -212,6 +218,7 @@ public class Constants
         MAX_SAT_PER_VB_RATIO = maxSatPerVbRatioEnv!= null ? decimal.Parse(maxSatPerVbRatioEnv) : MAX_SAT_PER_VB_RATIO;
 
     }
+
 }
 
 public class EnvironmentalVariableMissingException: ArgumentNullException

--- a/test/FundsManager.Tests/Data/Repositories/ChannelOperationRequestRepositoryTests.cs
+++ b/test/FundsManager.Tests/Data/Repositories/ChannelOperationRequestRepositoryTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using FundsManager.Data.Models;
+using FundsManager.Data.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FundsManager.Data.Repositories;
+
+public class ChannelOperationRequestRepositoryTests
+{
+    private readonly Random _random = new();
+
+    private Mock<IDbContextFactory<ApplicationDbContext>> SetupDbContextFactory()
+    {
+        var dbContextFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "ChannelOperationRequestRepositoryTests" + _random.Next())
+            .Options;
+        var context = ()=> new ApplicationDbContext(options);
+        dbContextFactory.Setup(x => x.CreateDbContext()).Returns(context);
+        dbContextFactory.Setup(x => x.CreateDbContextAsync(default)).ReturnsAsync(context);
+        return dbContextFactory;
+    }
+
+    [Fact]
+    public async Task AddAsync_ChannelCloseOperations()
+    {
+        // Arrange
+        var dbContextFactory = SetupDbContextFactory();
+        var repository = new Mock<IRepository<ChannelOperationRequest>>();
+
+        repository
+            .Setup(x => x.AddAsync(It.IsAny<ChannelOperationRequest>(), It.IsAny<ApplicationDbContext>()))
+            .ReturnsAsync((true, null));
+
+        await using var context = await dbContextFactory.Object.CreateDbContextAsync();
+
+        var request1 = new ChannelOperationRequest()
+        {
+            RequestType = OperationRequestType.Close,
+            Status = ChannelOperationRequestStatus.OnChainConfirmationPending
+        };
+        await context.ChannelOperationRequests.AddAsync(request1);
+
+        var channelOperationRequestRepository = new ChannelOperationRequestRepository(repository.Object, null, dbContextFactory.Object, null, null);
+
+        // Act
+        var result = await channelOperationRequestRepository.AddAsync(request1);
+
+        // Assert
+        result.Item1.Should().BeTrue();
+        result.Item2.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddAsync_ChannelOpenOperations_SimultaneousOpsNotAllowed()
+    {
+        // Arrange
+        Constants.ALLOW_SIMULTANEOUS_CHANNEL_OPENING_OPERATIONS = false;
+
+        var dbContextFactory = SetupDbContextFactory();
+        var repository = new Mock<IRepository<ChannelOperationRequest>>();
+
+        repository
+            .Setup(x => x.AddAsync(It.IsAny<ChannelOperationRequest>(), It.IsAny<ApplicationDbContext>()))
+            .ReturnsAsync((true, null));
+
+        var dbContextFactoryObject = dbContextFactory.Object;
+        var context = await dbContextFactoryObject.CreateDbContextAsync();
+
+        var request1 = new ChannelOperationRequest()
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNodeId = 1,
+            DestNodeId = 2,
+            Status = ChannelOperationRequestStatus.OnChainConfirmationPending
+        };
+
+        await context.ChannelOperationRequests.AddAsync(request1);
+        await context.SaveChangesAsync();
+
+        var channelOperationRequestRepository = new ChannelOperationRequestRepository(repository.Object, null, dbContextFactoryObject, null, null);
+
+        // Act
+        var result = await channelOperationRequestRepository.AddAsync(request1);
+
+        // Assert
+        result.Item1.Should().BeFalse();
+        result.Item2.Should().Be("Error, a channel operation request with the same source and destination node is in pending status, wait for that request to finalise before submitting a new request");
+    }
+
+    [Fact]
+    public async Task AddAsync_ChannelOpenOperations_SimultaneousOpsAllowed()
+    {
+        // Arrange
+        Constants.ALLOW_SIMULTANEOUS_CHANNEL_OPENING_OPERATIONS = true;
+
+        var dbContextFactory = SetupDbContextFactory();
+        var repository = new Mock<IRepository<ChannelOperationRequest>>();
+
+        repository
+            .Setup(x => x.AddAsync(It.IsAny<ChannelOperationRequest>(), It.IsAny<ApplicationDbContext>()))
+            .ReturnsAsync((true, null));
+
+        var dbContextFactoryObject = dbContextFactory.Object;
+        var context = await dbContextFactoryObject.CreateDbContextAsync();
+
+        var request1 = new ChannelOperationRequest()
+        {
+            RequestType = OperationRequestType.Open,
+            SourceNodeId = 1,
+            DestNodeId = 2,
+            Status = ChannelOperationRequestStatus.OnChainConfirmationPending
+        };
+
+        await context.ChannelOperationRequests.AddAsync(request1);
+        await context.SaveChangesAsync();
+
+        var channelOperationRequestRepository = new ChannelOperationRequestRepository(repository.Object, null, dbContextFactoryObject, null, null);
+
+        // Act
+        var result = await channelOperationRequestRepository.AddAsync(request1);
+
+        // Assert
+        result.Item1.Should().BeTrue();
+        result.Item2.Should().BeNull();
+    }
+}


### PR DESCRIPTION
- We allow simultaneous channel close operations for same source and destination nodes
- Added feature flag for when we modify LND we can allow also the opening of channels with same source and destination nodes