### PR TITLE
New intermediate step after user input

### DIFF
--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -57,7 +57,12 @@ namespace FundsManager.Data.Models
         /// <summary>
         /// The process failed in background
         /// </summary>
-        Failed = 8
+        Failed = 8,
+
+        /// <summary>
+        /// The PSBT is being funded and signed by NodeGuard
+        /// </summary>
+        FinalizingPSBT = 9
     }
 
     public enum OperationRequestType

--- a/src/Data/Models/WalletWithdrawalRequest.cs
+++ b/src/Data/Models/WalletWithdrawalRequest.cs
@@ -57,7 +57,12 @@ namespace FundsManager.Data.Models
         /// <summary>
         /// Marked when a error happens when broadcasting the TX
         /// </summary>
-        Failed = 6
+        Failed = 6,
+
+        /// <summary>
+        /// The PSBT is being signed by NodeGuard
+        /// </summary>
+        FinalizingPSBT = 7
     }
 
     /// <summary>

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -391,6 +391,13 @@ namespace FundsManager.Services
                                 break;
 
                             case OpenStatusUpdate.UpdateOneofCase.PsbtFund:
+                                channelOperationRequest.Status = ChannelOperationRequestStatus.FinalizingPSBT;
+                                var (isSuccess, error) = _channelOperationRequestRepository.Update(channelOperationRequest);
+                                if (!isSuccess)
+                                {
+                                    _logger.LogWarning("Request in funding stage, but could not update status to {Status} for request id: {RequestId} reason: {Reason}",
+                                        ChannelOperationRequestStatus.FinalizingPSBT, channelOperationRequest.Id, error);
+                                }
 
                                 //We got the funded PSBT, we need to tweak the tx outputs and mimick lnd-cli calls
                                 var hexPSBT = Convert.ToHexString((response.PsbtFund.Psbt.ToByteArray()));


### PR DESCRIPTION
This PR creates a new intermediate status that comes after `PSBTSignaturesPending`, and is updated after all user signatures are collected.
So when the process of funding/remote-signing starts, the Nodeguard will be stuck in the `FinalizingPSBT` state in case of an error.
In the case of the withdrawals, this prevents that the user might see the approve and reject buttons in the UI.