### PR TITLE
Fix migration issue with StatusLogs

### DIFF
--- a/src/Data/ApplicationDbContext.cs
+++ b/src/Data/ApplicationDbContext.cs
@@ -58,15 +58,6 @@ namespace FundsManager.Data
 
             modelBuilder.Entity<ApplicationUser>().HasIndex(x => x.NormalizedUserName).IsUnique();
 
-            modelBuilder.Entity<ChannelStatusLog>().HasNoKey();
-
-            modelBuilder.Entity<ChannelOperationRequest>()
-                .Property(e => e.StatusLogs)
-                .HasConversion(
-                    v => JsonSerializer.Serialize(v, new JsonSerializerOptions()),
-                    v => JsonSerializer.Deserialize<List<ChannelStatusLog>>(v, new JsonSerializerOptions())
-                );
-
             base.OnModelCreating(modelBuilder);
         }
 

--- a/src/Data/ApplicationDbContext.cs
+++ b/src/Data/ApplicationDbContext.cs
@@ -16,6 +16,7 @@
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
+using System.Reflection;
 using System.Text.Json;
 using FundsManager.Data.Models;
 using FundsManager.Helpers;
@@ -57,6 +58,20 @@ namespace FundsManager.Data
             modelBuilder.Entity<LiquidityRule>().HasIndex(x => x.ChannelId).IsUnique();
 
             modelBuilder.Entity<ApplicationUser>().HasIndex(x => x.NormalizedUserName).IsUnique();
+
+            // We allow the value converter for tests because the in-memory database doesn't support JSON columns
+            var command = Assembly.GetEntryAssembly()?.GetName().Name?.ToLowerInvariant();
+            if (command != null && command.Contains("test"))
+            {
+                modelBuilder.Entity<ChannelStatusLog>().HasNoKey();
+
+                modelBuilder.Entity<ChannelOperationRequest>()
+                    .Property(e => e.StatusLogs)
+                    .HasConversion(
+                        v => JsonSerializer.Serialize(v, new JsonSerializerOptions()),
+                        v => JsonSerializer.Deserialize<List<ChannelStatusLog>>(v, new JsonSerializerOptions())
+                    );
+            }
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/Migrations/20230725153505_NullableStatusLogs.Designer.cs
+++ b/src/Migrations/20230725153505_NullableStatusLogs.Designer.cs
@@ -5,6 +5,7 @@ using FundsManager.Data;
 using FundsManager.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FundsManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230725153505_NullableStatusLogs")]
+    partial class NullableStatusLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20230725153505_NullableStatusLogs.cs
+++ b/src/Migrations/20230725153505_NullableStatusLogs.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using FundsManager.Helpers;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FundsManager.Migrations
+{
+    public partial class NullableStatusLogs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<List<ChannelStatusLog>>(
+                name: "StatusLogs",
+                table: "ChannelOperationRequests",
+                type: "jsonb",
+                nullable: true,
+                oldClrType: typeof(List<ChannelStatusLog>),
+                oldType: "jsonb");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<List<ChannelStatusLog>>(
+                name: "StatusLogs",
+                table: "ChannelOperationRequests",
+                type: "jsonb",
+                nullable: false,
+                oldClrType: typeof(List<ChannelStatusLog>),
+                oldType: "jsonb",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
I did a "migration add" and suddenly the migrator was creating a new table for StatusLogs, which shouldn't be a table. This is probably because I added it after creating the migration, and didn't drop de database after to check.
This fix gets the migrations to normal again. The code removed was the one causing the issue.
Strangely enough, removing the converter had no effect on dotnet converting to and back from `List<StatusLogs>`