### PR TITLE
Fee rate info missing

### DIFF
--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -20,7 +20,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using FundsManager.Helpers;
 using NBitcoin;
-using System.Text.Json;
+using FundsManager.Services;
 
 namespace FundsManager.Data.Models
 {
@@ -106,6 +106,14 @@ namespace FundsManager.Data.Models
         /// </summary>
         public string? ClosingReason { get; set; }
 
+        /// <summary>
+        /// Recommended fee type selected by the user to be applied at the moment of the operation
+        /// </summary>
+        public MempoolRecommendedFeesTypes MempoolRecommendedFeesTypes { get; set; }
+
+        /// <summary>
+        /// Fee rate in sat/vbyte to be applied if the user selects a custom fee type
+        /// </summary>
         public decimal? FeeRate { get; set; }
 
         [Column(TypeName = "jsonb")]

--- a/src/Migrations/20230726125844_MempoolRecommendedFeesType.Designer.cs
+++ b/src/Migrations/20230726125844_MempoolRecommendedFeesType.Designer.cs
@@ -5,6 +5,7 @@ using FundsManager.Data;
 using FundsManager.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FundsManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230726125844_MempoolRecommendedFeesType")]
+    partial class MempoolRecommendedFeesType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20230726125844_MempoolRecommendedFeesType.cs
+++ b/src/Migrations/20230726125844_MempoolRecommendedFeesType.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FundsManager.Migrations
+{
+    public partial class MempoolRecommendedFeesType : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MempoolRecommendedFeesTypes",
+                table: "ChannelOperationRequests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MempoolRecommendedFeesTypes",
+                table: "ChannelOperationRequests");
+        }
+    }
+}

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -152,6 +152,9 @@
                 </EditTemplate>
             </DataGridColumn>
             <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.FeeRates)" Editable="true" Caption="Fee Rate" PopupFieldColumnSize="ColumnSize.Is12">
+                <DisplayTemplate>
+                    @(context.MempoolRecommendedFeesTypes == MempoolRecommendedFeesTypes.CustomFee ? $"{context.FeeRate} sats/vbyte" : FeesSelection.ToString().Humanize())
+                </DisplayTemplate>
                 <EditTemplate>
                     <div class="d-flex">
                         <Select TValue="MempoolRecommendedFeesTypes" SelectedValueChanged="async (value) => await OnChangeFeeSelection(value)">
@@ -169,6 +172,7 @@
                             </Feedback>
                         </NumericPicker>
                     </div>
+                    <FieldHelp>@(FeesSelection != MempoolRecommendedFeesTypes.CustomFee ? "Fees may change by the time the request is processed" : "")</FieldHelp>
                 </EditTemplate>
             </DataGridColumn>
             <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.Private)" Editable="true">
@@ -267,12 +271,7 @@
         </DataGridColumn>
         <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.FeeRate)" Caption="Fee Rate" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.FeeRates)">
             <DisplayTemplate>
-                @{
-                    if (context.FeeRate != null)
-                    {
-                        @($"{context.FeeRate} sats/vbyte")
-                    }
-                }
+                @(context.FeeRate != null ? $"{context.FeeRate} sats/vbyte" : FeesSelection.ToString().Humanize())
             </DisplayTemplate>
         </DataGridColumn>
         <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.IsChannelPrivate)" Caption="Private" Displayable="@IsAllRequestsColumnVisible(AllChannelsColumnName.Private)"></DataGridColumn>
@@ -414,7 +413,6 @@
     private List<UTXO> SelectedUTXOs = new();
     private MempoolRecommendedFeesTypes FeesSelection;
     private long FeeAmount = 1;
-    private MempoolRecommendedFees? _recommendedFees;
 
     // New Request integration
     private List<Wallet> _allWallets = new List<Wallet>();
@@ -515,7 +513,6 @@
 
     private async Task OnShowNewChannelRequestModal()
     {
-        _recommendedFees = await NBXplorerService.GetMempoolRecommendedFeesAsync();
         _utxoSelectorModalRef.ClearModal();
         FeesSelection = 0;
         await OnChangeFeeSelection(FeesSelection);
@@ -645,7 +642,8 @@
                     DestNodeId = _selectedDestNode?.Id,
                     IsChannelPrivate = _selectedPrivate,
                     Changeless = SelectedUTXOs.Count > 0,
-                    FeeRate = FeeAmount
+                    MempoolRecommendedFeesTypes = FeesSelection,
+                    FeeRate = FeesSelection == MempoolRecommendedFeesTypes.CustomFee ?  FeeAmount : null
                 };
 
                 var selectedWallet = await WalletRepository.GetById(_selectedWalletId.Value);
@@ -984,27 +982,8 @@
 
     private async Task OnChangeFeeSelection(MempoolRecommendedFeesTypes value)
     {
-        _recommendedFees = await NBXplorerService.GetMempoolRecommendedFeesAsync();
         FeesSelection = value;
-
-        switch (FeesSelection)
-        {
-            case MempoolRecommendedFeesTypes.EconomyFee:
-                FeeAmount = _recommendedFees.EconomyFee;
-                break;
-            case MempoolRecommendedFeesTypes.FastestFee:
-                FeeAmount = _recommendedFees.FastestFee;
-                break;
-            case MempoolRecommendedFeesTypes.HourFee:
-                FeeAmount = _recommendedFees.HourFee;
-                break;
-            case MempoolRecommendedFeesTypes.HalfHourFee:
-                FeeAmount = _recommendedFees.HalfHourFee;
-                break;
-            case MempoolRecommendedFeesTypes.CustomFee:
-                FeeAmount = 1;
-                break;
-        }
+        FeeAmount = await NBXplorerService.GetFeesByType(FeesSelection) ?? 1;
     }
 
     private void OnColumnLayoutUpdate()

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -153,7 +153,7 @@
             </DataGridColumn>
             <DataGridColumn TItem="ChannelOperationRequest" Displayable="@IsPendingRequestsColumnVisible(PendingChannelsColumnName.FeeRates)" Editable="true" Caption="Fee Rate" PopupFieldColumnSize="ColumnSize.Is12">
                 <DisplayTemplate>
-                    @(context.MempoolRecommendedFeesTypes == MempoolRecommendedFeesTypes.CustomFee ? $"{context.FeeRate} sats/vbyte" : FeesSelection.ToString().Humanize())
+                    @(context.MempoolRecommendedFeesTypes == MempoolRecommendedFeesTypes.CustomFee ? $"{context.FeeRate} sats/vb" : FeesSelection.ToString().Humanize())
                 </DisplayTemplate>
                 <EditTemplate>
                     <div class="d-flex">
@@ -983,7 +983,7 @@
     private async Task OnChangeFeeSelection(MempoolRecommendedFeesTypes value)
     {
         FeesSelection = value;
-        FeeAmount = await NBXplorerService.GetFeesByType(FeesSelection) ?? 1;
+        FeeAmount = (long?)await NBXplorerService.GetFeesByType(FeesSelection) ?? 1;
     }
 
     private void OnColumnLayoutUpdate()

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -226,10 +226,10 @@ namespace FundsManager.Services
                     throw new InvalidOperationException();
                 }
 
-                var initialFeeRate = channelOperationRequest.FeeRate ??
+                var feeRate = await _nbXplorerService.GetFeesByType(channelOperationRequest.MempoolRecommendedFeesTypes) ?? channelOperationRequest.FeeRate;;
+                var initialFeeRate = feeRate ??
                                      (await LightningHelper.GetFeeRateResult(network, _nbXplorerService)).FeeRate
                                      .SatoshiPerByte;
-                ;
 
                 var fundingAmount = GetFundingAmount(channelOperationRequest, combinedPSBT, initialFeeRate);
 
@@ -406,6 +406,7 @@ namespace FundsManager.Services
 
                             case OpenStatusUpdate.UpdateOneofCase.PsbtFund:
                                 channelOperationRequest.Status = ChannelOperationRequestStatus.FinalizingPSBT;
+                                channelOperationRequest.FeeRate = feeRate;
                                 var (isSuccess, error) =
                                     _channelOperationRequestRepository.Update(channelOperationRequest);
                                 if (!isSuccess)
@@ -1093,7 +1094,8 @@ namespace FundsManager.Services
                 var network = CurrentNetworkHelper.GetCurrentNetwork();
                 var txBuilder = network.CreateTransactionBuilder();
 
-                var feeRateResult = channelOperationRequest.FeeRate ??
+                var feeRate = await _nbXplorerService.GetFeesByType(channelOperationRequest.MempoolRecommendedFeesTypes) ?? channelOperationRequest.FeeRate;
+                var feeRateResult = feeRate ??
                                     (await LightningHelper.GetFeeRateResult(network, _nbXplorerService)).FeeRate
                                     .SatoshiPerByte;
 

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -32,8 +32,7 @@ public interface INBXplorerService
     public Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, FeeRate fallbackFeeRate,
         CancellationToken cancellation = default);
 
-    public Task<MempoolRecommendedFees> GetMempoolRecommendedFeesAsync(CancellationToken cancellation = default);
-
+    public Task<int?> GetFeesByType(MempoolRecommendedFeesTypes mempoolRecommendedFeesTypes, CancellationToken cancellation = default);
 
     public Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept,
         CancellationToken cancellation = default);
@@ -218,7 +217,7 @@ public class NBXplorerService : INBXplorerService
         return await nbExplorerClient.GetFeeRateAsync(blockCount, fallbackFeeRate, cancellation);
     }
 
-    public async Task<MempoolRecommendedFees> GetMempoolRecommendedFeesAsync(
+    private async Task<MempoolRecommendedFees> GetMempoolRecommendedFeesAsync(
         CancellationToken cancellation = default)
     {
         var mempoolEndpoint = Constants.MEMPOOL_ENDPOINT;
@@ -241,6 +240,29 @@ public class NBXplorerService : INBXplorerService
         }
 
         return new MempoolRecommendedFees();
+    }
+
+    public async Task<int?> GetFeesByType(
+        MempoolRecommendedFeesTypes mempoolRecommendedFeesTypes,
+        CancellationToken cancellation = default)
+    {
+        var recommendedFees = await GetMempoolRecommendedFeesAsync(cancellation);
+
+        switch (mempoolRecommendedFeesTypes)
+        {
+            case MempoolRecommendedFeesTypes.EconomyFee:
+                return recommendedFees.EconomyFee;
+            case MempoolRecommendedFeesTypes.FastestFee:
+                return recommendedFees.FastestFee;
+            case MempoolRecommendedFeesTypes.HourFee:
+                return recommendedFees.HourFee;
+            case MempoolRecommendedFeesTypes.HalfHourFee:
+                return recommendedFees.HalfHourFee;
+            case MempoolRecommendedFeesTypes.CustomFee:
+                return null;
+        }
+
+        throw new Exception("Invalid mempoolRecommendedFeesTypes");
     }
 
     public async Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept,

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -32,7 +32,7 @@ public interface INBXplorerService
     public Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, FeeRate fallbackFeeRate,
         CancellationToken cancellation = default);
 
-    public Task<int?> GetFeesByType(MempoolRecommendedFeesTypes mempoolRecommendedFeesTypes, CancellationToken cancellation = default);
+    public Task<decimal?> GetFeesByType(MempoolRecommendedFeesTypes mempoolRecommendedFeesTypes, CancellationToken cancellation = default);
 
     public Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept,
         CancellationToken cancellation = default);
@@ -61,11 +61,11 @@ public enum MempoolRecommendedFeesTypes
 /// </summary>
 public class MempoolRecommendedFees
 {
-    public int FastestFee { get; set; }
-    public int HalfHourFee { get; set; }
-    public int HourFee { get; set; }
-    public int EconomyFee { get; set; }
-    public int MinimumFee { get; set; }
+    public decimal FastestFee { get; set; }
+    public decimal HalfHourFee { get; set; }
+    public decimal HourFee { get; set; }
+    public decimal EconomyFee { get; set; }
+    public decimal MinimumFee { get; set; }
 }
 
 [JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
@@ -242,7 +242,7 @@ public class NBXplorerService : INBXplorerService
         return new MempoolRecommendedFees();
     }
 
-    public async Task<int?> GetFeesByType(
+    public async Task<decimal?> GetFeesByType(
         MempoolRecommendedFeesTypes mempoolRecommendedFeesTypes,
         CancellationToken cancellation = default)
     {


### PR DESCRIPTION
This PR solves the problem with the missing fee rate in the requests table, and the issue with the fee being selected at the moment of the creation of the request instead of at the moment of the processing of the request.

We show the user "Economy Fee" or other option they selected, then we show the real fee used in the table when the request is processed