### PR TITLE
Hotfix: downgrade restsharp

### DIFF
--- a/src/Helpers/PriceConversionHelper.cs
+++ b/src/Helpers/PriceConversionHelper.cs
@@ -31,7 +31,7 @@ public static class PriceConversionHelper
         var client = new RestClient(Constants.COINGECKO_ENDPOINT);
         var request = new RestRequest
         {
-            Method = Method.Get
+            Method = Method.GET
         };
         request.AddHeader("x-cg-pro-api-key", Constants.COINGECKO_KEY);
         var response = client.Execute(request);

--- a/src/NodeGuard.csproj
+++ b/src/NodeGuard.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Quartz.AspNetCore" Version="3.6.3" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.6.3" />
     <PackageReference Include="Blazorise.SpinKit" Version="1.2.4" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="106.13.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Unmockable" Version="3.0.132" />
     <PackageReference Include="Unmockable.Wrap" Version="3.0.132" />


### PR DESCRIPTION
Until https://github.com/OneSignal/onesignal-dotnet-api/pull/36 is solved, let's downgrade:


fix(PriceConversionHelper.cs): change Method.Get to Method.GET for co…nsistency with other code

fix(NodeGuard.csproj): downgrade RestSharp version from 110.2.0 to 106.13.0 due to compatibility issues with other packages