### PR TITLE
Revive inactive channels

### DIFF
--- a/src/Data/Repositories/NodeRepository.cs
+++ b/src/Data/Repositories/NodeRepository.cs
@@ -82,7 +82,7 @@ namespace NodeGuard.Data.Repositories
 
                 node = new Node()
                 {
-                    Name = foundNode?.Alias ?? "Unavailable Node",
+                    Name = foundNode?.Alias ?? "",
                     PubKey = pubKey
                 };
                 var addNode = await AddAsync(node);

--- a/src/Data/Repositories/NodeRepository.cs
+++ b/src/Data/Repositories/NodeRepository.cs
@@ -77,13 +77,13 @@ namespace NodeGuard.Data.Repositories
                 var foundNode = await lightningService.GetNodeInfo(pubKey);
                 if (foundNode == null)
                 {
-                    throw new Exception("Node info not found");
+                    _logger.LogWarning("Peer with PubKey {pubKey} not found", pubKey);
                 }
 
                 node = new Node()
                 {
-                    Name = foundNode.Alias,
-                    PubKey = foundNode.PubKey,
+                    Name = foundNode?.Alias ?? "Unavailable Node",
+                    PubKey = pubKey
                 };
                 var addNode = await AddAsync(node);
                 if (!addNode.Item1)

--- a/src/Jobs/ChannelMonitorJob.cs
+++ b/src/Jobs/ChannelMonitorJob.cs
@@ -76,7 +76,6 @@ public class ChannelMonitorJob : IJob
 
             foreach (var channel in result?.Channels)
             {
-                if (!channel.Active) continue;
                 var node2 = await _nodeRepository.GetOrCreateByPubKey(channel.RemotePubkey, _lightningService);
 
                 // Recover Operations on channels
@@ -94,7 +93,7 @@ public class ChannelMonitorJob : IJob
         _logger.LogInformation("{JobName} ended", nameof(ChannelMonitorJob));
     }
 
-    public async Task RecoverGhostChannels(Node source, Node destination, Channel? channel)
+    public async Task RecoverGhostChannels(Node source, Node destination, Channel channel)
     {
         if (!channel.Initiator && destination.IsManaged) return;
         try

--- a/test/NodeGuard.Tests/Data/Repositories/NodeRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/NodeRepositoryTests.cs
@@ -31,8 +31,9 @@ public class NodeRepositoryTests
         var lightningServiceMock = new Mock<ILightningService>();
         var repositoryMock = new Mock<IRepository<Node>>();
 
+        var node = new LightningNode() { Alias = "TestAlias", PubKey = "TestPubKey" };
         lightningServiceMock.Setup(service => service.GetNodeInfo(It.IsAny<string>()))
-            .ReturnsAsync(new LightningNode() { Alias = "TestAlias", PubKey = "TestPubKey" });
+            .ReturnsAsync(node);
 
         repositoryMock.Setup(repository => repository.AddAsync(It.IsAny<Node>(), It.IsAny<ApplicationDbContext>()))
             .ReturnsAsync((true, null));
@@ -40,7 +41,7 @@ public class NodeRepositoryTests
         var nodeRepository = new NodeRepository(repositoryMock.Object, null, dbContextFactory.Object, null);
 
         // Act
-        var result = await nodeRepository.GetOrCreateByPubKey("abc", lightningServiceMock.Object);
+        var result = await nodeRepository.GetOrCreateByPubKey(node.PubKey, lightningServiceMock.Object);
 
         // Assert
         result.Name.Should().Be("TestAlias");


### PR DESCRIPTION
- We create the node and revive the channel anyways in the case that it's not active. But as we cannot know the alias, we just name it "Unavailable Node"