### PR TITLE
Node Alias update

### DIFF
--- a/src/Jobs/ChannelMonitorJob.cs
+++ b/src/Jobs/ChannelMonitorJob.cs
@@ -121,6 +121,9 @@ public class ChannelMonitorJob : IJob
             _logger.LogWarning("The external node {NodeId} was set up for monitoring but the remote node {RemoteNodeId} doesn't exist anymore", managedNode.Id, remoteNode.PubKey);
             return;
         }
+
+        if (remoteNode.Name == nodeInfo.Alias) return;
+
         remoteNode.Name = nodeInfo.Alias;
         var (updated, error) = _nodeRepository.Update(remoteNode);
         if (!updated)

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -1297,6 +1297,13 @@ namespace NodeGuard.Services
             foreach (var node in nodes)
             {
                 var listChannelsResponse = await _lightningClientService.ListChannels(node);
+
+                if (listChannelsResponse == null)
+                {
+                    _logger.LogError("Error while getting channels for node: {NodeId}", node.Id);
+                    continue;
+                }
+
                 var channels = listChannelsResponse.Channels.ToList();
 
                 foreach (var channel in channels)


### PR DESCRIPTION
- Check if alias of node changed (this should have it's own "node monitor job", but as this is the only thing we do, I added it to the channel monitor
- prevent doing the same db calls a lot of times in channel monitor job
- prevent throw if 1 node was not found