### PR TITLE
Added nodeguard api endpoints for automatic settlements

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.4'
 
 services:
   nodeguard_postgres:
+    hostname: postgres
     container_name: nodeguard_postgres
     image: postgres:13
     restart: always
@@ -28,7 +29,8 @@ services:
       NBXPLORER_TRIMEVENTS: 10000
       NBXPLORER_SIGNALFILESDIR: /datadir
       #Keeping dbtrie for dev until it is fully removed since we would need to modify nbxplorer docker image to wait for the db to be ready
-      NBXPLORER_DBTRIE: 1
+      NBXPLORER_DBTRIE: 0
+      NBXPLORER_POSTGRES: Host=postgres;Port=5432;Database=nodeguard;Username=rw_dev;Password=rw_dev
       NBXPLORER_CHAINS: "btc"
       NBXPLORER_BTCRPCUSER: "polaruser"
       NBXPLORER_BTCRPCPASSWORD: "polarpass"

--- a/src/Data/Models/WalletWithdrawalRequest.cs
+++ b/src/Data/Models/WalletWithdrawalRequest.cs
@@ -115,6 +115,11 @@ namespace NodeGuard.Data.Models
         public string? JobId { get; set; }
 
         /// <summary>
+        /// This indicates if the user requested a changeless operation by selecting UTXOs
+        /// </summary>
+        public bool Changeless { get; set; }
+
+        /// <summary>
         /// TxId of the request
         /// </summary>
         public string? TxId { get; set; }

--- a/src/Data/Repositories/FUTXORepository.cs
+++ b/src/Data/Repositories/FUTXORepository.cs
@@ -99,6 +99,8 @@ namespace NodeGuard.Data.Repositories
                 walletWithdrawalRequestsLockedUTXOs = await applicationDbContext.WalletWithdrawalRequests
                     .Include(x => x.UTXOs)
                     .Where(x => x.Status == WalletWithdrawalRequestStatus.Pending ||
+                                x.Status == WalletWithdrawalRequestStatus.PSBTSignaturesPending ||
+                                x.Status == WalletWithdrawalRequestStatus.FinalizingPSBT ||
                                 x.Status == WalletWithdrawalRequestStatus.OnChainConfirmationPending)
                     .SelectMany(x => x.UTXOs).ToListAsync();
             }
@@ -108,6 +110,8 @@ namespace NodeGuard.Data.Repositories
                     .Include(x => x.UTXOs)
                     .Where(x => x.Id != ignoredWalletWithdrawalRequestId
                                 && x.Status == WalletWithdrawalRequestStatus.Pending ||
+                                x.Status == WalletWithdrawalRequestStatus.PSBTSignaturesPending ||
+                                x.Status == WalletWithdrawalRequestStatus.FinalizingPSBT ||
                                 x.Status == WalletWithdrawalRequestStatus.OnChainConfirmationPending)
                     .SelectMany(x => x.UTXOs).ToListAsync();
             }
@@ -118,6 +122,8 @@ namespace NodeGuard.Data.Repositories
             {
                 channelOperationRequestsLockedUTXOs = await applicationDbContext.ChannelOperationRequests.Include(x => x.Utxos)
                     .Where(x => x.Status == ChannelOperationRequestStatus.Pending ||
+                                x.Status == ChannelOperationRequestStatus.PSBTSignaturesPending ||
+                                x.Status == ChannelOperationRequestStatus.FinalizingPSBT ||
                                 x.Status == ChannelOperationRequestStatus.OnChainConfirmationPending)
                     .SelectMany(x => x.Utxos).ToListAsync();
             }
@@ -126,6 +132,8 @@ namespace NodeGuard.Data.Repositories
                 channelOperationRequestsLockedUTXOs = await applicationDbContext.ChannelOperationRequests.Include(x => x.Utxos)
                     .Where(x => x.Id != ignoredChannelOperationRequestId
                         && x.Status == ChannelOperationRequestStatus.Pending ||
+                                x.Status == ChannelOperationRequestStatus.PSBTSignaturesPending ||
+                                x.Status == ChannelOperationRequestStatus.FinalizingPSBT ||
                                 x.Status == ChannelOperationRequestStatus.OnChainConfirmationPending)
                     .SelectMany(x => x.Utxos).ToListAsync();
             }

--- a/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestRepository.cs
@@ -25,6 +25,8 @@ public interface IWalletWithdrawalRequestRepository: IBitcoinRequestRepository
 {
     Task<WalletWithdrawalRequest?> GetById(int id);
 
+    Task<List<WalletWithdrawalRequest>> GetByIds(List<int> ids);
+
     Task<List<WalletWithdrawalRequest>> GetAll();
 
     Task<List<WalletWithdrawalRequest>> GetUnsignedPendingRequestsByUser(string userId);

--- a/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
@@ -69,6 +69,13 @@ namespace NodeGuard.Data.Repositories
             return request;
         }
 
+        public async Task<List<WalletWithdrawalRequest>> GetByIds(List<int> ids)
+        {
+            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            return await applicationDbContext.WalletWithdrawalRequests.Where(wr => ids.Contains(wr.Id)).ToListAsync();
+        }
+
         public async Task<List<WalletWithdrawalRequest>> GetAll()
         {
             await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();

--- a/src/Migrations/20230905151204_ChangelessWithdrawalRequest.Designer.cs
+++ b/src/Migrations/20230905151204_ChangelessWithdrawalRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230905151204_ChangelessWithdrawalRequest")]
+    partial class ChangelessWithdrawalRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20230905151204_ChangelessWithdrawalRequest.cs
+++ b/src/Migrations/20230905151204_ChangelessWithdrawalRequest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangelessWithdrawalRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Changeless",
+                table: "WalletWithdrawalRequests",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Changeless",
+                table: "WalletWithdrawalRequests");
+        }
+    }
+}

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -19,7 +19,7 @@
         "BITCOIN_NETWORK": "REGTEST",
         "MAXIMUM_WITHDRAWAL_BTC_AMOUNT": "21000000",
         "NBXPLORER_ENABLE_CUSTOM_BACKEND": "true",
-        "NBXPLORER_URI": "http://127.0.0.1:32838",
+        "NBXPLORER_URI": "http://localhost:32838",
         "NBXPLORER_BTCRPCUSER": "polaruser",
         "NBXPLORER_BTCRPCPASSWORD": "polarpass",
         "NBXPLORER_BTCRPCURL": "http://127.0.0.1:18443/",

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -19,7 +19,7 @@
         "BITCOIN_NETWORK": "REGTEST",
         "MAXIMUM_WITHDRAWAL_BTC_AMOUNT": "21000000",
         "NBXPLORER_ENABLE_CUSTOM_BACKEND": "true",
-        "NBXPLORER_URI": "http://localhost:32838",
+        "NBXPLORER_URI": "http://127.0.0.1:32838",
         "NBXPLORER_BTCRPCUSER": "polaruser",
         "NBXPLORER_BTCRPCPASSWORD": "polarpass",
         "NBXPLORER_BTCRPCURL": "http://127.0.0.1:18443/",

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -53,6 +53,11 @@ service NodeGuardService {
   Adds a liquidity rule to a channel
    */
   rpc AddLiquidityRule(AddLiquidityRuleRequest) returns (AddLiquidityRuleResponse);
+
+  /*
+  Gets a list of available UTXOs for a wallet
+   */
+  rpc GetAvailableUtxos(GetAvailableUtxosRequest) returns (GetAvailableUtxosResponse);
 }
 
 message GetLiquidityRulesRequest {
@@ -88,6 +93,10 @@ message RequestWithdrawalRequest {
   string description = 4;
   // in JSON format
   string request_metadata = 5;
+  // Whether the withdrawal should be performed in a changeless way
+  bool changeless = 6;
+  // Outpoints for the UTXOs to use for the withdrawal
+  repeated string utxos_outpoints = 7;
 }
 
 message RequestWithdrawalResponse {
@@ -245,7 +254,7 @@ message GetChannelOperationRequestResponse {
 }
 
 message AddLiquidityRuleRequest {
-// Channel ID from NGs database
+  // Channel ID from NGs database
   int32 channel_id = 1;
   // Wallet ID as stored in the NG's database
   int32 wallet_id = 2;
@@ -261,3 +270,35 @@ message AddLiquidityRuleResponse {
   // Rule ID as stored in the NG's database
   int32 rule_id = 1;
 }
+
+enum COIN_SELECTION_STRATEGY
+{
+    SMALLEST_FIRST = 0;
+    BIGGEST_FIRST = 1;
+    CLOSEST_TO_TARGET_FIRST = 2;
+    UP_TO_AMOUNT = 3;
+}
+
+message GetAvailableUtxosRequest {
+  // Wallet ID as stored in the NG's database
+  int32 wallet_id = 1;
+  // How to order the UTXOs for automatic selection
+  optional COIN_SELECTION_STRATEGY strategy = 2;
+  // How many UTXOs are allowed to be used for the withdrawal
+  optional int32 limit = 3;
+  // Amount in satoshis
+  optional int64 amount = 4;
+  // Order the UTXOs by closest to the amount specified if the strategy selected is CLOSEST_TO_TARGET_FIRST
+  optional int64 closestTo = 5;
+}
+
+message Utxo {
+  int64 amount = 1;
+  string outpoint = 2;
+}
+
+message GetAvailableUtxosResponse {
+  repeated Utxo confirmed = 1;
+  repeated Utxo unconfirmed = 2;
+}
+

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -58,6 +58,11 @@ service NodeGuardService {
   Gets a list of available UTXOs for a wallet
    */
   rpc GetAvailableUtxos(GetAvailableUtxosRequest) returns (GetAvailableUtxosResponse);
+
+  /*
+  Gets the status for the provided withdrawals request ids
+   */
+  rpc GetWithdrawalsRequestStatus(GetWithdrawalsRequestStatusRequest) returns (GetWithdrawalsRequestStatusResponse);
 }
 
 message GetLiquidityRulesRequest {
@@ -103,6 +108,7 @@ message RequestWithdrawalResponse {
   //  optionalTransaction ID of the withdrawal
   string txid = 1;
   bool is_hot_wallet = 2;
+  int32 request_id = 3;
 }
 
 enum WALLET_TYPE {
@@ -302,3 +308,25 @@ message GetAvailableUtxosResponse {
   repeated Utxo unconfirmed = 2;
 }
 
+enum WITHDRAWAL_REQUEST_STATUS {
+    WITHDRAWAL_SETTLED = 0;
+    WITHDRAWAL_PENDING_APPROVAL = 1;
+    WITHDRAWAL_CANCELLED = 2;
+    WITHDRAWAL_REJECTED = 3;
+    WITHDRAWAL_PENDING_CONFIRMATION = 4;
+    WITHDRAWAL_FAILED = 5;
+}
+
+message GetWithdrawalsRequestStatusRequest {
+  repeated int32 request_ids = 1;
+}
+
+message WithdrawalRequest {
+  int32 request_id = 1;
+  WITHDRAWAL_REQUEST_STATUS status = 2;
+  optional string reject_or_cancel_reason = 3;
+}
+
+message GetWithdrawalsRequestStatusResponse {
+  repeated WithdrawalRequest withdrawal_requests = 1;
+}

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -434,26 +434,15 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
             }
 
             // Get the fee type of the request
-            MempoolRecommendedFeesTypes feeType;
-
-            switch (request.MempoolFeeRate)
+            var feeType = request.MempoolFeeRate switch
             {
-                case FEES_TYPE.EconomyFee:
-                    feeType = MempoolRecommendedFeesTypes.EconomyFee;
-                    break;
-                case FEES_TYPE.FastestFee:
-                    feeType = MempoolRecommendedFeesTypes.FastestFee;
-                    break;
-                case FEES_TYPE.HourFee:
-                    feeType = MempoolRecommendedFeesTypes.HourFee;
-                    break;
-                case FEES_TYPE.HalfHourFee:
-                    feeType = MempoolRecommendedFeesTypes.HalfHourFee;
-                    break;
-                default:
-                    feeType = MempoolRecommendedFeesTypes.CustomFee;
-                    break;
-            }
+                FEES_TYPE.EconomyFee => MempoolRecommendedFeesTypes.EconomyFee,
+                FEES_TYPE.FastestFee => MempoolRecommendedFeesTypes.FastestFee,
+                FEES_TYPE.HourFee => MempoolRecommendedFeesTypes.HourFee,
+                FEES_TYPE.HalfHourFee => MempoolRecommendedFeesTypes.HalfHourFee,
+                FEES_TYPE.CustomFee => MempoolRecommendedFeesTypes.CustomFee,
+                _ => throw new ArgumentOutOfRangeException(nameof(request.MempoolFeeRate), request.MempoolFeeRate, "Unknown status")
+            };
 
             if (feeType == MempoolRecommendedFeesTypes.CustomFee && !request.HasCustomFeeRate)
             {
@@ -795,25 +784,14 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
             throw new Exception("Wallet not found");
         }
 
-        CoinSelectionStrategy coinSelectionStrategy;
-        switch (request.Strategy)
+        var coinSelectionStrategy = request.Strategy switch
         {
-            case COIN_SELECTION_STRATEGY.BiggestFirst:
-                coinSelectionStrategy = CoinSelectionStrategy.BiggestFirst;
-                break;
-            case COIN_SELECTION_STRATEGY.SmallestFirst:
-                coinSelectionStrategy = CoinSelectionStrategy.SmallestFirst;
-                break;
-            case COIN_SELECTION_STRATEGY.ClosestToTargetFirst:
-                coinSelectionStrategy = CoinSelectionStrategy.ClosestToTargetFirst;
-                break;
-            case COIN_SELECTION_STRATEGY.UpToAmount:
-                coinSelectionStrategy = CoinSelectionStrategy.UpToAmount;
-                break;
-            default:
-                coinSelectionStrategy = CoinSelectionStrategy.SmallestFirst;
-                break;
-        }
+            COIN_SELECTION_STRATEGY.BiggestFirst => CoinSelectionStrategy.BiggestFirst,
+            COIN_SELECTION_STRATEGY.SmallestFirst => CoinSelectionStrategy.SmallestFirst,
+            COIN_SELECTION_STRATEGY.ClosestToTargetFirst => CoinSelectionStrategy.ClosestToTargetFirst,
+            COIN_SELECTION_STRATEGY.UpToAmount => CoinSelectionStrategy.UpToAmount,
+            _ => throw new ArgumentOutOfRangeException(nameof(request.Strategy), request.Strategy, "Unknown status")
+        };
 
         var derivationStrategy = wallet.GetDerivationStrategy();
         if (derivationStrategy == null)

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -73,7 +73,8 @@ public enum CoinSelectionStrategy
 {
     SmallestFirst,
     BiggestFirst,
-    ClosestToTargetFirst
+    ClosestToTargetFirst,
+    UpToAmount
 }
 
 /// <summary>

--- a/src/Shared/UTXOSelectorModal.razor
+++ b/src/Shared/UTXOSelectorModal.razor
@@ -24,6 +24,7 @@
                                         <SelectItem Value="CoinSelectionStrategy.SmallestFirst">@CoinSelectionStrategy.SmallestFirst.Humanize()</SelectItem>
                                         <SelectItem Value="CoinSelectionStrategy.BiggestFirst">@CoinSelectionStrategy.BiggestFirst.Humanize()</SelectItem>
                                         <SelectItem Value="CoinSelectionStrategy.ClosestToTargetFirst">@CoinSelectionStrategy.ClosestToTargetFirst.Humanize()</SelectItem>
+                                        <SelectItem Value="CoinSelectionStrategy.UpToAmount">@CoinSelectionStrategy.UpToAmount.Humanize()</SelectItem>
                                     </ChildContent>
                                     <Feedback>
                                         <ValidationError/>

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -77,7 +77,7 @@ namespace NodeGuard.Rpc
                 new Mock<IBitcoinService>().Object, new Mock<INBXplorerService>().Object,
                 schedulerFactoryMock,
                 nodeRepositoryMock.Object,
-                channelOperationRequestRepositoryMock.Object, null, null, null);
+                channelOperationRequestRepositoryMock.Object, null, null, null, null);
 
             var request = new OpenChannelRequest
             {
@@ -118,7 +118,7 @@ namespace NodeGuard.Rpc
                 new Mock<IBitcoinService>().Object, new Mock<INBXplorerService>().Object,
                 schedulerFactoryMock,
                 nodeRepositoryMock.Object,
-                channelOperationRequestRepositoryMock.Object, null, null, null);
+                channelOperationRequestRepositoryMock.Object, null, null, null, null);
 
             var request = new OpenChannelRequest
             {
@@ -174,7 +174,7 @@ namespace NodeGuard.Rpc
                 schedulerFactoryMock,
                 nodeRepositoryMock.Object,
                 channelOperationRequestRepositoryMock.Object, null,
-                coinSelectionServiceMock.Object, lightningServiceMock.Object);
+                coinSelectionServiceMock.Object, lightningServiceMock.Object, null);
 
             var request = new OpenChannelRequest
             {
@@ -247,7 +247,7 @@ namespace NodeGuard.Rpc
                 schedulerFactoryMock,
                 nodeRepositoryMock.Object,
                 channelOperationRequestRepositoryMock.Object, null,
-                coinSelectionServiceMock.Object, lightningServiceMock.Object);
+                coinSelectionServiceMock.Object, lightningServiceMock.Object, null);
 
             var request = new OpenChannelRequest
             {
@@ -311,7 +311,7 @@ namespace NodeGuard.Rpc
                 new Mock<IBitcoinService>().Object, new Mock<INBXplorerService>().Object,
                 schedulerFactoryMock,
                 nodeRepositoryMock.Object,
-                channelOperationRequestRepositoryMock.Object, null, coinSelectionServiceMock.Object, null);
+                channelOperationRequestRepositoryMock.Object, null, coinSelectionServiceMock.Object, null, null);
 
             var request = new OpenChannelRequest
             {
@@ -359,7 +359,7 @@ namespace NodeGuard.Rpc
                 new Mock<IBitcoinService>().Object, new Mock<INBXplorerService>().Object,
                 schedulerFactoryMock,
                 null,
-                channelOperationRequestRepositoryMock.Object, channelRepositoryMock.Object, null, null);
+                channelOperationRequestRepositoryMock.Object, channelRepositoryMock.Object, null, null, null);
 
 
             var request = new CloseChannelRequest
@@ -402,6 +402,7 @@ namespace NodeGuard.Rpc
                 null,
                 channelOperationRequestRepositoryMock.Object, channelRepositoryMock.Object,
                 null,
+                null,
                 null
             );
 
@@ -443,6 +444,7 @@ namespace NodeGuard.Rpc
                     new Mock<ISchedulerFactory>().Object,
                     new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
+                    null,
                     null,
                     null
                 );
@@ -496,6 +498,7 @@ namespace NodeGuard.Rpc
                     new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
                     null,
+                    null,
                     null
                 );
             var getLiquidityRulesRequest = new GetLiquidityRulesRequest
@@ -537,7 +540,7 @@ namespace NodeGuard.Rpc
                     new Mock<IBitcoinService>().Object, new Mock<INBXplorerService>().Object,
                     new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
             var getLiquidityRulesRequest = new GetLiquidityRulesRequest
             {
                 NodePubkey = "101001010101"
@@ -583,7 +586,7 @@ namespace NodeGuard.Rpc
                     new Mock<IBitcoinService>().Object,
                     mock.Object, new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             var newWalletAddressRequest = new GetNewWalletAddressRequest
             {
@@ -621,7 +624,7 @@ namespace NodeGuard.Rpc
                     bitcoinService.Object,
                     nbxplorerService.Object, mockScheduler, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             var requestWithdrawalRequest = new RequestWithdrawalRequest
             {
@@ -672,7 +675,7 @@ namespace NodeGuard.Rpc
                     bitcoinService.Object,
                     nbxplorerService.Object, new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             //Act
             var resp = async () => await mockNodeGuardService.RequestWithdrawal(requestWithdrawalRequest,
@@ -714,7 +717,7 @@ namespace NodeGuard.Rpc
                     bitcoinService.Object,
                     nbxplorerService.Object, new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             //Act
             var resp = async () => await mockNodeGuardService.RequestWithdrawal(requestWithdrawalRequest,
@@ -756,7 +759,7 @@ namespace NodeGuard.Rpc
                     bitcoinService.Object,
                     nbxplorerService.Object, new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             //Act
             var resp = async () => await mockNodeGuardService.RequestWithdrawal(requestWithdrawalRequest,
@@ -798,7 +801,7 @@ namespace NodeGuard.Rpc
                     bitcoinService.Object,
                     nbxplorerService.Object, new Mock<ISchedulerFactory>().Object, new Mock<INodeRepository>().Object,
                     new Mock<IChannelOperationRequestRepository>().Object, null,
-                    null, null);
+                    null, null, null);
 
             //Act
             var resp = async () => await mockNodeGuardService.RequestWithdrawal(requestWithdrawalRequest,
@@ -955,7 +958,7 @@ namespace NodeGuard.Rpc
             var nodeGuardService = new NodeGuardService(null, null, walletRepository, null, null, null, null,
                 scheduleFactory.Object, new Mock<INodeRepository>().Object,
                 new Mock<IChannelOperationRequestRepository>().Object, null,
-                null, null);
+                null, null, null);
             var result = await nodeGuardService.GetAvailableWallets(request, null);
 
             result.Wallets.ToList().Count().Should().Be(2);
@@ -998,7 +1001,7 @@ namespace NodeGuard.Rpc
             var nodeGuardService = new NodeGuardService(null, null, walletRepository, null, null, null, null,
                 scheduleFactory.Object, new Mock<INodeRepository>().Object,
                 new Mock<IChannelOperationRequestRepository>().Object, null,
-                null, null);
+                null, null, null);
             var result = await nodeGuardService.GetAvailableWallets(request, null);
 
             result.Wallets.ToList().Count().Should().Be(1);
@@ -1022,6 +1025,7 @@ namespace NodeGuard.Rpc
                 nodeRepositoryMock.Object,
                 new Mock<IChannelOperationRequestRepository>().Object,
                 new Mock<IChannelRepository>().Object,
+                null,
                 null,
                 null
             );
@@ -1064,6 +1068,7 @@ namespace NodeGuard.Rpc
                 nodeRepositoryMock.Object,
                 new Mock<IChannelOperationRequestRepository>().Object,
                 new Mock<IChannelRepository>().Object,
+                null,
                 null,
                 null
             );
@@ -1111,6 +1116,7 @@ namespace NodeGuard.Rpc
                 new Mock<IChannelOperationRequestRepository>().Object,
                 new Mock<IChannelRepository>().Object,
                 null,
+                null,
                 null
             );
 
@@ -1152,6 +1158,7 @@ namespace NodeGuard.Rpc
                 nodeRepositoryMock.Object,
                 new Mock<IChannelOperationRequestRepository>().Object,
                 new Mock<IChannelRepository>().Object,
+                null,
                 null,
                 null
             );
@@ -1209,7 +1216,7 @@ namespace NodeGuard.Rpc
             var nodeGuardService = new NodeGuardService(null, null, walletRepository, null, null, null, null,
                 scheduleFactory.Object, new Mock<INodeRepository>().Object,
                 new Mock<IChannelOperationRequestRepository>().Object, null,
-                null, null);
+                null, null, null);
             var result = await nodeGuardService.GetAvailableWallets(request, null);
 
             result.Wallets.ToList().Count().Should().Be(1);
@@ -1264,7 +1271,7 @@ namespace NodeGuard.Rpc
             var nodeGuardService = new NodeGuardService(null, null, walletRepository, null, null, null, null,
                 scheduleFactory.Object, new Mock<INodeRepository>().Object,
                 new Mock<IChannelOperationRequestRepository>().Object, null,
-                null, null);
+                null, null, null);
             var result = await nodeGuardService.GetAvailableWallets(request, null);
 
             result.Wallets.ToList().Count().Should().Be(2);
@@ -1287,7 +1294,7 @@ namespace NodeGuard.Rpc
             var nodeGuardService =
                 new NodeGuardService(null, null, null, null, null, null, null, scheduleFactory.Object, null,
                     null, null,
-                    null, null);
+                    null, null, null);
             var act = () => nodeGuardService.GetAvailableWallets(request, null);
 
             await act

--- a/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
@@ -343,7 +343,10 @@ public class BitcoinServiceTests
             {
                 Value = new Money((long)10000000),
                 ScriptPubKey = wallet.GetDerivationStrategy().GetDerivation(KeyPath.Parse("0/0")).ScriptPubKey,
-                KeyPath = KeyPath.Parse("0/0")
+                KeyPath = KeyPath.Parse("0/0"),
+                Index = 1,
+                TransactionHash = 12345678901234567890,
+                Outpoint = new OutPoint(12345678901234567890, 1)
             }
         };
         var withdrawalRequest = new WalletWithdrawalRequest()
@@ -387,7 +390,7 @@ public class BitcoinServiceTests
                 }
             });
 
-        var fmUtxos = utxos.Select(x => new FMUTXO() { TxId = x.Outpoint.Hash.ToString() }).ToList();
+        var fmUtxos = utxos.Select(x => new FMUTXO() { TxId = x.Outpoint.Hash.ToString(), OutputIndex = 1}).ToList();
         fmutxoRepository
             .Setup(x => x.GetLockedUTXOs(null, null))
             .ReturnsAsync(fmUtxos);
@@ -404,7 +407,7 @@ public class BitcoinServiceTests
         var result = await bitcoinService.GenerateTemplatePSBT(withdrawalRequest);
 
         // Assert
-        var psbt = PSBT.Parse("cHNidP8BAF4BAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wD/////AZiUmAAAAAAAIgAgPaPWaBQgTxHOMVfMfpX21blroUe8KAd6w2gLRelFuiAAAAAATwEENYfPA325Ro0AAAABg9H86IDUttPPFss+9te+0DByQgbeD7RPXNuVH9mh1qIDnMEWyKA+kvyG038on8+HxI+9AD8r6ZI1dNIDSGC8824Q7QIQyDAAAIABAACAAQAAAAABAR+AlpgAAAAAABYAFOk69QEyo0x+Xs/zV62OLrHh9eszIgYDe4P0dWOAXkT55CEen41rp96ZVilzhsIDgOaKZ6EB1ZwY7QIQyDAAAIABAACAAQAAAAAAAAAAAAAAAAA=", Network.RegTest);
+        var psbt = PSBT.Parse("cHNidP8BAF4BAAAAAdIKH+sAAAAAjKlUqwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAD/////AZiUmAAAAAAAIgAgPaPWaBQgTxHOMVfMfpX21blroUe8KAd6w2gLRelFuiAAAAAATwEENYfPA325Ro0AAAABg9H86IDUttPPFss+9te+0DByQgbeD7RPXNuVH9mh1qIDnMEWyKA+kvyG038on8+HxI+9AD8r6ZI1dNIDSGC8824Q7QIQyDAAAIABAACAAQAAAAABAR+AlpgAAAAAABYAFOk69QEyo0x+Xs/zV62OLrHh9eszIgYDe4P0dWOAXkT55CEen41rp96ZVilzhsIDgOaKZ6EB1ZwY7QIQyDAAAIABAACAAQAAAAAAAAAAAAAAAAA=", Network.RegTest);
         result.Should().BeEquivalentTo(psbt);
     }
 

--- a/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
@@ -183,7 +183,7 @@ public class BitcoinServiceTests
         fmutxoRepository
             .Setup(x => x.GetLockedUTXOs(null, null))
             .ReturnsAsync(new List<FMUTXO>());
-        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, null);
+        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, walletWithdrawalRequestRepository.Object);
 
         var bitcoinService = new BitcoinService(_logger, mapper.Object, walletWithdrawalRequestRepository.Object, walletWithdrawalRequestPsbtRepository.Object, null, null, nbXplorerService.Object, coinSelectionService);
 
@@ -252,7 +252,7 @@ public class BitcoinServiceTests
             .Setup(x => x.GetLockedUTXOs(null , null))
             .ReturnsAsync(new List<FMUTXO>());
 
-        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, null);
+        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, walletWithdrawalRequestRepository.Object);
 
         var bitcoinService = new BitcoinService(_logger, mapper.Object, walletWithdrawalRequestRepository.Object, walletWithdrawalRequestPsbtRepository.Object, null, null, nbXplorerService.Object, coinSelectionService);
 
@@ -320,7 +320,7 @@ public class BitcoinServiceTests
             .Setup(x => x.GetLockedUTXOs(null, null))
             .ReturnsAsync(new List<FMUTXO>());
 
-        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, null);
+        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, walletWithdrawalRequestRepository.Object);
 
         var bitcoinService = new BitcoinService(_logger, mapper.Object, walletWithdrawalRequestRepository.Object, walletWithdrawalRequestPsbtRepository.Object, null, null, nbXplorerService.Object, coinSelectionService);
 
@@ -329,6 +329,82 @@ public class BitcoinServiceTests
 
         // Assert
         var psbt = PSBT.Parse("cHNidP8BAIkBAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wD/////AkBCDwAAAAAAIgAgPaPWaBQgTxHOMVfMfpX21blroUe8KAd6w2gLRelFuiCsUYkAAAAAACIAIDx3862ZOy+vKdDZ4oysyRZX0HARoqQ9LqqK2ukxoopiAAAAAE8BBDWHzwN9uUaNAAAAAYPR/OiA1LbTzxbLPvbXvtAwckIG3g+0T1zblR/ZodaiA5zBFsigPpL8htN/KJ/Ph8SPvQA/K+mSNXTSA0hgvPNuEO0CEMgwAACAAQAAgAEAAAAAAQEfgJaYAAAAAAAWABTpOvUBMqNMfl7P81etji6x4fXrMyIGA3uD9HVjgF5E+eQhHp+Na6femVYpc4bCA4DmimehAdWcGO0CEMgwAACAAQAAgAEAAAAAAAAAAAAAAAAAAA==", Network.RegTest);
+        result.Should().BeEquivalentTo(psbt);
+    }
+
+    [Fact]
+    async Task GenerateTemplatePSBT_Changeless_SingleSigSucceeds()
+    {
+        // Arrange
+        var wallet = CreateWallet.SingleSig(_internalWallet);
+        var utxos = new List<UTXO>()
+        {
+            new UTXO()
+            {
+                Value = new Money((long)10000000),
+                ScriptPubKey = wallet.GetDerivationStrategy().GetDerivation(KeyPath.Parse("0/0")).ScriptPubKey,
+                KeyPath = KeyPath.Parse("0/0")
+            }
+        };
+        var withdrawalRequest = new WalletWithdrawalRequest()
+        {
+            Id = 1,
+            Status = WalletWithdrawalRequestStatus.Pending,
+            Wallet = wallet,
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>(),
+            Amount = 0.09m,
+            DestinationAddress = "bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf",
+            Changeless = true,
+        };
+
+        var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+        var walletWithdrawalRequestPsbtRepository = new Mock<IWalletWithdrawalRequestPsbtRepository>();
+        var fmutxoRepository = new Mock<IFMUTXORepository>();
+        var nbXplorerService = new Mock<INBXplorerService>();
+        var mapper = new Mock<IMapper>();
+        walletWithdrawalRequestRepository
+            .Setup((w) => w.GetById(It.IsAny<int>()))
+            .ReturnsAsync(withdrawalRequest);
+        walletWithdrawalRequestRepository
+            .Setup((w) => w.AddUTXOs(It.IsAny<WalletWithdrawalRequest>(), It.IsAny<List<FMUTXO>>()))
+            .ReturnsAsync((true, null));
+        walletWithdrawalRequestPsbtRepository
+            .Setup((w) => w.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>()))
+            .ReturnsAsync((true, null));
+        nbXplorerService
+            .Setup(x => x.GetStatusAsync(default))
+            .ReturnsAsync(new StatusResult() { IsFullySynched = true });
+        nbXplorerService
+            .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), DerivationFeature.Change, 0, false, default))
+            .ReturnsAsync(new KeyPathInformation() { Address = BitcoinAddress.Create("bcrt1q83ml8tve8vh672wsm83getxfzetaquq352jr6t423tdwjvdz3f3qe4r4t7", Network.RegTest) });
+        nbXplorerService
+            .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+            .ReturnsAsync(new UTXOChanges()
+            {
+                Confirmed = new UTXOChange()
+                {
+                    UTXOs = utxos,
+                }
+            });
+
+        var fmUtxos = utxos.Select(x => new FMUTXO() { TxId = x.Outpoint.Hash.ToString() }).ToList();
+        fmutxoRepository
+            .Setup(x => x.GetLockedUTXOs(null, null))
+            .ReturnsAsync(fmUtxos);
+
+        walletWithdrawalRequestRepository
+            .Setup(x => x.GetUTXOs(It.IsAny<IBitcoinRequest>()))
+            .ReturnsAsync((true, fmUtxos));
+
+        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, walletWithdrawalRequestRepository.Object);
+
+        var bitcoinService = new BitcoinService(_logger, mapper.Object, walletWithdrawalRequestRepository.Object, walletWithdrawalRequestPsbtRepository.Object, null, null, nbXplorerService.Object, coinSelectionService);
+
+        // Act
+        var result = await bitcoinService.GenerateTemplatePSBT(withdrawalRequest);
+
+        // Assert
+        var psbt = PSBT.Parse("cHNidP8BAF4BAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wD/////AZiUmAAAAAAAIgAgPaPWaBQgTxHOMVfMfpX21blroUe8KAd6w2gLRelFuiAAAAAATwEENYfPA325Ro0AAAABg9H86IDUttPPFss+9te+0DByQgbeD7RPXNuVH9mh1qIDnMEWyKA+kvyG038on8+HxI+9AD8r6ZI1dNIDSGC8824Q7QIQyDAAAIABAACAAQAAAAABAR+AlpgAAAAAABYAFOk69QEyo0x+Xs/zV62OLrHh9eszIgYDe4P0dWOAXkT55CEen41rp96ZVilzhsIDgOaKZ6EB1ZwY7QIQyDAAAIABAACAAQAAAAAAAAAAAAAAAAA=", Network.RegTest);
         result.Should().BeEquivalentTo(psbt);
     }
 


### PR DESCRIPTION
Related to
https://github.com/Elenpay/btcpayserver/pull/52
and
https://github.com/Elenpay/NBXplorer/pull/1


also related to https://github.com/Elenpay/NodeGuard/pull/286
because it has the backend part of coin selection for withdrawals