### PR TITLE
fixed bug hot wallets not transfering correct amount

### DIFF
--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -428,7 +428,7 @@
                             <Field>
                                 <FieldLabel>Amount</FieldLabel>
                                 <FieldBody>
-                                    <NumericPicker TValue="decimal" Disabled="_transferAllFunds" Value="@_amountToTransfer" ValueChanged="(value) => { _amountToTransfer = value; }" CurrencySymbol="₿ " Max="@_maxWithdrawal" Min="@_minWithdrawal" Decimals="8">
+                                    <NumericPicker TValue="decimal" Disabled="_transferAllFunds" @bind-Value="@_amountToTransfer"  CurrencySymbol="₿ " Max="@_maxWithdrawal" Min="@_minWithdrawal" Decimals="8">
                                         <Feedback>
                                             <ValidationError />
                                         </Feedback>
@@ -531,6 +531,7 @@
     private decimal _maxWithdrawal = Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _minWithdrawal = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _amountToTransfer = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
+    private decimal _copyAmountToTransfer;
     private ConfirmationModal _multisigTransferModal;
     private ConfirmationModal _hotWalletTransferModal;
 
@@ -1091,10 +1092,10 @@
             {
                 var withdrawal = await CreateWithdrawalRequestForFunds();
                 await _multisigTransferModal.ShowModal();
+                await CloseAndCleanTransferFundsModal();
             }
         }
-
-        await CloseAndCleanTransferFundsModal();
+        
 
     }
 
@@ -1112,6 +1113,7 @@
             ToastService.ShowError("Error while transferring funds, please contact a superadmin for troubleshooting");
         }
 
+        await CloseAndCleanTransferFundsModal();
         await CloseHotWalletTransferModal();
     }
 

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -531,7 +531,6 @@
     private decimal _maxWithdrawal = Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _minWithdrawal = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _amountToTransfer = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
-    private decimal _copyAmountToTransfer;
     private ConfirmationModal _multisigTransferModal;
     private ConfirmationModal _hotWalletTransferModal;
 


### PR DESCRIPTION
Fixing hot wallets not transferring the correct amount.

Changed a bit the flow of windows in hot wallets, so you can go back if you are not secure to the funds modal. 
This can be removed anyway if users don't like it.