### PR TITLE
fix: currency message not needed anymore and symbol change

### DIFF
--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -141,7 +141,7 @@
                 </DisplayTemplate>
                 <EditTemplate>
                     <Validation Validator="@ValidationHelper.ValidateChannelCapacity" @ref="_capacityValidation">
-                        <NumericPicker TValue="decimal" @bind-Value="@_amount" Min="@_minimumChannelCapacity" Max="@_maxChannelCapacity" Decimals="8" Step="0.00001m" CurrencySymbol=" BTC" CurrencySymbolPlacement="CurrencySymbolPlacement.Suffix" Disabled="@(SelectedUTXOs.Count > 0)"/>
+                        <NumericPicker TValue="decimal" @bind-Value="@_amount" Min="@_minimumChannelCapacity" Max="@_maxChannelCapacity" Decimals="8" Step="0.00001m" CurrencySymbol=" ₿" Disabled="@(SelectedUTXOs.Count > 0)"/>
                         <FieldHelp>
                             @{
                                   decimal amountToShow = _amount < _maxChannelCapacity
@@ -149,7 +149,7 @@
                                       : _maxChannelCapacity;
                                   decimal convertedAmount = Math.Round(PriceConversionService.SatToUsdConversion(new Money(amountToShow, MoneyUnit.BTC).Satoshi, _btcPrice), 2);
                               }
-                              @($"Amount in Satoshis. Minimum {_minimumChannelCapacity:f8}. Current amount: {convertedAmount} USD")
+                              @($"Minimum {_minimumChannelCapacity:f8}. Current amount: {convertedAmount} USD")
                             </FieldHelp>
                     </Validation>
                     <div class="mb-3">

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -176,7 +176,7 @@
                                             : Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
                                         decimal convertedAmount = Math.Round(PriceConversionService.SatToUsdConversion(new Money(amountToShow, MoneyUnit.BTC).Satoshi, _btcPrice), 2);    
                                     }
-                                    @($"Amount in BTC. Minimum {_minimumWithdrawalAmount:f8}. Current amount: {convertedAmount} USD")
+                                    @($"Minimum {_minimumWithdrawalAmount:f8}. Current amount: {convertedAmount} USD")
                                      </FieldHelp>
                                 </Validation>
                                        <div class="mb-3">


### PR DESCRIPTION
[Notion task](https://www.notion.so/clovrlabs/Remove-satoshi-inscription-in-Channel-Request-modal-7b985ca1ff55402dabb0e9ae3931012b?pvs=4)