### PR TITLE
Withdraw all funds fix

### DIFF
--- a/src/Helpers/ValidationHelper.cs
+++ b/src/Helpers/ValidationHelper.cs
@@ -78,14 +78,14 @@ public static class ValidationHelper
         }
     }
 
-    public static void ValidateWithdrawalAmount(ValidatorEventArgs obj)
+    public static void ValidateWithdrawalAmount(ValidatorEventArgs obj, decimal? walletBalance)
     {
         var amount = (decimal)obj.Value;
 
         obj.Status = ValidationStatus.Success;
 
         decimal minimum = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
-        decimal maximum = Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
+        decimal maximum = walletBalance ?? Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
 
         if (amount < minimum)
         {

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -450,7 +450,7 @@
                     <Column ColumnSize="ColumnSize.Is6">
                         <Field>
                             <FieldBody>
-                                <Check TValue="bool" @bind-Checked="@_transferAllFunds">Transfer all funds</Check>
+                                <Check TValue="bool" CheckedChanged="OnTransferAllFundsCheckedChanged" Checked="@_transferAllFunds">Transfer all funds</Check>
                             </FieldBody>
                         </Field>
                     </Column>
@@ -1402,4 +1402,9 @@
         }
     }
 
+    private void OnTransferAllFundsCheckedChanged(bool value)
+    {
+        _transferAllFunds = value;
+        _amountToTransfer = _sourceBalance;
+    }
 }

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -435,7 +435,7 @@
             <Fields>
                 <Validations @ref="_transferFundsValidations">
                     <Column ColumnSize="ColumnSize.Is6">
-                        <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args)">
+                        <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args, _sourceBalance)">
                             <Field>
                                 <FieldLabel>Amount</FieldLabel>
                                 <FieldBody>

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -160,38 +160,42 @@
                             }
                         </EditTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount (BTC)" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Amount)" >
+                    <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" PopupFieldColumnSize="ColumnSize.Is12" Editable="true" Field="@nameof(WalletWithdrawalRequest.Amount)" Caption="Amount" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.Amount)" >
                         <DisplayTemplate>
                             @{
                                 @($"{context.Amount:f8} BTC ({Math.Round(PriceConversionService.BtcToUsdConversion(context.Amount, _btcPrice), 2)} USD)")
                             }
                         </DisplayTemplate>
                         <EditTemplate>
-                            <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args)">
-                                <NumericPicker TValue="decimal" @bind-Value="@_amount" Step="0.00001m" CurrencySymbol="₿ " Max="@(_maxWithdrawal)" Min="_minWithdrawal" Decimals="8"  Disabled="@(SelectedUTXOs.Count > 0 || IsCheckedAllFunds)"  />
-                                     <FieldHelp>
+                            <Validation Validator="args => ValidationHelper.ValidateWithdrawalAmount(args, _selectedRequestWalletBalance)">
+                                <NumericPicker TValue="decimal" @bind-Value="@_amount" Step="0.00001m" CurrencySymbol="₿ " Decimals="8" DecimalSeparator="," Disabled="@(SelectedUTXOs.Count > 0 || IsCheckedAllFunds)">
+                                    <Feedback>
+                                        <ValidationError/>
+                                    </Feedback>
+                                </NumericPicker>
+                                <FieldHelp>
                                     @{
                                         decimal amountToShow = _amount < Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT
                                             ? _amount
                                             : Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
                                         decimal convertedAmount = Math.Round(PriceConversionService.SatToUsdConversion(new Money(amountToShow, MoneyUnit.BTC).Satoshi, _btcPrice), 2);
                                     }
-                                    @($"Minimum {_minimumWithdrawalAmount:f8}. Current amount: {convertedAmount} USD")
-                                     </FieldHelp>
-                                </Validation>
-                                       <div class="mb-3">
-                                <Button Color="Color.Primary" Disabled="@(!_selectedWalletId.HasValue)" Clicked="@OpenCoinSelectionModal">Select Coins</Button> or use
+                                    @($"Minimum {_minimumWithdrawalAmount:f8} BTC. Current amount: {convertedAmount} USD")
+                                </FieldHelp>
+                            </Validation>
+                            <div class="mb-3">
+                                <Button Color="Color.Primary" Disabled="@(!_selectedWalletId.HasValue || IsCheckedAllFunds)" Clicked="@OpenCoinSelectionModal">Select Coins</Button> or use
                                 <Button Color="Color.Primary" Disabled="@(SelectedUTXOs.Count == 0)" Clicked="@ClearSelectedUTXOs">Default Coin Selection</Button>
                             </div>
-                                @if (_selectedWalletId.HasValue && SelectedUTXOs.Count > 0)
-                                {
-                                    <span class="text-danger">Selected @(SelectedUTXOs.Count) UTXOs, this is a changeless operation</span>
-                                }
-                                else
-                                {
-                                    <span class="text-danger">Default coin selection strategy selected</span>
-                                }
-                            </EditTemplate>
+                            @if (_selectedWalletId.HasValue && SelectedUTXOs.Count > 0)
+                            {
+                                <span class="text-danger">Selected @(SelectedUTXOs.Count) UTXOs, this is a changeless operation</span>
+                            }
+                            else
+                            {
+                                <span class="text-danger">Default coin selection strategy selected</span>
+                            }
+                        </EditTemplate>
                     </DataGridColumn>
                     <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.WalletId)" Caption="Signatures Collected" Sortable="false" Displayable="@IsPendingRequestsColumnVisible(PendingWithdrawalsColumnName.SignaturesCollected)">
                         <DisplayTemplate>
@@ -445,8 +449,6 @@
     private bool _isNodeManager = false;
     private WalletWithdrawalRequestStatus? _rejectCancelStatus = WalletWithdrawalRequestStatus.Rejected;
     private decimal? _selectedRequestWalletBalance;
-    private decimal _maxWithdrawal = Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
-    private decimal _minWithdrawal = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _btcPrice;
     private ColumnLayout<AllWithdrawalsColumnName> AllRequestsColumnLayout;
     private Dictionary<string, bool> _pendingRequestsColumns = new();
@@ -543,13 +545,11 @@
     private async Task OnRowInserted(SavedRowItem<WalletWithdrawalRequest, Dictionary<string, object>> arg)
     {
         if (arg.Item == null) return;
-        //Balance validation
-        if (await ValidateBalance(arg)) return;
         var amount = SelectedUTXOs.Count > 0 ? SelectedUTXOsValue() : _amount;
         arg.Item.Wallet = await WalletRepository.GetById(arg.Item.WalletId);
         arg.Item.Amount = amount;
         arg.Item.Changeless = SelectedUTXOs.Count > 0;
-        arg.Item.WithdrawAllFunds = arg.Item.WithdrawAllFunds || _amount == _selectedRequestWalletBalance;
+        arg.Item.WithdrawAllFunds = IsCheckedAllFunds || _amount == _selectedRequestWalletBalance;
         if (arg.Item.Wallet.IsHotWallet)
         {
             await GetData();
@@ -590,6 +590,7 @@
         if (IsCheckedAllFunds)
         {
             ClearSelectedUTXOs();
+            _amount = _selectedRequestWalletBalance ?? _minimumWithdrawalAmount;
         }
     }
 
@@ -829,8 +830,12 @@
         _selectedWalletId = id == 0 ? null : id;
         if (wallet != null)
         {
-        var (balance,_) = await BitcoinService.GetWalletConfirmedBalance(wallet);
-        _selectedRequestWalletBalance = balance;
+            var (balance,_) = await BitcoinService.GetWalletConfirmedBalance(wallet);
+            _selectedRequestWalletBalance = balance;
+            if (IsCheckedAllFunds)
+            {
+                _amount = balance;
+            }
         }
     }
 
@@ -881,7 +886,7 @@
             {
                 _selectedRequest.Wallet = null;
                 _selectedRequest.Changeless = SelectedUTXOs.Count > 0;
-                _selectedRequest.WithdrawAllFunds = _selectedRequest.WithdrawAllFunds || _amount == _selectedRequestWalletBalance;
+                _selectedRequest.WithdrawAllFunds = IsCheckedAllFunds || _amount == _selectedRequestWalletBalance;
                 var createWithdrawalResult = await WalletWithdrawalRequestRepository.AddAsync(_selectedRequest);
                 if (!createWithdrawalResult.Item1)
                 {


### PR DESCRIPTION
- Added balance check to validator so it warns the user that the balance is not enough in the same modal instead of in a later toast popup
- Removed the Min and Max from the input, so it fails on the validator. Otherwise if you put less than the minimum amount in the input and click save, it changes to the minimum amount but the user doesn't get feedback
- Disabled the coin selector button when "transfer all funds", is selected
- Now when you click "transfer all funds", the input will be filled with the whole balance of the wallet