### PR TITLE
Fix selecting UTXOs 

### DIFF
--- a/src/Shared/UTXOSelectorModal.razor
+++ b/src/Shared/UTXOSelectorModal.razor
@@ -86,8 +86,7 @@
                                   Responsive
                                   FixedHeader
                                   FixedHeaderDataGridMaxHeight="400px"
-                                  ShowPager
-                                  PageSize="6"
+                                  ShowPager="false" 
                                   >
                             <DataGridMultiSelectColumn Width="30px"></DataGridMultiSelectColumn>
                             <DataGridColumn Field="@nameof(UTXO.Value)" Caption="BTC" Sortable="true"/>

--- a/src/Shared/UTXOSelectorModal.razor
+++ b/src/Shared/UTXOSelectorModal.razor
@@ -86,7 +86,6 @@
                                   Responsive
                                   FixedHeader
                                   FixedHeaderDataGridMaxHeight="400px"
-                                  ShowPager="false" 
                                   >
                             <DataGridMultiSelectColumn Width="30px"></DataGridMultiSelectColumn>
                             <DataGridColumn Field="@nameof(UTXO.Value)" Caption="BTC" Sortable="true"/>


### PR DESCRIPTION
Selecting UTXOs for operation unselects previously selected coins if select all

<img width="432" alt="image" src="https://github.com/Elenpay/NodeGuard/assets/81957232/d80a99ac-b800-44b4-be65-965e57d93e2e">
