### PR TITLE
Add remote node pubkey field to LiquidityRules and protos

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,12 @@
             // Use IntelliSense to find out which attributes exist for C# debugging
             // Use hover for the description of the existing attributes
             // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-            "name": ".NET Core Launch (web)",
+            "name": "Debug NG",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/bin/Debug/net7.0/NodeGuard.dll",
+            "program": "${workspaceFolder}/src/bin/Debug/net8.0/NodeGuard.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src",
             "stopAtEntry": false,
@@ -21,30 +21,41 @@
             },
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "POSTGRES_CONNECTIONSTRING": "Host=127.0.0.1;Port=35433;Database=fundsmanager;Username=rw_dev;Password=rw_dev",
+                "POSTGRES_CONNECTIONSTRING": "Host=127.0.0.1;Port=5432;Database=nodeguard;Username=rw_dev;Password=rw_dev",
                 "BITCOIN_NETWORK": "REGTEST",
-                "NBXPLORER_URI": "http://nbxplorer:32838",
+                "MAXIMUM_WITHDRAWAL_BTC_AMOUNT": "21000000",
+                "NBXPLORER_ENABLE_CUSTOM_BACKEND": "true",
+                "NBXPLORER_URI": "http://127.0.0.1:32838",
                 "NBXPLORER_BTCRPCUSER": "polaruser",
                 "NBXPLORER_BTCRPCPASSWORD": "polarpass",
-                "NBXPLORER_BTCRPCURL": "http://host.docker.internal:18443/",
-                "NBXPLORER_BTCNODEENDPOINT": "host.docker.internal:19444",
-                "ASPNETCORE_URLS": "http://localhost:5001",
-                "DEFAULT_DERIVATION_PATH": "m/48'/1'/1'"
+                "NBXPLORER_BTCRPCURL": "http://127.0.0.1:18443/",
+                "NBXPLORER_BTCNODEENDPOINT": "127.0.0.1:19444",
+                "PUSH_NOTIFICATIONS_ONESIGNAL_API_BASE_PATH": "https://onesignal.com/api/v1",
+                "PUSH_NOTIFICATIONS_ONESIGNAL_APP_ID": "changeme",
+                "PUSH_NOTIFICATIONS_ONESIGNAL_API_TOKEN": "changeme",
+                "PUSH_NOTIFICATIONS_ONESIGNAL_ENABLED": "false",
+                "DEFAULT_DERIVATION_PATH": "m/48'/1'",
+                "IS_DEV_ENVIRONMENT": "true",
+                "FUNDSMANAGER_ENDPOINT": "http://localhost:38080",
+                "Logging__LogLevel__Microsoft": "Warning",
+                "SWEEPNODEWALLETSJOB_CRON": "0 */1 * * * ?",
+                "ANCHOR_CLOSINGS_MINIMUM_SATS": "100000",
+                "ALICE_HOST": "localhost:10001",
+                "BOB_HOST": "localhost:10002",
+                "CAROL_HOST": "localhost:10003",
+                "ENABLE_HW_SUPPORT": "true",
+                "MINIMUM_WITHDRAWAL_BTC_AMOUNT": "0.001",
+                "MINIMUM_CHANNEL_CAPACITY_SATS": "20000",
+                "MEMPOOL_ENDPOINT": "https://mempool.space",
+                "AMBOSS_ENDPOINT": "https://amboss.space",
+                "TRANSACTION_CONFIRMATION_MINIMUM_BLOCKS": "6",
+                "MONITOR_WITHDRAWALS_CRON": "0 */1 * * * ?",
+                "MONITOR_CHANNELS_CRON": "0 0 */1 * * ?",
+                "COINGECKO_ENDPOINT": "https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin",
+                "COINGECKO_KEY": "TBD",
+                "HTTP1_LISTEN_PORT": "38080",
+                "API_TOKEN_SALT": "H/fCx1+maAFMcdi6idIYEg=="
             },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": "Launch against running docker-compose env (DEV)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/bin/Debug/net7.0/NodeGuard.dll",
-            "launchSettingsFilePath": "${workspaceFolder}/src/Properties/launchSettings.json",
-            "launchSettingsProfile": "NodeGuard local debug",
-            "cwd": "${workspaceFolder}/src",
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
             }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/src/FundsManager.csproj",
+                "${workspaceFolder}/src/NodeGuard.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/src/FundsManager.csproj",
+                "${workspaceFolder}/src/NodeGuard.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,7 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/src/FundsManager.csproj"
+                "${workspaceFolder}/src/NodeGuard.csproj"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - nodeguard_postgres_data:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - 25432:5432
 
   nbxplorer:
     restart: unless-stopped

--- a/src/Automapper/MapperProfile.cs
+++ b/src/Automapper/MapperProfile.cs
@@ -65,7 +65,7 @@ namespace NodeGuard.Automapper
             CreateMap<UTXO, FMUTXO>()
                 .ForMember(x => x.TxId, opt => opt.MapFrom(x => x.Outpoint.Hash.ToString()))
                 .ForMember(x => x.OutputIndex, opt => opt.MapFrom(x => x.Outpoint.N))
-                .ForMember(x => x.SatsAmount, opt => opt.MapFrom(x => ((Money) x.Value).Satoshi));
+                .ForMember(x => x.SatsAmount, opt => opt.MapFrom(x => ((Money)x.Value).Satoshi));
 
             CreateMap<LiquidityRule, Nodeguard.LiquidityRule>()
                 .ForMember(x => x.MinimumLocalBalance, opt => opt.MapFrom(x => x.MinimumLocalBalance ?? 0))
@@ -76,7 +76,8 @@ namespace NodeGuard.Automapper
                 .ForMember(x => x.SwapWalletId, opt => opt.MapFrom(x => x.SwapWalletId))
                 .ForMember(x => x.ReverseSwapWalletId, opt => opt.MapFrom(x => x.ReverseSwapWalletId ?? 0))
                 .ForMember(x => x.RebalanceTarget, opt => opt.MapFrom(x => x.RebalanceTarget ?? 0))
-                .ForMember(x => x.NodePubkey, opt => opt.MapFrom(x => x.Node.PubKey));
+                .ForMember(x => x.NodePubkey, opt => opt.MapFrom(x => x.Node.PubKey))
+                .ForMember(x => x.RemoteNodePubkey, opt => opt.MapFrom(x => x.RemoteNodePubkey ?? string.Empty));
 
             CreateMap<LiquidityRule, LiquidityRule>()
                 .ForMember(x => x.SwapWallet, opt => opt.Ignore())

--- a/src/Data/Models/LiquidityRule.cs
+++ b/src/Data/Models/LiquidityRule.cs
@@ -5,44 +5,48 @@ namespace NodeGuard.Data.Models;
 /// <summary>
 /// A rule for setting liquidity automation on NodeGuard
 /// </summary>
-public class LiquidityRule: Entity
+public class LiquidityRule : Entity
 {
-    
+
     public decimal? MinimumLocalBalance { get; set; }
-    
+
     public decimal? MinimumRemoteBalance { get; set; }
-    
+
     /// <summary>
     /// Target between 0 and 1 that we would like for the channel to be balanced after a rebalancing operation is complete
     /// </summary>
     public decimal? RebalanceTarget { get; set; }
-    
+
     /// <summary>
     /// Let's you know if the rule has a wallet or an address as a target for the rebalancing operation
     /// </summary>
     public bool IsReverseSwapWalletRule { get; set; }
-    
+
     /// <summary>
     /// In case that is a rule that sends the funds to an address instead of a wallet this is the address
     /// </summary>
     public string? ReverseSwapAddress { get; set; }
-    
+
     #region Relationships
-    
+
     public int ChannelId { get; set; }
     public Channel Channel { get; set; }
-  
+
     public int SwapWalletId { get; set; }
     public Wallet SwapWallet { get; set; }
-    
+
     public int? ReverseSwapWalletId { get; set; }
     public Wallet? ReverseSwapWallet { get; set; }
-    
+
     public int NodeId { get; set; }
     public Node Node { get; set; }
-    
-    //TODO Discuss about a liquidity rule at node level
 
-    #endregion
+    /// <summary>
+    /// The pubkey of the node that is the remote counterparty of the channel
+    /// </summary>
+    [NotMapped]
+    public string? RemoteNodePubkey => Channel?.SourceNode.PubKey != Node.PubKey ? Channel?.SourceNode.PubKey : Channel.DestinationNode.PubKey;
     
+    #endregion
+
 }

--- a/src/Data/Models/LiquidityRule.cs
+++ b/src/Data/Models/LiquidityRule.cs
@@ -45,7 +45,7 @@ public class LiquidityRule : Entity
     /// The pubkey of the node that is the remote counterparty of the channel
     /// </summary>
     [NotMapped]
-    public string? RemoteNodePubkey => Channel?.SourceNode.PubKey != Node.PubKey ? Channel?.SourceNode.PubKey : Channel.DestinationNode.PubKey;
+    public string? RemoteNodePubkey => Channel?.SourceNode?.PubKey != Node.PubKey ? Channel?.SourceNode?.PubKey : Channel?.DestinationNode?.PubKey;
     
     #endregion
 

--- a/src/Data/Repositories/LiquidityRuleRepository.cs
+++ b/src/Data/Repositories/LiquidityRuleRepository.cs
@@ -103,18 +103,21 @@ public class LiquidityRuleRepository : ILiquidityRuleRepository
     {
         if (string.IsNullOrWhiteSpace(nodePubKey))
             throw new ArgumentException("Value cannot be null or whitespace.", nameof(nodePubKey));
-        
+
         using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
 
         var result = applicationDbContext.LiquidityRules
-            .Include(x=> x.Node)
-            .Include(x=> x.SwapWallet)
-            .ThenInclude(x=> x.InternalWallet)
+            .Include(x => x.Node)
+            .Include(x => x.SwapWallet)
+            .ThenInclude(x => x.InternalWallet)
             .Include(x => x.ReverseSwapWallet)
             .ThenInclude(x => x.InternalWallet)
-            .Include(x=> x.Channel)
-            .Where(x=> x.Node.PubKey == nodePubKey && x.Channel.IsAutomatedLiquidityEnabled && x.Channel.Status != Channel.ChannelStatus.Closed).ToList();
-        
+            .Include(x => x.Channel)
+            .ThenInclude(ch => ch.SourceNode)
+            .Include(x => x.Channel)
+            .ThenInclude(ch => ch.DestinationNode)
+            .Where(x => x.Node.PubKey == nodePubKey && x.Channel.IsAutomatedLiquidityEnabled && x.Channel.Status != Channel.ChannelStatus.Closed).ToList();
+
         return result;
     }
 }

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -80,6 +80,7 @@ message GetLiquidityRulesResponse {
 
 message LiquidityRule {
   uint64 channel_id = 1;
+  // Public key of the node that is the managed node of the channel
   string node_pubkey = 2;
   int32 swap_wallet_id = 3;
   optional int32 reverse_swap_wallet_id = 4;
@@ -88,6 +89,8 @@ message LiquidityRule {
   float rebalance_target = 7;
   optional string reverse_swap_address = 8;
   bool is_reverse_swap_wallet_rule = 9;
+  // Public key of the node that is the counterparty of the channel
+  string remote_node_pubkey = 10;
 }
 
 message GetNewWalletAddressRequest {


### PR DESCRIPTION
This pull request adds a new field called `remote_node_pubkey` to the `LiquidityRule` class and the corresponding protobuf message. This field represents the public key of the node that is the counterparty of the channel.

This PR is needed to support automatic rebalancing without swaps.

This PR is needed for https://github.com/Elenpay/liquidator/pull/74