### PR TITLE
Fix nbxplorer tracking issue

### DIFF
--- a/src/NodeGuard.csproj
+++ b/src/NodeGuard.csproj
@@ -18,46 +18,46 @@
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'NodeGuard debug' " />
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="AwsSignatureVersion4" Version="4.0.1" />
-    <PackageReference Include="Blazored.Toast" Version="4.1.0" />
+    <PackageReference Include="AwsSignatureVersion4" Version="4.0.5" />
+    <PackageReference Include="Blazored.Toast" Version="4.2.1" />
     <PackageReference Include="Blazorise.Bootstrap" Version="1.2.4" />
     <PackageReference Include="Blazorise.Components" Version="1.2.4" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.2.4" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-    <PackageReference Include="NBitcoin" Version="7.0.32" />
-    <PackageReference Include="NBXplorer.Client" Version="4.2.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.2" />
+    <PackageReference Include="NBitcoin" Version="7.0.37" />
+    <PackageReference Include="NBXplorer.Client" Version="4.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="Blazorise.DataGrid" Version="1.2.4" />
     <PackageReference Include="OneSignalApi" Version="2.0.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
-    <PackageReference Include="Quartz" Version="3.8.0" />
-    <PackageReference Include="Quartz.AspNetCore" Version="3.8.0" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Quartz" Version="3.9.0" />
+    <PackageReference Include="Quartz.AspNetCore" Version="3.9.0" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.9.0" />
     <PackageReference Include="Blazorise.SpinKit" Version="1.2.4" />
     <PackageReference Include="RestSharp" Version="106.13.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/BitcoinService.cs
+++ b/src/Services/BitcoinService.cs
@@ -72,7 +72,7 @@ namespace NodeGuard.Services
             if (wallet == null) throw new ArgumentNullException(nameof(wallet));
 
             var balance = await _nbXplorerService.GetBalanceAsync(wallet.GetDerivationStrategy(), default);
-            var confirmedBalanceMoney = (Money) balance.Confirmed;
+            var confirmedBalanceMoney = (Money)balance.Confirmed;
 
             return (confirmedBalanceMoney.ToUnit(MoneyUnit.BTC), confirmedBalanceMoney.Satoshi);
         }
@@ -149,7 +149,7 @@ namespace NodeGuard.Services
             {
                 var balanceResponse = await _nbXplorerService.GetBalanceAsync(derivationStrategy);
 
-                walletWithdrawalRequest.Amount = ((Money) balanceResponse.Confirmed).ToUnit(MoneyUnit.BTC);
+                walletWithdrawalRequest.Amount = ((Money)balanceResponse.Confirmed).ToUnit(MoneyUnit.BTC);
 
                 var update = _walletWithdrawalRequestRepository.Update(walletWithdrawalRequest);
                 if (!update.Item1)
@@ -217,7 +217,7 @@ namespace NodeGuard.Services
                 var builder = txBuilder;
                 builder.AddCoins(scriptCoins);
 
-                var changelessAmount = selectedUTXOs.Sum(u => (Money) u.Value);
+                var changelessAmount = selectedUTXOs.Sum(u => (Money)u.Value);
                 var amount = new Money(walletWithdrawalRequest.SatsAmount, MoneyUnit.Satoshi);
                 var destination = BitcoinAddress.Create(walletWithdrawalRequest.DestinationAddress, nbXplorerNetwork);
 
@@ -452,7 +452,7 @@ namespace NodeGuard.Services
                     walletWithdrawalRequest.DestinationAddress,
                     CurrentNetworkHelper.GetCurrentNetwork()));
 
-                await _nbXplorerService.TrackAsync(trackedSourceAddress, default);
+                await _nbXplorerService.TrackAsync(trackedSourceAddress, new TrackWalletRequest{}, default);
             }
             catch (Exception e)
             {

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -13,7 +13,7 @@ public interface INBXplorerService
 {
     public Task TrackAsync(DerivationStrategyBase derivationStrategyBase, CancellationToken cancellation = default);
 
-    public Task TrackAsync(TrackedSource trackedSource, CancellationToken cancellation = default);
+    public Task TrackAsync(TrackedSource trackedSource, TrackWalletRequest trackWalletRequest, CancellationToken cancellation = default);
 
     public Task<TransactionResult?> GetTransactionAsync(uint256 txId, CancellationToken cancellation = default);
 
@@ -36,7 +36,7 @@ public interface INBXplorerService
 
     public Task<BroadcastResult> BroadcastAsync(Transaction tx, bool testMempoolAccept,
         CancellationToken cancellation = default);
-    
+
     public Task<GetTransactionsResponse> GetTransactionsAsync(DerivationStrategyBase derivationStrategy);
 
     public Task ScanUTXOSetAsync(DerivationStrategyBase derivationStrategy,
@@ -100,10 +100,10 @@ public class NBXplorerService : INBXplorerService
         await client.TrackAsync(derivationStrategyBase, cancellation: cancellation);
     }
 
-    public async Task TrackAsync(TrackedSource trackedSource, CancellationToken cancellation = default)
+    public async Task TrackAsync(TrackedSource trackedSource, TrackWalletRequest trackWalletRequest, CancellationToken cancellation = default)
     {
         var client = await LightningHelper.CreateNBExplorerClient();
-        await client.TrackAsync(trackedSource, cancellation);
+        await client.TrackAsync(trackedSource, trackWalletRequest, cancellation);
     }
 
     public async Task<TransactionResult?> GetTransactionAsync(uint256 txId, CancellationToken cancellation = default)
@@ -209,7 +209,7 @@ public class NBXplorerService : INBXplorerService
             {
                 var feerate = new GetFeeRateResult
                 {
-                    FeeRate = new FeeRate((decimal) recommendedFees.FastestFee),
+                    FeeRate = new FeeRate((decimal)recommendedFees.FastestFee),
                     BlockCount = 1 // 60 mins / 10 mins
                 };
 

--- a/test/NodeGuard.Tests/NodeGuard.Tests.csproj
+++ b/test/NodeGuard.Tests/NodeGuard.Tests.csproj
@@ -10,30 +10,30 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Grpc.Core.Api" Version="2.59.0" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.63.0" />
     <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-    <PackageReference Include="NBitcoin.TestFramework" Version="3.0.24" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.2" />
+    <PackageReference Include="NBitcoin.TestFramework" Version="3.0.27" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="xunit" Version="2.6.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="XunitXml.TestLogger" Version="3.1.17" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request bumps most nuget dependencies and fixes TrackAsync method from NBXplorer as it has a new parameter. 

This will require checking that onchain withdrawals tracking work after merging.

