### PR TITLE
Fix race condition in EF Core migration

### DIFF
--- a/src/Migrations/20230309121807_UpdateSourceDestChannelNodeIdFromRequests.cs
+++ b/src/Migrations/20230309121807_UpdateSourceDestChannelNodeIdFromRequests.cs
@@ -9,8 +9,6 @@ namespace NodeGuard.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             string query = @"
-BEGIN TRANSACTION;
-
 UPDATE public.""Channels"" AS c
 SET
     ""SourceNodeId"" = cor.""SourceNodeId"",
@@ -26,8 +24,6 @@ FROM (
     ORDER BY ""CreationDatetime""
 ) AS cor
 WHERE c.""Id"" = cor.""ChannelId"";
-
-COMMIT TRANSACTION;
 ";
 
             migrationBuilder.Sql(query);


### PR DESCRIPTION
This pull request fixes a race condition in the EF Core migration process. Previously, the migration already was a transaction but the RAW SQL code also did a nested transaction which was not needed and makes the migration process fail.