### PR TITLE
Fixed Cryptographic exception

### DIFF
--- a/src/Services/LocalStorageService.cs
+++ b/src/Services/LocalStorageService.cs
@@ -4,7 +4,7 @@ namespace NodeGuard.Services;
 
 public interface  ILocalStorageService
 {
-    Task<T> LoadStorage<T>(string name, T? defaultValue = default);
+    Task<T?> LoadStorage<T>(string name, T? defaultValue = default);
     Task SetStorage<T>(string name, T value);
 }
 
@@ -17,17 +17,24 @@ public class LocalStorageService: ILocalStorageService
         ProtectedLocalStorage = protectedLocalStorage;
     }
 
-    public async Task<T> LoadStorage<T>(string name, T? defaultValue = default)
+    public async Task<T?> LoadStorage<T>(string name, T? defaultValue = default)
     {
-        var result = await ProtectedLocalStorage.GetAsync<T>(name);
-        if (result.Success)
+        if (defaultValue == null) return defaultValue;
+        try
         {
-            return result.Value;
+            var result = await ProtectedLocalStorage.GetAsync<T>(name);
+            if (result.Success)
+            {
+                return result.Value;
+            }
+
+            throw new Exception("Value not found");
         }
-        if (defaultValue != null)
+        catch
         {
             await ProtectedLocalStorage.SetAsync(name, defaultValue);
         }
+
         return defaultValue;
     }
 


### PR DESCRIPTION
It looks like the culprit for the exception was the ProtecetedLocalStorage. Since the keys have to be protected with
the data protection key, when the key id was not found in the database, the local storage crashed. Now if the key is
not found in the DB, we set the storage with the new data protection key
