### PR TITLE
added reference_id to withdrawal request creation

### DIFF
--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -132,7 +132,7 @@ message RequestWithdrawalRequest {
   FEES_TYPE mempool_fee_rate = 8;
   // Fee rate in sat/vbyte
   optional int32 custom_fee_rate = 9;
-  // Exteneral reference id for the withdrawal
+  // Exteneral reference id for the withdrawal request
   optional string reference_id = 10;
 }
 

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -132,7 +132,7 @@ message RequestWithdrawalRequest {
   FEES_TYPE mempool_fee_rate = 8;
   // Fee rate in sat/vbyte
   optional int32 custom_fee_rate = 9;
-  // Exteneral reference id for the withdrawal request
+  // External reference id for the withdrawal request
   optional string reference_id = 10;
 }
 

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -132,6 +132,8 @@ message RequestWithdrawalRequest {
   FEES_TYPE mempool_fee_rate = 8;
   // Fee rate in sat/vbyte
   optional int32 custom_fee_rate = 9;
+  // Exteneral reference id for the withdrawal
+  optional string reference_id = 10;
 }
 
 message RequestWithdrawalResponse {

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -228,7 +228,8 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
                 RequestMetadata = request.RequestMetadata,
                 Changeless = request.Changeless,
                 MempoolRecommendedFeesType = (MempoolRecommendedFeesType)request.MempoolFeeRate,
-                CustomFeeRate = request.CustomFeeRate
+                CustomFeeRate = request.CustomFeeRate,
+                ReferenceId = request.ReferenceId
             };
 
             //Save withdrawal request


### PR DESCRIPTION
This adds `reference_id` field to RPC method `RequestWithdrawalRequest`. This is needed for settlements as we need to track our inner reference ids for the system (external reference id).
