### PR TITLE
Fix CoinSelectionService bug to display UTXOs correctly in the UTXOSelectorModal

### DIFF
--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -181,7 +181,7 @@ public class CoinSelectionService: ICoinSelectionService
     public async Task<List<UTXO>> GetAvailableUTXOsAsync(DerivationStrategyBase derivationStrategy, CoinSelectionStrategy strategy, int limit, long amount, long closestTo)
     {
         UTXOChanges utxoChanges;
-        if (Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND)
+        if (Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND && limit > 0)
         {
             utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo);
         }


### PR DESCRIPTION
Fix CoinSelectionService.GetAvailableUTXOsAsync method to display UTXOs correctly in the UTXOSelectorModal DataGrid