### PR TITLE
Add manually_frozen tag

### DIFF
--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -87,6 +87,7 @@ public class Constants
     public static decimal MAX_TX_FEE_RATIO = 0.5m;
 
     public const string IsFrozenTag = "frozen";
+    public const string IsManuallyFrozenTag = "manually_frozen";
 
     //  Constants for the NBXplorer API
     public static int SCAN_GAP_LIMIT = 1000;

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -1154,8 +1154,16 @@
             .Select((u) => (
                 u.Outpoint,
                 u,
-                tagsMap[u.Outpoint].Where(t => t.Key != Constants.IsFrozenTag).ToList(),
-                tagsMap[u.Outpoint].Any(t => t.Key == Constants.IsFrozenTag && t.Value == "true")
+                tagsMap[u.Outpoint]
+                    .Where(t => t.Key != Constants.IsFrozenTag && t.Key != Constants.IsManuallyFrozenTag)
+                    .ToList(),
+                // Check if the UTXO is frozen, has been manually frozen or has been manually unfrozen
+                (tagsMap[u.Outpoint]
+                     .Any(t => t.Key == Constants.IsFrozenTag && t.Value == "true") ||
+                 tagsMap[u.Outpoint]
+                     .Any(t => t.Key == Constants.IsManuallyFrozenTag && t.Value == "true")) &&
+                !tagsMap[u.Outpoint]
+                    .Any(t => t.Key == Constants.IsManuallyFrozenTag && t.Value == "false")
             )).ToList();
 
         _detailsTransactions = await NBXplorerService.GetTransactionsAsync(derivationStrategyBase);
@@ -1703,8 +1711,8 @@
 
     private async Task ToggleUtxoFreeze(bool newValue, UTXO utxo)
     {
-        var tag = await UTXOTagRepository.GetByKeyAndOutpoint(Constants.IsFrozenTag, utxo.Outpoint.ToString());
-        var (saved, _) = UTXOTagRepository.Update(new UTXOTag {Key = Constants.IsFrozenTag, Value = newValue ? "true" : "false", Outpoint = utxo.Outpoint.ToString(), Id = tag?.Id ?? 0 });
+        var tag = await UTXOTagRepository.GetByKeyAndOutpoint(Constants.IsManuallyFrozenTag, utxo.Outpoint.ToString());
+        var (saved, _) = UTXOTagRepository.Update(new UTXOTag {Key = Constants.IsManuallyFrozenTag, Value = newValue ? "true" : "false", Outpoint = utxo.Outpoint.ToString(), Id = tag?.Id ?? 0 });
         if (!saved)
         {
             ToastService.ShowError("Error while updating the UTXO status");

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -1419,7 +1419,7 @@
         var withdrawalRequest = new WalletWithdrawalRequest
         {
             UserRequestorId = LoggedUser != null ? LoggedUser.Id : string.Empty,
-            Description = @$"Funds transferred from {_sourceWalletName} to {_targetWalletName}",
+            Description = $"Funds transferred from {_sourceWalletName} to {_targetWalletName}",
             WithdrawAllFunds = _transferAllFunds,
             DestinationAddress = targetBitcoinAddress.ToString(),
             MempoolRecommendedFeesType = MempoolRecommendedFeesType.HourFee,

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -951,11 +951,9 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         }
 
         var lockedUtxos = await _fmutxoRepository.GetLockedUTXOs();
-        var frozenUtxos = await _utxoTagRepository.GetByKeyValue(Constants.IsFrozenTag, "true");
-
         var ignoreOutpoints = new List<string>();
         var listLocked = lockedUtxos.Select(utxo => $"{utxo.TxId}-{utxo.OutputIndex}").ToList();
-        var listFrozen = frozenUtxos.Select(utxo => utxo.Outpoint).ToList();
+        var listFrozen = await _coinSelectionService.GetFrozenUTXOs();
         ignoreOutpoints.AddRange(listLocked);
         ignoreOutpoints.AddRange(listFrozen);
 


### PR DESCRIPTION
This pull request adds a new tag called "manually_frozen" to the codebase. The tag is used to mark UTXOs as manually frozen or manually unfrozen. The code changes include adding the "IsManuallyFrozenTag" constant, updating the UTXO filtering logic to consider the new tag, and adding methods to retrieve the list of frozen UTXOs. This enhancement improves the flexibility and control over freezing and unfreezing UTXOs in the application.