### PR TITLE
Disable jobs for disabled nodes on restart

### DIFF
--- a/src/Data/Repositories/Interfaces/INodeRepository.cs
+++ b/src/Data/Repositories/Interfaces/INodeRepository.cs
@@ -34,7 +34,7 @@ public interface INodeRepository
 
     Task<List<Node>> GetAllManagedByUser(string userId);
 
-    Task<List<Node>> GetAllManagedByNodeGuard();
+    Task<List<Node>> GetAllManagedByNodeGuard(bool withDisabled = true);
 
     Task<(bool, string?)> AddAsync(Node type);
 

--- a/src/Data/Repositories/NodeRepository.cs
+++ b/src/Data/Repositories/NodeRepository.cs
@@ -110,7 +110,7 @@ namespace NodeGuard.Data.Repositories
                 .ToListAsync();
         }
 
-        public async Task<List<Node>> GetAllManagedByNodeGuard()
+        public async Task<List<Node>> GetAllManagedByNodeGuard(bool withDisabled = true)
         {
             await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
 
@@ -119,6 +119,11 @@ namespace NodeGuard.Data.Repositories
                 .ThenInclude(x => x.Keys)
                 .Include(x => x.ReturningFundsWallet)
                 .Where(node => node.Endpoint != null);
+            if (!withDisabled)
+            {
+                query = query.Where(node => !node.IsNodeDisabled);
+
+            }
 
             var resultAsync = await query.ToListAsync();
 

--- a/src/Jobs/ChannelAcceptorJob.cs
+++ b/src/Jobs/ChannelAcceptorJob.cs
@@ -48,7 +48,7 @@ public class ChannelAcceptorJob : IJob
         _logger.LogInformation("Starting {JobName}... ", nameof(ChannelAcceptorJob));
         try
         {
-            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard();
+            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(false);
 
             var scheduler = await _schedulerFactory.GetScheduler();
             foreach (var managedNode in managedNodes)

--- a/src/Jobs/MonitorChannelsJob.cs
+++ b/src/Jobs/MonitorChannelsJob.cs
@@ -22,7 +22,7 @@ public class MonitorChannelsJob : IJob
         _logger.LogInformation("Starting {JobName}... ", nameof(MonitorChannelsJob));
         try
         {
-            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard();
+            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(false);
 
             var scheduler = await _schedulerFactory.GetScheduler();
 

--- a/src/Jobs/NodeChannelSubscribeJob.cs
+++ b/src/Jobs/NodeChannelSubscribeJob.cs
@@ -97,7 +97,7 @@ public class NodeChannelSuscribeJob : IJob
         {
             _logger.LogError(e, "Error while subscribing for the channel updates of node {NodeId}", nodeId);
             //Sleep to avoid massive requests
-            await Task.Delay(1000);
+            await Task.Delay(5000);
             
             throw new JobExecutionException(e, true);
         }

--- a/src/Jobs/NodeSubscriptorJob.cs
+++ b/src/Jobs/NodeSubscriptorJob.cs
@@ -23,7 +23,7 @@ public class NodeSubscriptorJob : IJob
         _logger.LogInformation("Starting {JobName}... ", nameof(NodeSubscriptorJob));
         try
         {
-            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard();
+            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(false);
 
             var scheduler = await _schedulerFactory.GetScheduler();
             

--- a/src/Jobs/ProcessNodeChannelAcceptorJob.cs
+++ b/src/Jobs/ProcessNodeChannelAcceptorJob.cs
@@ -240,7 +240,7 @@ public class ProcessNodeChannelAcceptorJob : IJob
             _logger.LogError(e, "Error on {JobName}", nameof(ProcessNodeChannelAcceptorJob));
             
             //Sleep to avoid massive requests
-            await Task.Delay(1000);
+            await Task.Delay(5000);
 
             throw new JobExecutionException(e, true);
 

--- a/src/Jobs/SweepAllNodesWalletsJob.cs
+++ b/src/Jobs/SweepAllNodesWalletsJob.cs
@@ -46,7 +46,7 @@ namespace NodeGuard.Jobs
             _logger.LogInformation("Starting {JobName}... ", nameof(SweepAllNodesWalletsJob));
             try
             {
-                var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard();
+                var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(false);
 
                 var scheduler = await _schedulerFactory.GetScheduler();
                 foreach (var managedNode in managedNodes.Where(managedNode => managedNode.ChannelAdminMacaroon != null && managedNode.AutosweepEnabled))

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -1411,7 +1411,7 @@
         var withdrawalRequest = new WalletWithdrawalRequest
         {
             UserRequestorId = LoggedUser != null ? LoggedUser.Id : string.Empty,
-            Description = @$"Funds transferred from {_sourceWalletName} to {_targetWalletName}",
+            Description = $"Funds transferred from {_sourceWalletName} to {_targetWalletName}",
             WithdrawAllFunds = _transferAllFunds,
             DestinationAddress = targetBitcoinAddress.ToString(),
             MempoolRecommendedFeesType = MempoolRecommendedFeesType.HourFee,

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -1107,7 +1107,7 @@ namespace NodeGuard.Rpc
             };
 
             nodeRepositoryMock.Setup(repo => repo.GetAll()).ReturnsAsync(sampleNodes);
-            nodeRepositoryMock.Setup(repo => repo.GetAllManagedByNodeGuard()).ReturnsAsync(new List<Node>());
+            nodeRepositoryMock.Setup(repo => repo.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(new List<Node>());
 
             var service = new NodeGuardService(
                 _logger.Object, new Mock<ILiquidityRuleRepository>().Object,
@@ -1135,7 +1135,7 @@ namespace NodeGuard.Rpc
             // Assert
             response.Nodes.Count.Should().Be(sampleNodes.Count);
             nodeRepositoryMock.Verify(repo => repo.GetAll(), Times.Once);
-            nodeRepositoryMock.Verify(repo => repo.GetAllManagedByNodeGuard(), Times.Never);
+            nodeRepositoryMock.Verify(repo => repo.GetAllManagedByNodeGuard(It.IsAny<bool>()), Times.Never);
         }
 
         [Fact]
@@ -1150,7 +1150,7 @@ namespace NodeGuard.Rpc
             };
 
             nodeRepositoryMock.Setup(repo => repo.GetAll()).ReturnsAsync(new List<Node>());
-            nodeRepositoryMock.Setup(repo => repo.GetAllManagedByNodeGuard()).ReturnsAsync(sampleNodes);
+            nodeRepositoryMock.Setup(repo => repo.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(sampleNodes);
 
             var service = new NodeGuardService(
                 _logger.Object, new Mock<ILiquidityRuleRepository>().Object,
@@ -1178,7 +1178,7 @@ namespace NodeGuard.Rpc
             // Assert
             response.Nodes.Count.Should().Be(sampleNodes.Count);
             nodeRepositoryMock.Verify(repo => repo.GetAll(), Times.Never);
-            nodeRepositoryMock.Verify(repo => repo.GetAllManagedByNodeGuard(), Times.Once);
+            nodeRepositoryMock.Verify(repo => repo.GetAllManagedByNodeGuard(It.IsAny<bool>()), Times.Once);
         }
 
 

--- a/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
@@ -571,7 +571,7 @@ public class BitcoinServiceTests
             .Setup(x => x.BroadcastAsync(It.IsAny<Transaction>(), default, default))
             .ReturnsAsync(new BroadcastResult() { Success = true });
         nodeRepository
-            .Setup(x => x.GetAllManagedByNodeGuard())
+            .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
             .Returns(Task.FromResult(new List<Node>() {node}));
         var bitcoinService = new BitcoinService(_logger, null, walletWithdrawalRequestRepository.Object, null, nodeRepository.Object, null, nbXplorerService.Object, null);
 
@@ -651,7 +651,7 @@ public class BitcoinServiceTests
             .Setup(x => x.BroadcastAsync(It.IsAny<Transaction>(), default, default))
             .ReturnsAsync(new BroadcastResult() { Success = true });
         nodeRepository
-            .Setup(x => x.GetAllManagedByNodeGuard())
+            .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
             .Returns(Task.FromResult(new List<Node>() {node}));
         var bitcoinService = new BitcoinService(_logger, null, walletWithdrawalRequestRepository.Object, null, nodeRepository.Object, null, nbXplorerService.Object, null);
 
@@ -731,7 +731,7 @@ public class BitcoinServiceTests
             .Setup(x => x.BroadcastAsync(It.IsAny<Transaction>(), default, default))
             .ReturnsAsync(new BroadcastResult() { Success = true });
         nodeRepository
-            .Setup(x => x.GetAllManagedByNodeGuard())
+            .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
             .Returns(Task.FromResult(new List<Node>() {node}));
         var bitcoinService = new BitcoinService(_logger, null, walletWithdrawalRequestRepository.Object, null, nodeRepository.Object, null, nbXplorerService.Object, null);
 

--- a/test/NodeGuard.Tests/Services/LightningServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningServiceTests.cs
@@ -406,7 +406,7 @@ namespace NodeGuard.Services
             var nodes = new List<Node> { destinationNode };
 
             nodeRepository
-                .Setup(x => x.GetAllManagedByNodeGuard())
+                .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
                 .Returns(Task.FromResult(nodes));
 
             var lightningClientService = new Mock<ILightningClientService>();
@@ -597,7 +597,7 @@ namespace NodeGuard.Services
             var nodes = new List<Node> { destinationNode };
 
             nodeRepository
-                .Setup(x => x.GetAllManagedByNodeGuard())
+                .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
                 .Returns(Task.FromResult(nodes));
 
             var lightningClient = new Mock<ILightningClientService>();
@@ -810,7 +810,7 @@ namespace NodeGuard.Services
             var nodes = new List<Node> { destinationNode };
 
             nodeRepository
-                .Setup(x => x.GetAllManagedByNodeGuard())
+                .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
                 .Returns(Task.FromResult(nodes));
 
             var lightningClient = new Mock<ILightningClientService>();
@@ -1029,7 +1029,7 @@ namespace NodeGuard.Services
             var nodes = new List<Node> { destinationNode };
 
             nodeRepository
-                .Setup(x => x.GetAllManagedByNodeGuard())
+                .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
                 .Returns(Task.FromResult(nodes));
 
             var lightningClient = new Mock<ILightningClientService>();
@@ -1242,7 +1242,7 @@ namespace NodeGuard.Services
             var nodes = new List<Node> { destinationNode };
 
             nodeRepository
-                .Setup(x => x.GetAllManagedByNodeGuard())
+                .Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()))
                 .Returns(Task.FromResult(nodes));
 
             var lightningClient = new Mock<ILightningClientService>();
@@ -1588,7 +1588,7 @@ namespace NodeGuard.Services
             var nodeRepository = new Mock<INodeRepository>();
             var lightningClientService = new Mock<ILightningClientService>();
 
-            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard()).ReturnsAsync(
+            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(
                 new List<Node>()
                 {
                     new()
@@ -1632,7 +1632,7 @@ namespace NodeGuard.Services
             var nodeRepository = new Mock<INodeRepository>();
             var lightningClientService = new Mock<ILightningClientService>();
 
-            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard()).ReturnsAsync(
+            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(
                 new List<Node>()
                 {
                     new()
@@ -1676,7 +1676,7 @@ namespace NodeGuard.Services
             var nodeRepository = new Mock<INodeRepository>();
             var lightningClientService = new Mock<ILightningClientService>();
 
-            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard()).ReturnsAsync(
+            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(
                 new List<Node>()
                 {
                     new()
@@ -1743,7 +1743,7 @@ namespace NodeGuard.Services
             var nodeRepository = new Mock<INodeRepository>();
             var lightningClientService = new Mock<ILightningClientService>();
 
-            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard()).ReturnsAsync(
+            nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>())).ReturnsAsync(
                 new List<Node>()
                 {
                     new()


### PR DESCRIPTION
Nodes that are disabled, remove the jobs that are currently running but if there is a restart on nodeguard, all jobs
start again, even for those disabled nodes. Also incremented retry interval to 5 seconds
