### PR TITLE
Update schedule interval to 1 hour for SweepAllNodesWalletsJob

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -222,7 +222,7 @@ namespace NodeGuard
                         .WithIdentity($"{nameof(SweepAllNodesWalletsJob)}Trigger")
                         .StartNow().WithSimpleSchedule(scheduleBuilder =>
                         {
-                            scheduleBuilder.WithIntervalInMinutes(1).RepeatForever();
+                            scheduleBuilder.WithIntervalInMinutes(60).RepeatForever();
                         });
                 });
 


### PR DESCRIPTION
This pull request updates the schedule interval for the `SweepAllNodesWalletsJob` to 1 hour. Previously, it was set to 1 minute. This change ensures that the job runs less frequently, reducing unnecessary resource consumption.