### PR TITLE
Fix outputs for sweep transactions

### DIFF
--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -75,6 +75,7 @@ public class Constants
     public static readonly decimal MAXIMUM_WITHDRAWAL_BTC_AMOUNT = 21_000_000;
     public static readonly int TRANSACTION_CONFIRMATION_MINIMUM_BLOCKS;
     public static readonly long ANCHOR_CLOSINGS_MINIMUM_SATS;
+    public static readonly long MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS = 5_000_000; //5M sats
     public static readonly string DEFAULT_DERIVATION_PATH = "48'/1'";
     public static readonly int SESSION_TIMEOUT_MILLISECONDS = 3_600_000;
 
@@ -85,6 +86,11 @@ public class Constants
     /// Max ratio of the tx total input sum that could be used as fee
     /// </summary>
     public static decimal MAX_TX_FEE_RATIO = 0.5m;
+
+    /// <summary>
+    /// The target number of confirmations blocks (fee rate) for the sweep transaction
+    /// </summary>
+    public static int SWEEP_CONF_TARGET = 6;
 
     public const string IsFrozenTag = "frozen";
     public const string IsManuallyFrozenTag = "manually_frozen";
@@ -216,6 +222,13 @@ public class Constants
 
         var anchorClosingMinSats = GetEnvironmentalVariableOrThrowIfNotTesting("ANCHOR_CLOSINGS_MINIMUM_SATS");
         if (anchorClosingMinSats != null) ANCHOR_CLOSINGS_MINIMUM_SATS = long.Parse(anchorClosingMinSats); // Check https://github.com/lightningnetwork/lnd/issues/6505#issuecomment-1120364460 to understand, we need 100K+ to support anchor channel closings
+
+        var sweepConfTarget = Environment.GetEnvironmentVariable("SWEEP_CONF_TARGET");
+        if (sweepConfTarget != null) SWEEP_CONF_TARGET = int.Parse(sweepConfTarget);
+
+        var minSweepTransactionAmount = Environment.GetEnvironmentVariable("MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS");
+        if (minSweepTransactionAmount != null) MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS = long.Parse(minSweepTransactionAmount);
+
 
         DEFAULT_DERIVATION_PATH = GetEnvironmentalVariableOrThrowIfNotTesting("DEFAULT_DERIVATION_PATH") ?? DEFAULT_DERIVATION_PATH;
 

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -75,7 +75,7 @@ public class Constants
     public static readonly decimal MAXIMUM_WITHDRAWAL_BTC_AMOUNT = 21_000_000;
     public static readonly int TRANSACTION_CONFIRMATION_MINIMUM_BLOCKS;
     public static readonly long ANCHOR_CLOSINGS_MINIMUM_SATS;
-    public static readonly long MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS = 5_000_000; //5M sats
+    public static readonly long MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS = 25_000_000; //25M sats
     public static readonly string DEFAULT_DERIVATION_PATH = "48'/1'";
     public static readonly int SESSION_TIMEOUT_MILLISECONDS = 3_600_000;
 


### PR DESCRIPTION
This pull request adds two constants that sets a minimum amount for a sweep tx to be created and the conf target in blocks.

It also removes the bug where we could create dust utxos because of LND change, before we create three outputs as in this picture:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/38758498-5e6f-4d8e-ac07-595cf6c728db">

Now this shall be more efficient as only two utxos are created, however, there must be always a 100K utxo in the wallet at all times, we no longer create it programatically but this is just ops things.
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/aad2be54-4bb8-4188-b4ca-b83fd5b36606">
