### PR TITLE
Add support for multiple withdrawal destinations and deprecate old fields

### DIFF
--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -123,11 +123,18 @@ message GetNewWalletAddressResponse {
   string address = 1;
 }
 
+message Destination {
+  // BTC address to send the funds to
+  string address = 1;
+  // Amount in satoshis
+  int64 amount_sats = 2;
+}
+
 message RequestWithdrawalRequest {
   int32 wallet_id = 1;
-  string address = 2;
+  string address = 2 [deprecated = true];
   // Amount in satoshis
-  int64 amount = 3;
+  int64 amount = 3 [deprecated = true];
   string description = 4;
   // in JSON format
   string request_metadata = 5;
@@ -141,6 +148,8 @@ message RequestWithdrawalRequest {
   optional int32 custom_fee_rate = 9;
   // External reference id for the withdrawal request
   optional string reference_id = 10;
+  // Destinations for the withdrawal
+  repeated Destination destinations = 11;
 }
 
 message RequestWithdrawalResponse {

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -289,8 +289,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
 
             // Template PSBT generation with SIGHASH_ALL
             var psbt = await _bitcoinService.GenerateTemplatePSBT(withdrawalRequest ??
-                                                                  throw new ArgumentException(
-                                                                      nameof(withdrawalRequest)));
+            throw new ArgumentException(nameof(withdrawalRequest)));
 
             // If the wallet is hot, we send the withdrawal request to the embedded or remote signer
             if (wallet.IsHotWallet)

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -632,9 +632,13 @@ namespace NodeGuard.Rpc
             var requestWithdrawalRequest = new RequestWithdrawalRequest
             {
                 WalletId = wallet.Id,
-                Amount = 100,
                 Description = $"Request Withdrawal Test {DateTime.Now}",
-                Address = "bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal",
+                Destinations = { new Destination
+                {
+                    Address = "bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal",
+                    AmountSats = new Money(1, MoneyUnit.BTC).Satoshi
+                }
+                }
             };
 
             //Act


### PR DESCRIPTION
Introduce a new `Destination` message to handle multiple withdrawal addresses and amounts.

 Deprecate the old single address and amount fields in the withdrawal request. Implement validation for withdrawal destinations to ensure proper input. 

Update the withdrawal processing logic to accommodate multiple destinations.