### PR TITLE
Filter UTXOs by wallet for sending ignoreOutputs to nbxplorer

### DIFF
--- a/src/Data/Repositories/FUTXORepository.cs
+++ b/src/Data/Repositories/FUTXORepository.cs
@@ -144,5 +144,31 @@ namespace NodeGuard.Data.Repositories
 
             return result;
         }
+        
+        public async Task<List<FMUTXO>> GetLockedUTXOsByWalletId(int walletId)
+        {
+            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            var walletWithdrawalRequestsLockedUTXOs = await applicationDbContext.WalletWithdrawalRequests
+                    .Include(x => x.UTXOs)
+                    .Where(x => x.Status == WalletWithdrawalRequestStatus.Pending ||
+                                x.Status == WalletWithdrawalRequestStatus.PSBTSignaturesPending ||
+                                x.Status == WalletWithdrawalRequestStatus.FinalizingPSBT ||
+                                x.Status == WalletWithdrawalRequestStatus.OnChainConfirmationPending)
+                    .Where(x => x.WalletId == walletId)
+                    .SelectMany(x => x.UTXOs)
+                    .ToListAsync();
+
+            var channelOperationRequestsLockedUTXOs = await applicationDbContext.ChannelOperationRequests.Include(x => x.Utxos)
+                    .Where(x => x.Status == ChannelOperationRequestStatus.Pending ||
+                                x.Status == ChannelOperationRequestStatus.PSBTSignaturesPending ||
+                                x.Status == ChannelOperationRequestStatus.FinalizingPSBT ||
+                                x.Status == ChannelOperationRequestStatus.OnChainConfirmationPending)
+                    .Where(x => x.WalletId == walletId)
+                    .SelectMany(x => x.Utxos)
+                    .ToListAsync();
+
+            return walletWithdrawalRequestsLockedUTXOs.Union(channelOperationRequestsLockedUTXOs).ToList();
+        }
     }
 }

--- a/src/Data/Repositories/Interfaces/IFMUTXORepository.cs
+++ b/src/Data/Repositories/Interfaces/IFMUTXORepository.cs
@@ -42,4 +42,5 @@ public interface IFMUTXORepository
     /// </summary>
     /// <returns></returns>
     Task<List<FMUTXO>> GetLockedUTXOs(int? ignoredWalletWithdrawalRequestId = null, int? ignoredChannelOperationRequestId = null);
+    Task<List<FMUTXO>> GetLockedUTXOsByWalletId(int walletId);
 }


### PR DESCRIPTION
Right now when we are going to get the available utxos for a specific wallet, the nodeguard gets all locked and frozen utxos from ALL wallets, and send them as an "ignoreOutput" to the nbxplorer. This makes the uri request be so long that it fails. This PR mitigates the problem by only sending the ignored outputs relevant to the wallet in question.

The real solution will be to modify the Nbxplorer endpoint to receive the ignored outputs in the body of a POST request