### PR TITLE
Add ClosedAt column to Channels table and update timestamp on closure

### DIFF
--- a/src/Data/Models/Channel.cs
+++ b/src/Data/Models/Channel.cs
@@ -48,6 +48,12 @@ namespace NodeGuard.Data.Models
         public ChannelStatus Status { get; set; }
 
         /// <summary>
+        /// Timestamp at which the channel transitioned to <see cref="ChannelStatus.Closed"/>.
+        /// Null while the channel is open or for channels closed before this column existed.
+        /// </summary>
+        public DateTimeOffset? ClosedAt { get; set; }
+
+        /// <summary>
         /// Indicates if this channel was created by NodeGuard
         /// </summary>
         public bool CreatedByNodeGuard { get; set; }

--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -186,6 +186,8 @@ namespace NodeGuard.Data.Repositories
         {
             using var applicationDbContext = _dbContextFactory.CreateDbContext();
 
+            type.SetUpdateDatetime();
+
             //Automapper to avoid creation of entities
             type = _mapper.Map<Channel, Channel>(type);
 
@@ -340,6 +342,7 @@ namespace NodeGuard.Data.Repositories
             }
 
             channel.Status = Channel.ChannelStatus.Closed;
+            channel.ClosedAt = DateTimeOffset.UtcNow;
 
             var markAsClosed = _repository.Update(channel, applicationDbContext);
 

--- a/src/Jobs/ChannelMonitorJob.cs
+++ b/src/Jobs/ChannelMonitorJob.cs
@@ -206,6 +206,7 @@ public class ChannelMonitorJob : IJob
                 if (channel == null)
                 {
                     openChannel.Status = ChannelStatus.Closed;
+                    openChannel.ClosedAt = DateTimeOffset.UtcNow;
                     await dbContext.SaveChangesAsync();
                 }
             }

--- a/src/Jobs/NodeChannelSubscribeJob.cs
+++ b/src/Jobs/NodeChannelSubscribeJob.cs
@@ -166,6 +166,7 @@ public class NodeChannelSuscribeJob : IJob
                 else
                 {
                     channelToClose.Status = Channel.ChannelStatus.Closed;
+                    channelToClose.ClosedAt = DateTimeOffset.UtcNow;
                     var updateChannel = _channelRepository.Update(channelToClose);
                     if (!updateChannel.Item1)
                     {

--- a/src/Migrations/20260430155542_AddChannelClosedAt.Designer.cs
+++ b/src/Migrations/20260430155542_AddChannelClosedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430155542_AddChannelClosedAt")]
+    partial class AddChannelClosedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260430155542_AddChannelClosedAt.cs
+++ b/src/Migrations/20260430155542_AddChannelClosedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChannelClosedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ClosedAt",
+                table: "Channels",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClosedAt",
+                table: "Channels");
+        }
+    }
+}

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -1301,6 +1301,7 @@ namespace NodeGuard.Services
                                     }
 
                                     channel.Status = Channel.ChannelStatus.Closed;
+                                    channel.ClosedAt = DateTimeOffset.UtcNow;
 
                                     var updateChannelResult = _channelRepository.Update(channel);
 
@@ -1331,6 +1332,7 @@ namespace NodeGuard.Services
                         if (channel != null)
                         {
                             channel.Status = Channel.ChannelStatus.Closed;
+                            channel.ClosedAt = DateTimeOffset.UtcNow;
 
                             _channelRepository.Update(channel);
                             _logger.LogInformation(


### PR DESCRIPTION
Introduce a new `ClosedAt` column to the Channels table to track when a channel is closed. Update the timestamp for this column whenever a channel's status is changed to closed.