### PR TITLE
Add PaymentHashHex column to Rebalances table

### DIFF
--- a/src/Data/Models/Rebalance.cs
+++ b/src/Data/Models/Rebalance.cs
@@ -105,6 +105,13 @@ public class Rebalance : Entity
     public string? TargetPubkey { get; set; }
 
     /// <summary>
+    /// Payment hash of the self-invoice. Persisted as soon as the invoice is created so the
+    /// reconciliation job can call <c>Router.TrackPaymentV2</c> after a crash / cancellation
+    /// and resolve the true outcome against LND.
+    /// </summary>
+    public string? PaymentHashHex { get; set; }
+
+    /// <summary>
     /// Persisted for forensic / proof-of-payment lookup; intentionally not exposed via gRPC.
     /// </summary>
     public string? PreimageHex { get; set; }

--- a/src/Data/Repositories/Interfaces/IRebalanceRepository.cs
+++ b/src/Data/Repositories/Interfaces/IRebalanceRepository.cs
@@ -38,10 +38,15 @@ public interface IRebalanceRepository
         DateTimeOffset? toDate = null);
 
     /// <summary>
-    /// Get all rebalances currently in flight (Pending/Probing/InFlight). Used by the
-    /// monitor job for stale-state cleanup after process restart.
+    /// Returns rebalances the monitor job should reconcile against LND:
+    /// non-terminal rows (Pending/Probing/InFlight) plus recently-marked terminal failures
+    /// within <paramref name="recentTerminalWindow"/>. Only rows with a stored payment hash
+    /// are returned — without a hash there is nothing to look up in LND.
+    /// The recent-terminal sweep exists because the catch-all in RebalanceService can mark
+    /// a row Failed on transient errors (cancellation, RPC timeout) while LND has actually
+    /// settled the payment. Includes Node so the caller can call LND directly.
     /// </summary>
-    Task<List<Rebalance>> GetAllInFlight();
+    Task<List<Rebalance>> GetReconcilable(TimeSpan recentTerminalWindow);
 
     Task<(bool, string?)> AddAsync(Rebalance rebalance);
 

--- a/src/Data/Repositories/RebalanceRepository.cs
+++ b/src/Data/Repositories/RebalanceRepository.cs
@@ -101,14 +101,23 @@ public class RebalanceRepository : IRebalanceRepository
         return (rebalances, totalCount);
     }
 
-    public async Task<List<Rebalance>> GetAllInFlight()
+    public async Task<List<Rebalance>> GetReconcilable(TimeSpan recentTerminalWindow)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
+        var terminalCutoff = DateTimeOffset.UtcNow - recentTerminalWindow;
+
         return await context.Rebalances
-            .Where(r => r.Status == RebalanceStatus.Pending
-                        || r.Status == RebalanceStatus.Probing
-                        || r.Status == RebalanceStatus.InFlight)
+            .Include(r => r.Node)
+            .Where(r => r.PaymentHashHex != null
+                        && (r.Status == RebalanceStatus.Pending
+                            || r.Status == RebalanceStatus.Probing
+                            || r.Status == RebalanceStatus.InFlight
+                            || ((r.Status == RebalanceStatus.Failed
+                                 || r.Status == RebalanceStatus.Timeout
+                                 || r.Status == RebalanceStatus.NoRoute
+                                 || r.Status == RebalanceStatus.InsufficientBalance)
+                                && r.UpdateDatetime >= terminalCutoff)))
             .ToListAsync();
     }
 

--- a/src/Migrations/20260513103017_AddRebalancePaymentHashHex.Designer.cs
+++ b/src/Migrations/20260513103017_AddRebalancePaymentHashHex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513103017_AddRebalancePaymentHashHex")]
+    partial class AddRebalancePaymentHashHex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260513103017_AddRebalancePaymentHashHex.cs
+++ b/src/Migrations/20260513103017_AddRebalancePaymentHashHex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRebalancePaymentHashHex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentHashHex",
+                table: "Rebalances",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentHashHex",
+                table: "Rebalances");
+        }
+    }
+}


### PR DESCRIPTION
Stacked PRs:
 * #513
 * #512
 * __->__#511
 * #510


--- --- ---

### Add PaymentHashHex column to Rebalances table


- Introduced a new column 'PaymentHashHex' of type text in the 'Rebalances' table to store payment hash information.
- Updated the ApplicationDbContextModelSnapshot to reflect the new column in the model.
