### PR TITLE
Fix FailureString on HTLC events longer than 1024 chars

### DIFF
--- a/src/Data/Models/ForwardingHtlcEvent.cs
+++ b/src/Data/Models/ForwardingHtlcEvent.cs
@@ -71,7 +71,7 @@ public class ForwardingHtlcEvent
     public int? WireFailureCode { get; set; }
     public int? FailureDetail { get; set; }
 
-    [MaxLength(1024)]
+    [MaxLength(2048)]
     public string? FailureString { get; set; }
 }
 

--- a/src/Jobs/NodeHtlcSubscribeJob.cs
+++ b/src/Jobs/NodeHtlcSubscribeJob.cs
@@ -181,7 +181,7 @@ public class NodeHtlcSubscribeJob : IJob
             FeeMsat = CalculateNetFeeMsat(info?.IncomingAmtMsat, info?.OutgoingAmtMsat),
             WireFailureCode = htlcEvent.LinkFailEvent != null ? (int)htlcEvent.LinkFailEvent.WireFailure : null,
             FailureDetail = htlcEvent.LinkFailEvent != null ? (int)htlcEvent.LinkFailEvent.FailureDetail : null,
-            FailureString = htlcEvent.LinkFailEvent?.FailureString,
+            FailureString = TruncateFailureString(htlcEvent.LinkFailEvent?.FailureString),
         };
     }
 
@@ -397,6 +397,22 @@ public class NodeHtlcSubscribeJob : IJob
         }
 
         return feeMsat.Value - grossFeeMsat.Value;
+    }
+
+    // FailureString is persisted to a character varying(2048) column. lnd can emit failure
+    // descriptions longer than that, so when the value reaches the column limit we keep the
+    // first 2044 characters and append an ellipsis (2044 + 3 = 2047, within the 2048 bound).
+    private const int FailureStringMaxLength = 2048;
+    private const string FailureStringEllipsis = "...";
+
+    private static string? TruncateFailureString(string? value)
+    {
+        if (value is null || value.Length < FailureStringMaxLength)
+        {
+            return value;
+        }
+
+        return string.Concat(value.AsSpan(0, FailureStringMaxLength - FailureStringEllipsis.Length - 1), FailureStringEllipsis);
     }
 
     internal static DateTimeOffset MapEventTimestamp(ulong timestampNs)

--- a/src/Migrations/20260629075424_ForwardingHtlcEventFailureStringLength.Designer.cs
+++ b/src/Migrations/20260629075424_ForwardingHtlcEventFailureStringLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629075424_ForwardingHtlcEventFailureStringLength")]
+    partial class ForwardingHtlcEventFailureStringLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260629075424_ForwardingHtlcEventFailureStringLength.cs
+++ b/src/Migrations/20260629075424_ForwardingHtlcEventFailureStringLength.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class ForwardingHtlcEventFailureStringLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FailureString",
+                table: "ForwardingHtlcEvents",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FailureString",
+                table: "ForwardingHtlcEvents",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+        }
+    }
+}

--- a/test/NodeGuard.Tests/Jobs/NodeHtlcSubscribeJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/NodeHtlcSubscribeJobTests.cs
@@ -237,4 +237,63 @@ public class NodeHtlcSubscribeJobTests
         result.RoutingFeePpm.Should().Be(100000);
         result.InboundFeePpm.Should().Be(-50000);
     }
+
+    [Fact]
+    public void MapForwardingEvent_WhenFailureStringReachesColumnLimit_TruncatesAndAppendsEllipsis()
+    {
+        // Arrange
+        var longFailureString = new string('x', 5000);
+        var htlcEvent = new HtlcEvent
+        {
+            EventType = HtlcEvent.Types.EventType.Forward,
+            TimestampNs = 1_735_689_600_000_000_000,
+            IncomingChannelId = 1001,
+            OutgoingChannelId = 1002,
+            IncomingHtlcId = 1003,
+            OutgoingHtlcId = 1004,
+            LinkFailEvent = new LinkFailEvent
+            {
+                FailureDetail = FailureDetail.InsufficientBalance,
+                WireFailure = Failure.Types.FailureCode.TemporaryChannelFailure,
+                FailureString = longFailureString
+            }
+        };
+
+        // Act
+        var result = NodeHtlcSubscribeJob.MapForwardingEvent(ManagedNode, htlcEvent);
+
+        // Assert: 2044 preserved characters + "..." == 2047, within the varchar(2048) column.
+        result.Should().NotBeNull();
+        result!.FailureString.Should().HaveLength(2047);
+        result.FailureString.Should().Be(new string('x', 2044) + "...");
+    }
+
+    [Fact]
+    public void MapForwardingEvent_WhenFailureStringFitsColumn_IsNotTruncated()
+    {
+        // Arrange: a value just under the 2048 limit must be stored verbatim.
+        var failureString = new string('x', 2047);
+        var htlcEvent = new HtlcEvent
+        {
+            EventType = HtlcEvent.Types.EventType.Forward,
+            TimestampNs = 1_735_689_600_000_000_000,
+            IncomingChannelId = 1001,
+            OutgoingChannelId = 1002,
+            IncomingHtlcId = 1003,
+            OutgoingHtlcId = 1004,
+            LinkFailEvent = new LinkFailEvent
+            {
+                FailureDetail = FailureDetail.InsufficientBalance,
+                WireFailure = Failure.Types.FailureCode.TemporaryChannelFailure,
+                FailureString = failureString
+            }
+        };
+
+        // Act
+        var result = NodeHtlcSubscribeJob.MapForwardingEvent(ManagedNode, htlcEvent);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.FailureString.Should().Be(failureString);
+    }
 }


### PR DESCRIPTION
Fix for spotted noisy errors like https://app.datadoghq.eu/logs?query=cluster_name%3Aelenpay-production%20-service%3Atraefik%20service%3Anodeguard&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ8KXRwwXBWr2wAAABhBWjhLWFRCQUFBQThuanhiZkZJXzRBQUMAAABdMTE5ZjBhYWEtZTVmMC00OWI3LWIxNDMtODI1MzRhOGE2ODM3LXN5bnRoZXRpYy10aW1lLTE3ODI1ODMyMDAwMDAwMDAwMDBjLTE3ODI1OTAzOTk5ODQwMDAwMDFvAAL_iQ&messageDisplay=inline&refresh_mode=paused&saved-view-id=219284&storage=hot&stream_sort=desc&viz=stream&from_ts=1782584400000&to_ts=1782585600000&live=false

