### PR TITLE
Add PaymentRequest column for rebalancing V2

### DIFF
--- a/src/Data/Models/Rebalance.cs
+++ b/src/Data/Models/Rebalance.cs
@@ -112,6 +112,13 @@ public class Rebalance : Entity
     public string? PaymentHashHex { get; set; }
 
     /// <summary>
+    /// The (amountless) self-invoice bolt11. Created once on the first attempt and reused on
+    /// every retry, so the whole rebalance settles against a single payment hash. The amount
+    /// paid is set per attempt on SendPaymentV2, not encoded in the invoice.
+    /// </summary>
+    public string? PaymentRequest { get; set; }
+
+    /// <summary>
     /// Persisted for forensic / proof-of-payment lookup; intentionally not exposed via gRPC.
     /// </summary>
     public string? PreimageHex { get; set; }

--- a/src/Migrations/20260630104247_AddRebalancePaymentRequest.Designer.cs
+++ b/src/Migrations/20260630104247_AddRebalancePaymentRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630104247_AddRebalancePaymentRequest")]
+    partial class AddRebalancePaymentRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260630104247_AddRebalancePaymentRequest.cs
+++ b/src/Migrations/20260630104247_AddRebalancePaymentRequest.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRebalancePaymentRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentRequest",
+                table: "Rebalances",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentRequest",
+                table: "Rebalances");
+        }
+    }
+}


### PR DESCRIPTION
Stacked PRs:
 * #528
 * #527
 * __->__#526
 * #525


--- --- ---

### Add PaymentRequest column for rebalancing V2


Additive-only: a nullable bolt11 self-invoice column on Rebalances, set at
runtime by RebalanceService so every retry settles against a single payment
hash. No behavioural change; existing rebalancing (probing) is untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>