### PR TITLE
feat: FeeOptimizerService + positive inbound fees (routing engine Phase 2a)

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -135,6 +135,7 @@ namespace NodeGuard
             builder.Services.AddSingleton<ILightningClientService, LightningClientService>();
             builder.Services.AddSingleton<ILightningRouterService, LightningRouterService>();
             builder.Services.AddSingleton<IPeerCategorizationService, PeerCategorizationService>();
+            builder.Services.AddSingleton<IFeeOptimizerService, FeeOptimizerService>();
             builder.Services.AddSingleton<ILoopService, LoopService>();
             builder.Services.AddSingleton<IFortySwapService, FortySwapService>();
 

--- a/src/Services/FeeOptimizerService.cs
+++ b/src/Services/FeeOptimizerService.cs
@@ -1,0 +1,203 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using NodeGuard.Data.Models;
+using NodeGuard.Helpers;
+
+namespace NodeGuard.Services;
+
+/// <summary>
+/// What the fee optimizer decided to do this cycle for a single channel.
+/// </summary>
+public enum FeeAction
+{
+    /// <summary>Inside the fee deadband (or computed delta below the min-delta dead-zone) — leave fees as they are.</summary>
+    NoOp = 0,
+
+    /// <summary>|deviation| exceeds the rebalance deadband — the rebalancer owns this channel, the fee engine must not touch it.</summary>
+    DeferToRebalancer = 1,
+
+    /// <summary>Apply the new outbound/inbound ppm.</summary>
+    Update = 2,
+}
+
+/// <summary>
+/// Result of one <see cref="IFeeOptimizerService.ComputeNextPolicy"/> call. For <see cref="FeeAction.Update"/>,
+/// <see cref="OutboundPpm"/>/<see cref="InboundPpm"/> are the values to apply; for NoOp/DeferToRebalancer they
+/// echo the current (unchanged) values so the caller can log a coherent "would-keep" line.
+/// </summary>
+public record FeePolicyDecision(FeeAction Action, uint OutboundPpm, int InboundPpm, string Reason);
+
+/// <summary>
+/// Control-law tunables for <see cref="IFeeOptimizerService.ComputeNextPolicy"/>. Passed in explicitly so the
+/// decision logic stays pure and unit-testable; <see cref="FromConstants"/> is the production wiring.
+/// </summary>
+public record FeeOptimizerTunables(
+    double KpOut,
+    double Ki,
+    double FeeDeadband,
+    double RebalanceDeadband,
+    uint MaxStepPpm,
+    uint MaxInboundStepPpm,
+    uint MinDeltaPpm,
+    uint MinOutboundPpm,
+    uint MaxOutboundPpm,
+    int MinInboundPpm,
+    int MaxInboundPpm,
+    uint BaselineSourcePpm,
+    uint BaselineBidirectionalPpm,
+    uint BaselineSinkPpm,
+    uint BaselineUncategorizedPpm)
+{
+    /// <summary>Builds the tunable set from the ROUTING_ENGINE_FEE_* constants (the production configuration).</summary>
+    public static FeeOptimizerTunables FromConstants() => new(
+        KpOut: Constants.ROUTING_ENGINE_FEE_KP_OUT,
+        Ki: Constants.ROUTING_ENGINE_FEE_KI,
+        FeeDeadband: Constants.ROUTING_ENGINE_FEE_DEADBAND,
+        RebalanceDeadband: Constants.ROUTING_ENGINE_REBALANCE_DEADBAND,
+        MaxStepPpm: Constants.ROUTING_ENGINE_FEE_MAX_STEP_PPM,
+        MaxInboundStepPpm: Constants.ROUTING_ENGINE_FEE_MAX_INBOUND_STEP_PPM,
+        MinDeltaPpm: Constants.ROUTING_ENGINE_FEE_MIN_DELTA_PPM,
+        MinOutboundPpm: Constants.ROUTING_ENGINE_FEE_MIN_OUTBOUND_PPM,
+        MaxOutboundPpm: Constants.ROUTING_ENGINE_FEE_MAX_OUTBOUND_PPM,
+        MinInboundPpm: Constants.ROUTING_ENGINE_FEE_MIN_INBOUND_PPM,
+        MaxInboundPpm: Constants.ROUTING_ENGINE_FEE_MAX_INBOUND_PPM,
+        BaselineSourcePpm: Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_SOURCE,
+        BaselineBidirectionalPpm: Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_BIDIRECTIONAL,
+        BaselineSinkPpm: Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_SINK,
+        BaselineUncategorizedPpm: (uint)Constants.DEFAULT_CHANNEL_FEE_POLICY_FEE_RATE_PPM);
+}
+
+public interface IFeeOptimizerService
+{
+    /// <summary>
+    /// Proportional control on the EMA-smoothed local ratio, driving both outbound ppm and (signed)
+    /// inbound ppm toward the channel's target. Pure — no I/O, no clock, no DB.
+    /// <para>
+    /// With <c>d = emaLocalRatio - targetLocalRatio</c>:
+    /// <list type="bullet">
+    /// <item><c>|d| &gt; rebalanceDeadband</c> → <see cref="FeeAction.DeferToRebalancer"/> (authority split).</item>
+    /// <item><c>|d| ≤ feeDeadband</c> → <see cref="FeeAction.NoOp"/>.</item>
+    /// <item><c>d &gt; 0</c> (too local): lower outbound to attract exits, positive inbound to repel entry.</item>
+    /// <item><c>d &lt; 0</c> (too remote): raise outbound to preserve local, negative inbound to attract entry.</item>
+    /// </list>
+    /// The category baseline (p₀) both scales the proportional term and seeds the "last" values on the
+    /// first evaluation of a channel, so a freshly categorized off-target channel jumps toward its
+    /// category baseline and then fine-tunes within the per-step clamp.
+    /// </para>
+    /// </summary>
+    /// <param name="emaLocalRatio">Pre-smoothed local/(local+remote) ratio from ChannelRoutingState.</param>
+    /// <param name="targetLocalRatio">Dynamic target ratio from ChannelRoutingState.</param>
+    /// <param name="category">Peer flow category — selects the outbound baseline p₀.</param>
+    /// <param name="lastOutboundPpm">Last-applied outbound ppm (ChannelFeeState); null on first eval → seeded with p₀.</param>
+    /// <param name="lastInboundPpm">Last-applied inbound ppm (ChannelFeeState); null on first eval → seeded with 0.</param>
+    /// <param name="allowPositiveInboundFees">When false, inbound is collapsed to ≤ 0 regardless of direction.</param>
+    /// <param name="tunables">Control-law constants.</param>
+    FeePolicyDecision ComputeNextPolicy(
+        double emaLocalRatio,
+        double targetLocalRatio,
+        PeerFlowCategory category,
+        uint? lastOutboundPpm,
+        int? lastInboundPpm,
+        bool allowPositiveInboundFees,
+        FeeOptimizerTunables tunables);
+}
+
+public class FeeOptimizerService : IFeeOptimizerService
+{
+    public FeePolicyDecision ComputeNextPolicy(
+        double emaLocalRatio,
+        double targetLocalRatio,
+        PeerFlowCategory category,
+        uint? lastOutboundPpm,
+        int? lastInboundPpm,
+        bool allowPositiveInboundFees,
+        FeeOptimizerTunables tunables)
+    {
+        var p0 = BaselineFor(category, tunables);
+        // Seed the initial category "jump": with no last-applied value, start from the category
+        // baseline so the first actionable write lands near p₀ rather than crawling from the
+        // operator's pre-engine fee.
+        var pLast = lastOutboundPpm ?? p0;
+        var iLast = lastInboundPpm ?? 0;
+
+        var d = emaLocalRatio - targetLocalRatio;
+        var absD = Math.Abs(d);
+
+        // Authority split — outside the rebalance deadband the rebalancer moves the ratio artificially,
+        // so the fee engine must not react to (its own) manufactured signal.
+        if (absD > tunables.RebalanceDeadband)
+        {
+            return new FeePolicyDecision(FeeAction.DeferToRebalancer, pLast, iLast,
+                $"|d|={absD:0.###} > rebalanceDeadband={tunables.RebalanceDeadband:0.###}");
+        }
+
+        // Nothing to correct inside the fee deadband.
+        if (absD <= tunables.FeeDeadband)
+        {
+            return new FeePolicyDecision(FeeAction.NoOp, pLast, iLast,
+                $"|d|={absD:0.###} <= feeDeadband={tunables.FeeDeadband:0.###}");
+        }
+
+        // Outbound: raise when too remote (d<0), lower when too local (d>0).
+        var pNew = RoundClampUint(pLast - tunables.KpOut * d * p0, tunables.MinOutboundPpm, tunables.MaxOutboundPpm);
+        var dp = Math.Clamp((long)pNew - pLast, -(long)tunables.MaxStepPpm, tunables.MaxStepPpm);
+        var outbound = Math.Abs(dp) < tunables.MinDeltaPpm ? pLast : (uint)(pLast + dp);
+
+        // Inbound: negative when too remote (attract entry), positive when too local (repel entry).
+        var iTargetRaw = tunables.Ki * d * p0;
+        if (!allowPositiveInboundFees)
+        {
+            iTargetRaw = Math.Min(iTargetRaw, 0);
+        }
+        var iTarget = RoundClampInt(iTargetRaw, tunables.MinInboundPpm, tunables.MaxInboundPpm);
+        var di = Math.Clamp((long)iTarget - iLast, -(long)tunables.MaxInboundStepPpm, tunables.MaxInboundStepPpm);
+        var inbound = Math.Abs(di) < tunables.MinDeltaPpm ? iLast : (int)(iLast + di);
+
+        if (outbound == pLast && inbound == iLast)
+        {
+            return new FeePolicyDecision(FeeAction.NoOp, pLast, iLast, "computed delta below min-delta dead-zone");
+        }
+
+        return new FeePolicyDecision(FeeAction.Update, outbound, inbound,
+            $"d={d:0.###} outbound {pLast}->{outbound}ppm inbound {iLast}->{inbound}ppm (p0={p0})");
+    }
+
+    private static uint BaselineFor(PeerFlowCategory category, FeeOptimizerTunables t) => category switch
+    {
+        PeerFlowCategory.Source => t.BaselineSourcePpm,
+        PeerFlowCategory.Bidirectional => t.BaselineBidirectionalPpm,
+        PeerFlowCategory.Sink => t.BaselineSinkPpm,
+        _ => t.BaselineUncategorizedPpm,
+    };
+
+    private static uint RoundClampUint(double value, uint min, uint max)
+    {
+        var rounded = Math.Round(value, MidpointRounding.AwayFromZero);
+        if (rounded < min) return min;
+        if (rounded > max) return max;
+        return (uint)rounded;
+    }
+
+    private static int RoundClampInt(double value, int min, int max)
+    {
+        var rounded = (int)Math.Round(value, MidpointRounding.AwayFromZero);
+        return Math.Clamp(rounded, min, max);
+    }
+}

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -198,8 +198,13 @@ namespace NodeGuard.Services
         /// <param name="timeLockDelta"></param>
         /// <param name="inboundBaseFeeMsat"></param>
         /// <param name="inboundFeeRatePpm"></param>
+        /// <param name="allowPositiveInboundFees">
+        /// When false (default — the manual/UI/gRPC path), inbound base fee and rate must be
+        /// &lt;= 0. When true, positive inbound fees are permitted; this is the routing engine's
+        /// fee-optimizer path (Cyberdyne-style positive inbound) and is audit-marked as such.
+        /// </param>
         /// <returns></returns>
-        public Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm);
+        public Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, bool allowPositiveInboundFees = false);
 
         /// <summary>
         /// Gets the channel fee policy for a given channel identified by its chanPoint
@@ -1762,7 +1767,7 @@ namespace NodeGuard.Services
             return await GetLocalOutboundFeeRatePpmAsync(node, match.ChanId);
         }
 
-        public async Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm)
+        public async Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, bool allowPositiveInboundFees = false)
         {
             // Validate chanPoint format
             if (!OutPoint.TryParse(chanPoint, out var outPoint))
@@ -1781,14 +1786,19 @@ namespace NodeGuard.Services
                 throw new ArgumentException("Both inboundBaseFeeMsat and inboundFeeRatePpm must be provided together for inbound fee policy.");
             }
 
-            if (inboundBaseFeeMsat.HasValue && inboundBaseFeeMsat.Value > 0)
+            // Positive inbound fees are only permitted on the routing-engine path
+            // (allowPositiveInboundFees == true). The manual/UI/gRPC path keeps the <= 0 cap.
+            if (!allowPositiveInboundFees)
             {
-                throw new ArgumentException("Inbound base fee must be lower or equal to zero.", nameof(inboundBaseFeeMsat));
-            }
+                if (inboundBaseFeeMsat.HasValue && inboundBaseFeeMsat.Value > 0)
+                {
+                    throw new ArgumentException("Inbound base fee must be lower or equal to zero.", nameof(inboundBaseFeeMsat));
+                }
 
-            if (inboundFeeRatePpm.HasValue && inboundFeeRatePpm.Value > 0)
-            {
-                throw new ArgumentException("Inbound fee rate must be lower or equal to zero.", nameof(inboundFeeRatePpm));
+                if (inboundFeeRatePpm.HasValue && inboundFeeRatePpm.Value > 0)
+                {
+                    throw new ArgumentException("Inbound fee rate must be lower or equal to zero.", nameof(inboundFeeRatePpm));
+                }
             }
 
             var channel = await _channelRepository.GetByOutpoint(outPoint);
@@ -1851,7 +1861,10 @@ namespace NodeGuard.Services
                         FeeRatePpm = feeRatePpm,
                         TimeLockDelta = timeLockDelta,
                         InboundBaseFeeMsat = inboundBaseFeeMsat,
-                        InboundFeeRatePpm = inboundFeeRatePpm
+                        InboundFeeRatePpm = inboundFeeRatePpm,
+                        // Marks routing-engine fee-optimizer writes (the only path that passes
+                        // allowPositiveInboundFees) so they can be filtered apart from manual/UI writes.
+                        EngineWrite = allowPositiveInboundFees
                     })
                 });
 

--- a/test/NodeGuard.Tests/Services/FeeOptimizerServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/FeeOptimizerServiceTests.cs
@@ -1,0 +1,161 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using NodeGuard.Data.Models;
+using NodeGuard.Helpers;
+
+namespace NodeGuard.Services;
+
+public class FeeOptimizerServiceTests
+{
+    private readonly FeeOptimizerService _sut = new();
+
+    // Vision-doc defaults.
+    private static readonly FeeOptimizerTunables Tunables = new(
+        KpOut: 0.8,
+        Ki: 0.5,
+        FeeDeadband: 0.03,
+        RebalanceDeadband: 0.15,
+        MaxStepPpm: 50,
+        MaxInboundStepPpm: 25,
+        MinDeltaPpm: 5,
+        MinOutboundPpm: 0,
+        MaxOutboundPpm: 5000,
+        MinInboundPpm: -250,
+        MaxInboundPpm: 100,
+        BaselineSourcePpm: 50,
+        BaselineBidirectionalPpm: 500,
+        BaselineSinkPpm: 2500,
+        BaselineUncategorizedPpm: 500);
+
+    private FeePolicyDecision Compute(
+        double ema,
+        double target,
+        PeerFlowCategory category,
+        uint? lastOutbound,
+        int? lastInbound,
+        bool allowPositiveInbound)
+        => _sut.ComputeNextPolicy(ema, target, category, lastOutbound, lastInbound, allowPositiveInbound, Tunables);
+
+    [Fact]
+    public void OutOfRebalanceDeadband_DefersToRebalancer()
+    {
+        // d = 0.9 - 0.5 = 0.40 > 0.15
+        var decision = Compute(0.90, 0.50, PeerFlowCategory.Sink, 2500, 0, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.DeferToRebalancer);
+    }
+
+    [Fact]
+    public void InsideFeeDeadband_IsNoOp()
+    {
+        // d = 0.51 - 0.50 = 0.01 <= 0.03
+        var decision = Compute(0.51, 0.50, PeerFlowCategory.Sink, 2500, 0, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.NoOp);
+    }
+
+    [Fact]
+    public void TooLocal_LowersOutbound_AndAppliesPositiveInbound()
+    {
+        // d = +0.10 (too local, need to drain): outbound down, inbound positive.
+        var decision = Compute(0.60, 0.50, PeerFlowCategory.Sink, 2500, 0, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.OutboundPpm.Should().Be(2450); // 2500 - clamp(200, ±50) = 2500 - 50
+        decision.InboundPpm.Should().Be(25);     // clamp(+125→+100 target, step ±25) from 0
+    }
+
+    [Fact]
+    public void TooRemote_RaisesOutbound_AndAppliesNegativeInbound()
+    {
+        // d = -0.10 (too remote, need to fill): outbound up, inbound negative.
+        var decision = Compute(0.40, 0.50, PeerFlowCategory.Sink, 2500, 0, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.OutboundPpm.Should().Be(2550); // 2500 + clamp(200, ±50)
+        decision.InboundPpm.Should().Be(-25);   // -125 target, step-clamped to -25 from 0
+    }
+
+    [Fact]
+    public void PositiveInboundDisallowed_CollapsesInboundToZero_ButStillMovesOutbound()
+    {
+        // Same too-local case as above, but the node forbids positive inbound.
+        var decision = Compute(0.60, 0.50, PeerFlowCategory.Sink, 2500, 0, allowPositiveInbound: false);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.OutboundPpm.Should().Be(2450);
+        decision.InboundPpm.Should().Be(0); // +125 → min(.,0)=0 → no inbound change
+    }
+
+    [Fact]
+    public void ComputedDeltaBelowMinDelta_IsNoOp()
+    {
+        // Source baseline p0=50, small d just outside the deadband → both deltas < min-delta (5).
+        var decision = Compute(0.54, 0.50, PeerFlowCategory.Source, 50, 0, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.NoOp);
+        decision.OutboundPpm.Should().Be(50);
+        decision.InboundPpm.Should().Be(0);
+    }
+
+    [Fact]
+    public void FirstEvaluation_SeedsLastValuesFromCategoryBaseline()
+    {
+        // No last-applied values (first eval). Should behave identically to seeding p_last=p0(sink)=2500, i_last=0.
+        var decision = Compute(0.40, 0.50, PeerFlowCategory.Sink, lastOutbound: null, lastInbound: null, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.OutboundPpm.Should().Be(2550);
+        decision.InboundPpm.Should().Be(-25);
+    }
+
+    [Fact]
+    public void Outbound_IsClampedToMaxCeiling()
+    {
+        // Near the ceiling, too-remote pressure would push past MAX_OUTBOUND_PPM (5000).
+        // d = -0.14 (inside the rebalance deadband, so still fee-engine territory).
+        var decision = Compute(0.36, 0.50, PeerFlowCategory.Sink, 4990, -200, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.OutboundPpm.Should().Be(5000); // pNew 5270 clamped to 5000, reached within one +10 step
+    }
+
+    [Fact]
+    public void Inbound_IsClampedToMaxCeiling()
+    {
+        // iLast already near +100; a further positive push must not exceed MAX_INBOUND_PPM.
+        var decision = Compute(0.60, 0.50, PeerFlowCategory.Sink, 2500, 90, allowPositiveInbound: true);
+
+        decision.Action.Should().Be(FeeAction.Update);
+        decision.InboundPpm.Should().Be(100); // 90 + clamp(10, ±25) = 100 (ceiling)
+    }
+
+    [Fact]
+    public void FromConstants_MapsBaselineTriple()
+    {
+        var t = FeeOptimizerTunables.FromConstants();
+
+        t.BaselineSourcePpm.Should().Be(Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_SOURCE);
+        t.BaselineBidirectionalPpm.Should().Be(Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_BIDIRECTIONAL);
+        t.BaselineSinkPpm.Should().Be(Constants.ROUTING_ENGINE_FEE_BASELINE_PPM_SINK);
+        t.BaselineUncategorizedPpm.Should().Be((uint)Constants.DEFAULT_CHANNEL_FEE_POLICY_FEE_RATE_PPM);
+    }
+}

--- a/test/NodeGuard.Tests/Services/LightningServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningServiceTests.cs
@@ -2302,6 +2302,86 @@ namespace NodeGuard.Services
         }
 
         [Fact]
+        public async Task SetChannelFeePolicy_EngineAllowsPositiveInbound_UpdatesPolicyAndMarksEngineWrite()
+        {
+            // Arrange — the routing-engine fee path (allowPositiveInboundFees: true) must accept a
+            // positive inbound fee rate that the manual/UI path rejects, and mark the audit log.
+            var channelRepository = new Mock<IChannelRepository>();
+            var nodeRepository = new Mock<INodeRepository>();
+            var lightningClientService = new Mock<ILightningClientService>();
+            var dbContextFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: $"SetChannelFeePolicyEngine_{Guid.NewGuid()}")
+                .Options;
+            dbContextFactory
+                .Setup(x => x.CreateDbContextAsync(default))
+                .ReturnsAsync(() => new ApplicationDbContext(options));
+
+            var chanPoint = "0000000000000000000000000000000000000000000000000000000000000001:2";
+            var outPoint = NBitcoin.OutPoint.Parse(chanPoint);
+            var channel = new Channel
+            {
+                Id = 11,
+                ChanId = 456,
+                FundingTx = outPoint.Hash.ToString(),
+                FundingTxOutputIndex = outPoint.N,
+                SourceNodeId = 21
+            };
+            var node = new Node
+            {
+                Id = 21,
+                PubKey = "managedPubKey",
+                Endpoint = "127.0.0.1:10009",
+                ChannelAdminMacaroon = "test-macaroon"
+            };
+
+            channelRepository
+                .Setup(x => x.GetByOutpoint(It.Is<NBitcoin.OutPoint>(point => point.Hash == outPoint.Hash && point.N == outPoint.N)))
+                .ReturnsAsync(channel);
+            nodeRepository
+                .Setup(x => x.GetByPubkey(node.PubKey))
+                .ReturnsAsync(node);
+            lightningClientService
+                .Setup(x => x.SetChannelFeePolicy(node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null))
+                .ReturnsAsync(new PolicyUpdateResponse());
+
+            var lightningService = new LightningService(
+                _logger,
+                null,
+                nodeRepository.Object,
+                dbContextFactory.Object,
+                null,
+                channelRepository.Object,
+                null,
+                null,
+                null,
+                lightningClientService.Object,
+                null);
+
+            // Act — positive inbound rate (50 ppm), allowed only because allowPositiveInboundFees is true.
+            await lightningService.SetChannelFeePolicy(
+                chanPoint,
+                node.PubKey,
+                baseFeeMsat: 1000,
+                feeRatePpm: 250,
+                timeLockDelta: 40,
+                inboundBaseFeeMsat: 0,
+                inboundFeeRatePpm: 50,
+                allowPositiveInboundFees: true);
+
+            // Assert
+            lightningClientService.Verify(x => x.SetChannelFeePolicy(
+                node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null), Times.Once);
+
+            await using var assertContext = new ApplicationDbContext(options);
+            var auditLog = await assertContext.AuditLogs.SingleAsync();
+            auditLog.Username.Should().Be("SYSTEM");
+            using var details = System.Text.Json.JsonDocument.Parse(auditLog.Details!);
+            details.RootElement.GetProperty("InboundFeeRatePpm").GetInt32().Should().Be(50);
+            details.RootElement.GetProperty("EngineWrite").GetBoolean().Should().BeTrue();
+        }
+
+        [Fact]
         public async Task SetChannelFeePolicy_NodeNotParticipant_ThrowsArgumentException()
         {
             // Arrange


### PR DESCRIPTION
## Routing engine — Phase 2a (dynamic fee engine: logic + write primitive)

**Stacked on #533 (Phase 1).** Base branch is `feat/heuristic-fee-engine-phase1`, so this PR's diff shows only the Phase 2a layer. Review/merge #533 first.

This is the first of two Phase 2 PRs. It adds the *pure decision logic* and the *LND-write primitive* the actuator job (Phase 2b) will drive — **no actuator runs yet**, so behaviour is unchanged.

### What's here
- **`FeeOptimizerService`** (pure, singleton) — `ComputeNextPolicy` runs proportional control on the EMA-smoothed local ratio:
  - Authority split: defers to the rebalancer outside the rebalance deadband.
  - Fee-deadband no-op; per-step + min-delta clamps; outbound/inbound ppm floors & ceilings.
  - Direction table: `d>0` (too local) → lower outbound + positive inbound; `d<0` (too remote) → raise outbound + negative inbound.
  - Inbound collapses to `≤0` when the node disallows positive inbound.
  - Category baseline `p₀` scales the term **and** seeds the first-eval "jump" toward the category baseline.
- **`SetChannelFeePolicy`** gains an opt-in `allowPositiveInboundFees` flag (default `false`). Per review guidance, this reuses the existing method rather than adding a separate engine method: the manual/UI/gRPC path keeps its `≤0` inbound cap; the engine passes `true` and its writes are audit-marked `EngineWrite=true`.

### Tests
- `FeeOptimizerServiceTests`: direction table, clamps, inbound-collapse, first-eval seeding, `FromConstants` mapping.
- `LightningServiceTests`: positive-inbound engine write path + audit marker.

Full suite green (337 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)