### PR TITLE
added method to get withdrawas by tx hash

### DIFF
--- a/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestRepository.cs
@@ -27,6 +27,7 @@ public interface IWalletWithdrawalRequestRepository : IBitcoinRequestRepository
 
     Task<List<WalletWithdrawalRequest>> GetByIds(List<int> ids);
     Task<List<WalletWithdrawalRequest>> GetByReferenceIds(List<string> referenceIds);
+    Task<WalletWithdrawalRequest?> GetByTxHash(string txHash);
 
     Task<List<WalletWithdrawalRequest>> GetAll();
 

--- a/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
@@ -85,6 +85,14 @@ namespace NodeGuard.Data.Repositories
             return await applicationDbContext.WalletWithdrawalRequests.Where(wr => !string.IsNullOrEmpty(wr.ReferenceId) && referenceIds.Contains(wr.ReferenceId)).ToListAsync();
         }
 
+        public async Task<WalletWithdrawalRequest?> GetByTxHash(string txHash)
+        {
+            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            return await applicationDbContext.WalletWithdrawalRequests
+                .FirstOrDefaultAsync(wr => wr.TxId == txHash);
+        }
+
 
         public async Task<List<WalletWithdrawalRequest>> GetAll()
         {

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -81,6 +81,11 @@ service NodeGuardService {
   rpc GetWithdrawalsRequestStatusByReferenceIds(GetWithdrawalsRequestStatusByReferenceIdsRequest) returns (GetWithdrawalsRequestStatusResponse);
 
   /*
+  Gets the status for a withdrawal request by its transaction hash
+   */
+  rpc GetWithdrawalsRequestStatusByTxHash(GetWithdrawalsRequestStatusByTxHashRequest) returns (GetWithdrawalsRequestStatusResponse);
+
+  /*
   Gets a channel by id
    */
   rpc GetChannel(GetChannelRequest) returns (GetChannelResponse);
@@ -428,6 +433,10 @@ message GetWithdrawalsRequestStatusResponse {
 
 message GetWithdrawalsRequestStatusByReferenceIdsRequest {
   repeated string reference_ids = 1;
+}
+
+message GetWithdrawalsRequestStatusByTxHashRequest {
+  string tx_hash = 1;
 }
 
 message GetChannelRequest {

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -51,6 +51,8 @@ public interface INodeGuardService
 
     Task<GetWithdrawalsRequestStatusResponse> GetWithdrawalsRequestStatusByReferenceIds(GetWithdrawalsRequestStatusByReferenceIdsRequest request, ServerCallContext context);
 
+    Task<GetWithdrawalsRequestStatusResponse> GetWithdrawalsRequestStatusByTxHash(GetWithdrawalsRequestStatusByTxHashRequest request, ServerCallContext context);
+
     Task<GetChannelResponse> GetChannel(GetChannelRequest request, ServerCallContext context);
 
     Task<AddTagsResponse> AddTags(AddTagsRequest request, ServerCallContext context);
@@ -1113,7 +1115,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
                 RequestId = withdrawalRequest.Id,
                 Status = GetStatus(withdrawalRequest.Status),
                 RejectOrCancelReason = withdrawalRequest.RejectCancelDescription ?? "",
-                ReferenceId = withdrawalRequest.ReferenceId,
+                ReferenceId = withdrawalRequest.ReferenceId ?? "",
                 Confirmations = confirmations,
                 TxId = withdrawalRequest.TxId ?? "",
             });
@@ -1137,6 +1139,17 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         var withdrawalRequests = await _walletWithdrawalRequestRepository.GetByReferenceIds(request.ReferenceIds.ToList());
 
         return await GetWithdrawalsRequestStatusResponse(withdrawalRequests);
+    }
+
+    public override async Task<GetWithdrawalsRequestStatusResponse> GetWithdrawalsRequestStatusByTxHash(GetWithdrawalsRequestStatusByTxHashRequest request, ServerCallContext context)
+    {
+        var withdrawalRequest = await _walletWithdrawalRequestRepository.GetByTxHash(request.TxHash);
+        if (withdrawalRequest == null)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound, "Withdrawal request not found"));
+        }
+
+        return await GetWithdrawalsRequestStatusResponse(new List<WalletWithdrawalRequest> { withdrawalRequest });
     }
 
     public override async Task<GetChannelResponse> GetChannel(GetChannelRequest request, ServerCallContext context)


### PR DESCRIPTION
This is a helpful method to see the status of a withdrawal by txhash, for example for batching withdrawals this will help us change the status of several withdrawals at once instead of getting them by psp_reference_id