### PR TITLE
Refactor DeleteByManagedNodePubKey to return boolean

### DIFF
--- a/src/Data/Repositories/ChannelFeeStateRepository.cs
+++ b/src/Data/Repositories/ChannelFeeStateRepository.cs
@@ -102,7 +102,7 @@ public class ChannelFeeStateRepository : IChannelFeeStateRepository
         return true;
     }
 
-    public async Task<int> DeleteByManagedNodePubKey(string managedNodePubKey)
+    public async Task<bool> DeleteByManagedNodePubKey(string managedNodePubKey)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
@@ -116,11 +116,11 @@ public class ChannelFeeStateRepository : IChannelFeeStateRepository
 
         if (states.Count == 0)
         {
-            return 0;
+            return false;
         }
 
         context.ChannelFeeStates.RemoveRange(states);
         await context.SaveChangesAsync();
-        return states.Count;
+        return true;
     }
 }

--- a/src/Data/Repositories/Interfaces/IChannelFeeStateRepository.cs
+++ b/src/Data/Repositories/Interfaces/IChannelFeeStateRepository.cs
@@ -42,6 +42,6 @@ public interface IChannelFeeStateRepository
     /// <summary>
     /// Deletes the fee-state rows for every channel owned by the given managed node.
     /// </summary>
-    /// <returns>The number of rows deleted.</returns>
-    Task<int> DeleteByManagedNodePubKey(string managedNodePubKey);
+    /// <returns><c>true</c> if any rows were deleted; <c>false</c> if none existed.</returns>
+    Task<bool> DeleteByManagedNodePubKey(string managedNodePubKey);
 }

--- a/src/Services/FeeEngineStateService.cs
+++ b/src/Services/FeeEngineStateService.cs
@@ -85,11 +85,11 @@ public class FeeEngineStateService : IFeeEngineStateService
         }
 
         var deleted = await _feeStateRepository.DeleteByManagedNodePubKey(node.PubKey);
-        if (deleted > 0)
+        if (deleted)
         {
             _logger.LogInformation(
-                "Purged fee state for {Count} channel(s) on node {NodeName} ({PubKey}) — fee management disabled for the node",
-                deleted, node.Name, node.PubKey);
+                "Purged fee state for node {NodeName} ({PubKey}) — fee management disabled for the node",
+                node.Name, node.PubKey);
         }
     }
 }

--- a/test/NodeGuard.Tests/Data/Repositories/ChannelFeeStateRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/ChannelFeeStateRepositoryTests.cs
@@ -85,7 +85,7 @@ public class ChannelFeeStateRepositoryTests
 
         var deleted = await sut.DeleteByManagedNodePubKey("02a");
 
-        deleted.Should().Be(2);
+        deleted.Should().BeTrue();
         (await sut.GetByChannelId(1)).Should().BeNull();
         (await sut.GetByChannelId(2)).Should().BeNull();
         // Node B's channel is untouched.

--- a/test/NodeGuard.Tests/Services/FeeEngineStateServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/FeeEngineStateServiceTests.cs
@@ -31,7 +31,7 @@ public class FeeEngineStateServiceTests
     private FeeEngineStateService Sut()
     {
         _feeStateRepository.Setup(r => r.DeleteByChannelId(It.IsAny<int>())).ReturnsAsync(true);
-        _feeStateRepository.Setup(r => r.DeleteByManagedNodePubKey(It.IsAny<string>())).ReturnsAsync(1);
+        _feeStateRepository.Setup(r => r.DeleteByManagedNodePubKey(It.IsAny<string>())).ReturnsAsync(true);
         return new FeeEngineStateService(_feeStateRepository.Object, _logger.Object);
     }
 


### PR DESCRIPTION
Change the return type of the DeleteByManagedNodePubKey method to boolean, indicating whether any rows were deleted. Update related methods and tests to reflect this change. This improves clarity on the deletion operation's success.