### PR TITLE
fix: quiet benign duplicate-HTLC EF errors and disable sensitive-data logging in prod

### DIFF
--- a/src/Data/Repositories/ForwardingHtlcEventRepository.cs
+++ b/src/Data/Repositories/ForwardingHtlcEventRepository.cs
@@ -87,7 +87,11 @@ public class ForwardingHtlcEventRepository : IForwardingHtlcEventRepository
         }
         catch (DbUpdateException e) when (e.InnerException is PostgresException pg && pg.SqlState == PostgresErrorCodes.UniqueViolation)
         {
-            _logger.LogDebug("Skipping duplicated forwarding HTLC event for node {ManagedNodePubKey}", forwardingHtlcEvent.ManagedNodePubKey);
+            _logger.LogDebug(
+                "Skipping duplicate forwarding HTLC event for node {ManagedNodePubKey} (in {IncomingChannelId}:{IncomingHtlcId} -> out {OutgoingChannelId}:{OutgoingHtlcId})",
+                forwardingHtlcEvent.ManagedNodePubKey,
+                forwardingHtlcEvent.IncomingChannelId, forwardingHtlcEvent.IncomingHtlcId,
+                forwardingHtlcEvent.OutgoingChannelId, forwardingHtlcEvent.OutgoingHtlcId);
             return (true, null);
         }
         catch (Exception e)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -33,6 +33,8 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Quartz;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Resources;
@@ -204,8 +206,22 @@ namespace NodeGuard
             builder.Services.AddDbContextFactory<ApplicationDbContext>(
                 options =>
                 {
-                    options.EnableSensitiveDataLogging();
-                    options.EnableDetailedErrors();
+                    // Sensitive-data logging dumps raw SQL parameter values (pubkeys, amounts,
+                    // aliases) into logs, so keep it to dev only — never leak it in prod.
+                    if (isDevEnvironment)
+                    {
+                        options.EnableSensitiveDataLogging();
+                        options.EnableDetailedErrors();
+                    }
+
+                    // Duplicate-key violations on inserts like ForwardingHtlcEvents are expected
+                    // and handled by the repositories (deduped/skipped). EF logs the failed command
+                    // and SaveChanges at Error regardless of our catch, which floods prod with
+                    // benign, verbose stack traces — downgrade both to Debug so they stay quiet.
+                    options.ConfigureWarnings(warnings => warnings
+                        .Log((RelationalEventId.CommandError, LogLevel.Debug))
+                        .Log((CoreEventId.SaveChangesFailed, LogLevel.Debug)));
+
                     options.UseNpgsql(Constants.POSTGRES_CONNECTIONSTRING, options =>
                     {
                         options.UseQuerySplittingBehavior(QuerySplittingBehavior


### PR DESCRIPTION
Production logs were being flooded with large `Error`-level entries every time a
duplicate `ForwardingHtlcEvent` was inserted (composite PK collision, Postgres `23505`).

These duplicates are **expected and already handled**: `ForwardingHtlcEventRepository.UpsertAsync`
catches the unique-violation and skips the row. But two things made them noisy anyway:

1. **EF Core logs the failure independently of our `catch`.** During the failing command EF
   emits `RelationalEventId.CommandError` and `CoreEventId.SaveChangesFailed` at `Error` — a full
   SQL command + parameter dump and a complete stack trace — before the exception ever reaches
   our handler. Serilog pins `Microsoft` to `Warning`, but these are `Error`, so they passed through.
2. **Sensitive-data logging was on in prod.** `AddDbContextFactory<ApplicationDbContext>` called
   `EnableSensitiveDataLogging()` + `EnableDetailedErrors()` unconditionally, dumping raw parameter
   values (node pubkeys, HTLC amounts, peer aliases) into every failed-command log — both noise
   and a privacy concern.