### PR TITLE
Avoid dust coin selection in transactions

### DIFF
--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -109,7 +109,6 @@ public class Constants
 
     /// <summary>
     /// UTXOs with value less than or equal to this are excluded from coin selection (dust-attack protection).
-    /// Can be configured via the MINIMUM_UTXO_VALUE_SATS environment variable.
     /// </summary>
     public static readonly long MINIMUM_UTXO_VALUE_SATS = 546;
 

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -28,7 +28,7 @@ public class Constants
     public static readonly bool ENABLE_REMOTE_SIGNER;
     public static readonly bool PUSH_NOTIFICATIONS_ONESIGNAL_ENABLED;
     public static readonly bool ENABLE_HW_SUPPORT;
-    public static readonly bool NBXPLORER_ENABLE_CUSTOM_BACKEND = false;
+    public static bool NBXPLORER_ENABLE_CUSTOM_BACKEND = false; // Not readonly so we can change it in tests
     /// <summary>
     /// Allow simultaneous channel opening operations using the same source and destination nodes
     /// </summary>

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -108,6 +108,12 @@ public class Constants
     public static readonly Money BITCOIN_DUST = new Money(0.00000546m, MoneyUnit.BTC); // 546 satoshi in BTC
 
     /// <summary>
+    /// UTXOs with value less than or equal to this are excluded from coin selection (dust-attack protection).
+    /// Can be configured via the MINIMUM_UTXO_VALUE_SATS environment variable.
+    /// </summary>
+    public static readonly long MINIMUM_UTXO_VALUE_SATS = 546;
+
+    /// <summary>
     /// Minimum swap out size in BTC for automatic liquidity management (Swap Out).
     /// Can be configured via MINIMUM_SWAP_OUT_SIZE_BTC environment variable.
     /// </summary>
@@ -494,6 +500,9 @@ public class Constants
 
         var minSweepTransactionAmount = Environment.GetEnvironmentVariable("MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS");
         if (minSweepTransactionAmount != null) MINIMUM_SWEEP_TRANSACTION_AMOUNT_SATS = long.Parse(minSweepTransactionAmount);
+
+        var minimumUtxoValueSats = Environment.GetEnvironmentVariable("MINIMUM_UTXO_VALUE_SATS");
+        if (minimumUtxoValueSats != null) MINIMUM_UTXO_VALUE_SATS = long.Parse(minimumUtxoValueSats);
 
 
         DEFAULT_DERIVATION_PATH = GetEnvironmentalVariableOrThrowIfNotTesting("DEFAULT_DERIVATION_PATH") ?? DEFAULT_DERIVATION_PATH;

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -581,6 +581,7 @@
                                 {
                                     foreach (var (_, utxo, tags, isFrozen) in _detailsUTXOs)
                                     {
+                                        var isDust = ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS;
                                         <TableRow>
                                             <TableRowHeader class="utxo-tags">
                                                 <a href="@($"{Environment.GetEnvironmentVariable("MEMPOOL_ENDPOINT")}/tx/{utxo.Outpoint.Hash}#vout={utxo.Outpoint.N}")"
@@ -589,6 +590,10 @@
                                             <TableRowCell>@utxo.Confirmations</TableRowCell>
                                             <TableRowCell>@($"{utxo.Value} BTC")</TableRowCell>
                                             <TableRowCell class="utxo-tags">
+                                                @if (isDust)
+                                                {
+                                                    <Badge class="utxo-tag" Color="Color.Warning" Pill title="Dust UTXO, automatically excluded from coin selection">dust</Badge>
+                                                }
                                                 @if (tags.Any())
                                                 {
                                                     foreach (var data in tags.Select((tag, i) => new { tag, i }))
@@ -598,7 +603,7 @@
                                                 }
                                             </TableRowCell>
                                             <TableRowCell>
-                                                <Check TValue="bool" Checked="@isFrozen"
+                                                <Check TValue="bool" Checked="@isFrozen" Disabled="@isDust"
                                                        CheckedChanged="@((b) => ToggleUtxoFreeze(b, utxo))"></Check>
                                             </TableRowCell>
                                         </TableRow>

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -1091,17 +1091,13 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
             utxos = new UTXOChanges();
         }
 
-        var confirmedUtxos = utxos.Confirmed.UTXOs
-            .Where(utxo => ((Money)utxo.Value).Satoshi > Constants.MINIMUM_UTXO_VALUE_SATS)
-            .Select(utxo => new Utxo()
+        var confirmedUtxos = utxos.Confirmed.UTXOs.Select(utxo => new Utxo()
         {
             Amount = (Money)utxo.Value,
             Outpoint = utxo.Outpoint.ToString(),
             Address = utxo.Address.ToString()
         });
-        var unconfirmedUtxos = utxos.Unconfirmed.UTXOs
-            .Where(utxo => ((Money)utxo.Value).Satoshi > Constants.MINIMUM_UTXO_VALUE_SATS)
-            .Select(utxo => new Utxo()
+        var unconfirmedUtxos = utxos.Unconfirmed.UTXOs.Select(utxo => new Utxo()
         {
             Amount = (Money)utxo.Value,
             Outpoint = utxo.Outpoint.ToString(),

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -1069,14 +1069,27 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         ignoreOutpoints.AddRange(listFrozen);
         ignoreOutpoints.AddRange(listDust);
 
-        var utxos = await _nbXplorerService.GetUTXOsByLimitAsync(
-            derivationStrategy,
-            coinSelectionStrategy,
-            request.Limit,
-            request.Amount,
-            request.ClosestTo,
-            ignoreOutpoints
-            );
+        UTXOChanges utxos;
+        try
+        {
+            utxos = await _nbXplorerService.GetUTXOsByLimitAsync(
+                derivationStrategy,
+                coinSelectionStrategy,
+                request.Limit,
+                request.Amount,
+                request.ClosestTo,
+                ignoreOutpoints
+                );
+        }
+        catch (Exception e)
+        {
+            // Preserve this RPC's previous contract: a failing custom backend yields an empty
+            // selection instead of an error
+            _logger.LogWarning(e,
+                "UTXO selection through the custom NBXplorer backend failed for wallet {WalletId}, returning an empty selection",
+                request.WalletId);
+            utxos = new UTXOChanges();
+        }
 
         var confirmedUtxos = utxos.Confirmed.UTXOs
             .Where(utxo => ((Money)utxo.Value).Satoshi > Constants.MINIMUM_UTXO_VALUE_SATS)

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -1057,8 +1057,17 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
                            walletUtxos.Unconfirmed.UTXOs.Any(u => u.Outpoint.ToString() == utxo))
                            .ToList();
 
+        // Ignore dust UTXOs server-side too, so they are not counted towards the requested amount
+        // by any selection strategy and then stripped locally, returning a short selection
+        var listDust = walletUtxos.Confirmed.UTXOs
+            .Concat(walletUtxos.Unconfirmed.UTXOs)
+            .Where(utxo => ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
+            .Select(utxo => utxo.Outpoint.ToString())
+            .ToList();
+
         ignoreOutpoints.AddRange(listLocked);
         ignoreOutpoints.AddRange(listFrozen);
+        ignoreOutpoints.AddRange(listDust);
 
         var utxos = await _nbXplorerService.GetUTXOsByLimitAsync(
             derivationStrategy,
@@ -1069,13 +1078,17 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
             ignoreOutpoints
             );
 
-        var confirmedUtxos = utxos.Confirmed.UTXOs.Select(utxo => new Utxo()
+        var confirmedUtxos = utxos.Confirmed.UTXOs
+            .Where(utxo => ((Money)utxo.Value).Satoshi > Constants.MINIMUM_UTXO_VALUE_SATS)
+            .Select(utxo => new Utxo()
         {
             Amount = (Money)utxo.Value,
             Outpoint = utxo.Outpoint.ToString(),
             Address = utxo.Address.ToString()
         });
-        var unconfirmedUtxos = utxos.Unconfirmed.UTXOs.Select(utxo => new Utxo()
+        var unconfirmedUtxos = utxos.Unconfirmed.UTXOs
+            .Where(utxo => ((Money)utxo.Value).Satoshi > Constants.MINIMUM_UTXO_VALUE_SATS)
+            .Select(utxo => new Utxo()
         {
             Amount = (Money)utxo.Value,
             Outpoint = utxo.Outpoint.ToString(),

--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -159,6 +159,22 @@ public class CoinSelectionService: ICoinSelectionService
         return frozenAndLockedOutpoints;
     }
 
+    /// <summary>
+    /// Outpoints that must never be offered for coin selection: locked, frozen and dust UTXOs.
+    /// Locked/frozen are state lookups (database/tags); dust is a value predicate over the
+    /// wallet's current UTXO set, so the caller provides the already-fetched set instead of this
+    /// method issuing its own NBXplorer query.
+    /// </summary>
+    private async Task<List<string>> GetIgnoredOutpoints(UTXOChanges utxos)
+    {
+        var ignoredOutpoints = await GetLockedFrozenOutpoints();
+        ignoredOutpoints.AddRange(utxos.Confirmed.UTXOs
+            .Concat(utxos.Unconfirmed.UTXOs)
+            .Where(utxo => ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
+            .Select(utxo => utxo.Outpoint.ToString()));
+        return ignoredOutpoints;
+    }
+
     private async Task<List<UTXO>> FilterLockedFrozenUTXOs(UTXOChanges? utxoChanges)
     {
         var frozenAndLockedOutpoints = await GetLockedFrozenOutpoints();
@@ -220,14 +236,9 @@ public class CoinSelectionService: ICoinSelectionService
             // Tell the backend which UTXOs to skip (locked, frozen and dust), otherwise it counts
             // them towards the requested amount and the local filter below strips them afterwards,
             // returning a selection that falls short of that amount
-            var ignoreOutpoints = await GetLockedFrozenOutpoints();
             var allUtxos = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
             allUtxos.RemoveDuplicateUTXOs();
-            var dustOutpoints = allUtxos.Confirmed.UTXOs
-                .Concat(allUtxos.Unconfirmed.UTXOs)
-                .Where(utxo => ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
-                .Select(utxo => utxo.Outpoint.ToString());
-            ignoreOutpoints.AddRange(dustOutpoints);
+            var ignoreOutpoints = await GetIgnoredOutpoints(allUtxos);
 
             utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo, ignoreOutpoints);
         }

--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -233,14 +233,28 @@ public class CoinSelectionService: ICoinSelectionService
         UTXOChanges utxoChanges;
         if (Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND)
         {
-            // Tell the backend which UTXOs to skip (locked, frozen and dust), otherwise it counts
-            // them towards the requested amount and the local filter below strips them afterwards,
-            // returning a selection that falls short of that amount
-            var allUtxos = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
-            allUtxos.RemoveDuplicateUTXOs();
-            var ignoreOutpoints = await GetIgnoredOutpoints(allUtxos);
+            try
+            {
+                // Tell the backend which UTXOs to skip (locked, frozen and dust), otherwise it
+                // counts them towards the requested amount and the local filter below strips them
+                // afterwards, returning a selection that falls short of that amount
+                var allUtxos = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
+                allUtxos.RemoveDuplicateUTXOs();
+                var ignoreOutpoints = await GetIgnoredOutpoints(allUtxos);
 
-            utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo, ignoreOutpoints);
+                utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo, ignoreOutpoints);
+            }
+            catch (Exception e)
+            {
+                // Skip the custom backend entirely and degrade to the plain UTXO listing, same as
+                // when NBXPLORER_ENABLE_CUSTOM_BACKEND is off: the strategy/amount are no longer
+                // applied server-side, but the local filter below still strips locked, frozen and
+                // dust UTXOs, so none of them can leak through
+                _logger.LogWarning(e,
+                    "UTXO selection through the custom NBXplorer backend failed for strategy {Strategy}, falling back to the plain UTXO listing",
+                    strategy);
+                utxoChanges = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
+            }
         }
         else
         {

--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -148,15 +148,21 @@ public class CoinSelectionService: ICoinSelectionService
         return utxos.Confirmed.UTXOs.Where(utxo => lockedUTXOsList.Contains(utxo.Outpoint.ToString())).ToList();
     }
 
-    private async Task<List<UTXO>> FilterLockedFrozenUTXOs(UTXOChanges? utxoChanges)
+    private async Task<List<string>> GetLockedFrozenOutpoints()
     {
         var lockedUTXOs = await _fmutxoRepository.GetLockedUTXOs();
-        var listLocked = lockedUTXOs.Select(utxo => $"{utxo.TxId}-{utxo.OutputIndex}").ToList(); 
+        var listLocked = lockedUTXOs.Select(utxo => $"{utxo.TxId}-{utxo.OutputIndex}").ToList();
         var listFrozen = await GetFrozenUTXOs();
         var frozenAndLockedOutpoints = new List<string>();
         frozenAndLockedOutpoints.AddRange(listLocked);
         frozenAndLockedOutpoints.AddRange(listFrozen);
-        
+        return frozenAndLockedOutpoints;
+    }
+
+    private async Task<List<UTXO>> FilterLockedFrozenUTXOs(UTXOChanges? utxoChanges)
+    {
+        var frozenAndLockedOutpoints = await GetLockedFrozenOutpoints();
+
         utxoChanges.RemoveDuplicateUTXOs();
 
         var availableUTXOs = new List<UTXO>();
@@ -211,7 +217,19 @@ public class CoinSelectionService: ICoinSelectionService
         UTXOChanges utxoChanges;
         if (Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND)
         {
-            utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo);
+            // Tell the backend which UTXOs to skip (locked, frozen and dust), otherwise it counts
+            // them towards the requested amount and the local filter below strips them afterwards,
+            // returning a selection that falls short of that amount
+            var ignoreOutpoints = await GetLockedFrozenOutpoints();
+            var allUtxos = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
+            allUtxos.RemoveDuplicateUTXOs();
+            var dustOutpoints = allUtxos.Confirmed.UTXOs
+                .Concat(allUtxos.Unconfirmed.UTXOs)
+                .Where(utxo => ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
+                .Select(utxo => utxo.Outpoint.ToString());
+            ignoreOutpoints.AddRange(dustOutpoints);
+
+            utxoChanges = await _nbXplorerService.GetUTXOsByLimitAsync(derivationStrategy, strategy, limit, amount, closestTo, ignoreOutpoints);
         }
         else
         {

--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -167,6 +167,11 @@ public class CoinSelectionService: ICoinSelectionService
             {
                 _logger.LogInformation("Removing UTXO: {Utxo} from UTXO set as it is locked", utxo.Outpoint.ToString());
             }
+            else if (((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
+            {
+                _logger.LogInformation("Removing UTXO: {Utxo} from UTXO set as it is dust ({Sats} sats <= {MinSats} sats)",
+                    utxo.Outpoint.ToString(), ((Money)utxo.Value).Satoshi, Constants.MINIMUM_UTXO_VALUE_SATS);
+            }
             else
             {
                 availableUTXOs.Add(utxo);

--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -161,9 +161,6 @@ public class CoinSelectionService: ICoinSelectionService
 
     /// <summary>
     /// Outpoints that must never be offered for coin selection: locked, frozen and dust UTXOs.
-    /// Locked/frozen are state lookups (database/tags); dust is a value predicate over the
-    /// wallet's current UTXO set, so the caller provides the already-fetched set instead of this
-    /// method issuing its own NBXplorer query.
     /// </summary>
     private async Task<List<string>> GetIgnoredOutpoints(UTXOChanges utxos)
     {

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -179,14 +179,15 @@ public class NBXplorerService : INBXplorerService
 
                 return client.Serializer.ToObject<UTXOChanges>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
             }
+
+            throw new HttpRequestException(
+                $"selectutxos request failed with status code {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync(cancellation).ConfigureAwait(false)}");
         }
         catch (Exception e)
         {
             _logger.LogError(e.ToString());
-            throw e;
+            throw;
         }
-
-        return new UTXOChanges();
     }
 
     public async Task<GetFeeRateResult> GetFeeRateAsync(int blockCount, FeeRate fallbackFeeRate,

--- a/test/NodeGuard.Tests/E2E/DustUtxoWithdrawalE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/DustUtxoWithdrawalE2ETests.cs
@@ -109,19 +109,23 @@ public class DustUtxoWithdrawalE2ETests
         // No selection strategy may surface the dust UTXO. SmallestFirst would rank it first, and
         // ClosestToTargetFirst targeting exactly 546 sats is the most adversarial case: the dust
         // UTXO would be the top candidate if it were not filtered out.
-        foreach (var strategy in new[]
-                 {
-                     COIN_SELECTION_STRATEGY.SmallestFirst,
-                     COIN_SELECTION_STRATEGY.BiggestFirst,
-                     COIN_SELECTION_STRATEGY.ClosestToTargetFirst,
-                     COIN_SELECTION_STRATEGY.UpToAmount,
-                 })
+        // UpToAmount selects UTXOs whose sum stays UNDER the target, so it gets a ceiling above
+        // the wallet balance: with a small target the dust UTXO would be the only one that fits
+        // (and the correct result once it is filtered out is an empty selection).
+        var strategyProbes = new (COIN_SELECTION_STRATEGY Strategy, long AmountSats)[]
+        {
+            (COIN_SELECTION_STRATEGY.SmallestFirst, ProbeAmountSats),
+            (COIN_SELECTION_STRATEGY.BiggestFirst, ProbeAmountSats),
+            (COIN_SELECTION_STRATEGY.ClosestToTargetFirst, ProbeAmountSats),
+            (COIN_SELECTION_STRATEGY.UpToAmount, Money.Coins(25m).Satoshi),
+        };
+        foreach (var (strategy, amountSats) in strategyProbes)
         {
             var availableUtxos = await client.GetAvailableUtxosAsync(new GetAvailableUtxosRequest
             {
                 WalletId = walletId,
                 Strategy = strategy,
-                Amount = ProbeAmountSats,
+                Amount = amountSats,
                 ClosestTo = DustAmountSats,
             }, headers);
             availableUtxos.Confirmed.Should().NotBeEmpty(
@@ -129,6 +133,17 @@ public class DustUtxoWithdrawalE2ETests
             availableUtxos.Confirmed.Select(u => u.Outpoint).Should().NotContain(dustOutpoint.ToString(),
                 $"dust UTXOs must not be offered for coin selection with strategy {strategy}");
         }
+
+        // With a target below any real UTXO, UpToAmount's only fitting candidate is the dust
+        // UTXO — the selection must come back empty rather than surface it.
+        var upToDustOnly = await client.GetAvailableUtxosAsync(new GetAvailableUtxosRequest
+        {
+            WalletId = walletId,
+            Strategy = COIN_SELECTION_STRATEGY.UpToAmount,
+            Amount = ProbeAmountSats,
+        }, headers);
+        upToDustOnly.Confirmed.Should().BeEmpty(
+            "no UTXO other than the (filtered) dust fits an UpToAmount target below the smallest real UTXO");
 
         // 3. Request an automatic withdrawal: no explicit outpoints, so coin selection runs.
         var destination = await rpc.GetNewAddressAsync();

--- a/test/NodeGuard.Tests/E2E/DustUtxoWithdrawalE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/DustUtxoWithdrawalE2ETests.cs
@@ -1,0 +1,200 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using System.Net;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using NBitcoin;
+using NBitcoin.RPC;
+using Nodeguard;
+using Xunit.Abstractions;
+
+namespace NodeGuard.Tests.E2E;
+
+/// <summary>
+/// End-to-end coverage for the dust UTXO protection (MINIMUM_UTXO_VALUE_SATS): a confirmed
+/// 546-sat output sent to a NodeGuard hot wallet must be hidden from GetAvailableUtxos and must
+/// never be auto-selected as an input of a withdrawal, even though the coin selection picks the
+/// newest confirmed UTXO first (which the freshly-mined dust output would otherwise be).
+/// Exercised against a LIVE NodeGuard instance + bitcoind.
+/// Gated by <see cref="E2EFactAttribute"/> (RUN_E2E_TESTS=1). Connection via env:
+///   NODEGUARD_GRPC_ENDPOINT  default http://localhost:50051 (h2c)
+///   NODEGUARD_API_TOKEN      default the dev "Liquidator" token
+///   BITCOIND_RPC_URL/USER/PASS/WALLET  default http://localhost:18443 / polaruser / polarpass / default
+///   E2E_HOT_WALLET_ID        NodeGuard hot wallet to withdraw from (default 3)
+/// </summary>
+[Trait("Category", "E2E")]
+[Collection("E2E")]
+public class DustUtxoWithdrawalE2ETests
+{
+    private const string DefaultDevToken = "8rvSsUGeyXXdDQrHctcTey/xtHdZQEn945KHwccKp9Q=";
+    private const long DustAmountSats = 546;
+    // The custom NBXplorer selectutxos backend behind GetAvailableUtxos picks UTXOs toward a
+    // target amount (amount=0 always yields an empty selection), so every call must request one.
+    private const long ProbeAmountSats = 2_000_000;
+
+    private readonly ITestOutputHelper _output;
+
+    public DustUtxoWithdrawalE2ETests(ITestOutputHelper output)
+    {
+        _output = output;
+        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+    }
+
+    [E2EFact]
+    public async Task RequestWithdrawal_DoesNotSelectDustUtxo()
+    {
+        var client = CreateClient(out var headers);
+        var rpc = CreateBitcoindRpc();
+        var walletId = int.Parse(Env("E2E_HOT_WALLET_ID", "3"));
+
+        // 0. Wait for NodeGuard to be up and for the dev hot wallet to have a spendable UTXO
+        //    (DbInitializer funds it with 20 BTC; another E2E test may have it locked temporarily).
+        await RetryAsync(async () =>
+        {
+            var resp = await client.GetNodesAsync(new GetNodesRequest(), headers);
+            if (resp.Nodes.Count == 0) throw new InvalidOperationException("no nodes seeded yet");
+            return true;
+        }, attempts: 90, delay: TimeSpan.FromSeconds(4), what: "GetNodes (NodeGuard readiness)");
+
+        await RetryAsync(async () =>
+        {
+            var available = await client.GetAvailableUtxosAsync(
+                new GetAvailableUtxosRequest { WalletId = walletId, Amount = ProbeAmountSats }, headers);
+            if (available.Confirmed.Sum(u => u.Amount) < ProbeAmountSats)
+                throw new InvalidOperationException("hot wallet has no spendable UTXO yet");
+            return true;
+        }, attempts: 60, delay: TimeSpan.FromSeconds(4), what: "GetAvailableUtxos (hot wallet funded)");
+
+        // 1. Send a 546-sat dust output to a fresh address of the wallet and confirm it.
+        var addressResponse = await client.GetNewWalletAddressAsync(
+            new GetNewWalletAddressRequest { WalletId = walletId, Skip = 0, Reserve = true }, headers);
+        var dustAddress = BitcoinAddress.Create(addressResponse.Address, Network.RegTest);
+        var dustTxId = await rpc.SendToAddressAsync(dustAddress, Money.Satoshis(DustAmountSats));
+        await MineAsync(rpc, 6);
+
+        var dustFundingTx = await rpc.GetRawTransactionAsync(dustTxId);
+        var dustVout = dustFundingTx.Outputs.AsIndexedOutputs()
+            .Single(o => o.TxOut.ScriptPubKey == dustAddress.ScriptPubKey).N;
+        var dustOutpoint = new OutPoint(dustTxId, dustVout);
+        _output.WriteLine($"dust UTXO: {dustOutpoint}");
+
+        // 2. The dust UTXO must show up in the raw GetUtxos listing (NBXplorer indexed it)
+        //    but must be hidden from the available-for-coin-selection listing.
+        await RetryAsync(async () =>
+        {
+            var all = await client.GetUtxosAsync(new GetUtxosRequest(), headers);
+            if (all.Confirmed.All(u => u.Outpoint != dustOutpoint.ToString()))
+                throw new InvalidOperationException("dust UTXO not indexed by NBXplorer yet");
+            return true;
+        }, attempts: 30, delay: TimeSpan.FromSeconds(4), what: "GetUtxos (dust UTXO indexed)");
+
+        // No selection strategy may surface the dust UTXO. SmallestFirst would rank it first, and
+        // ClosestToTargetFirst targeting exactly 546 sats is the most adversarial case: the dust
+        // UTXO would be the top candidate if it were not filtered out.
+        foreach (var strategy in new[]
+                 {
+                     COIN_SELECTION_STRATEGY.SmallestFirst,
+                     COIN_SELECTION_STRATEGY.BiggestFirst,
+                     COIN_SELECTION_STRATEGY.ClosestToTargetFirst,
+                     COIN_SELECTION_STRATEGY.UpToAmount,
+                 })
+        {
+            var availableUtxos = await client.GetAvailableUtxosAsync(new GetAvailableUtxosRequest
+            {
+                WalletId = walletId,
+                Strategy = strategy,
+                Amount = ProbeAmountSats,
+                ClosestTo = DustAmountSats,
+            }, headers);
+            availableUtxos.Confirmed.Should().NotBeEmpty(
+                $"the wallet's non-dust UTXOs must still be available with strategy {strategy}");
+            availableUtxos.Confirmed.Select(u => u.Outpoint).Should().NotContain(dustOutpoint.ToString(),
+                $"dust UTXOs must not be offered for coin selection with strategy {strategy}");
+        }
+
+        // 3. Request an automatic withdrawal: no explicit outpoints, so coin selection runs.
+        var destination = await rpc.GetNewAddressAsync();
+        var withdrawal = await client.RequestWithdrawalAsync(new RequestWithdrawalRequest
+        {
+            WalletId = walletId,
+            Description = "E2E dust protection test",
+            Destinations = { new Destination { Address = destination.ToString(), AmountSats = 1_000_000 } },
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = 2,
+        }, headers);
+        _output.WriteLine($"withdrawal request {withdrawal.RequestId} → txid {withdrawal.Txid}");
+        withdrawal.IsHotWallet.Should().BeTrue();
+
+        // 4. The hot wallet signs and broadcasts asynchronously (PerformWithdrawalJob); wait for
+        //    the tx to hit the mempool and assert the dust outpoint is not among its inputs.
+        var withdrawalTx = await RetryAsync(async () =>
+        {
+            var tx = await rpc.GetRawTransactionAsync(uint256.Parse(withdrawal.Txid), throwIfNotFound: false);
+            return tx ?? throw new InvalidOperationException("withdrawal tx not broadcast yet");
+        }, attempts: 30, delay: TimeSpan.FromSeconds(4), what: "GetRawTransaction (withdrawal broadcast)");
+
+        withdrawalTx.Inputs.Select(i => i.PrevOut).Should().NotContain(dustOutpoint,
+            "a freshly-confirmed dust UTXO would be the first pick of SelectUTXOsByOldest if it were not filtered out");
+
+        // 5. The dust UTXO must remain unspent (and unlocked) after the withdrawal.
+        var allUtxos = await client.GetUtxosAsync(new GetUtxosRequest(), headers);
+        allUtxos.Confirmed.Select(u => u.Outpoint).Should().Contain(dustOutpoint.ToString(),
+            "the dust UTXO must be left untouched in the wallet");
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------
+
+    private async Task MineAsync(RPCClient rpc, int blocks)
+    {
+        var addr = await rpc.GetNewAddressAsync();
+        await rpc.GenerateToAddressAsync(blocks, addr);
+    }
+
+    private async Task<T> RetryAsync<T>(Func<Task<T>> action, int attempts, TimeSpan delay, string what)
+    {
+        Exception? last = null;
+        for (var i = 0; i < attempts; i++)
+        {
+            try { return await action(); }
+            catch (Exception ex) { last = ex; _output.WriteLine($"{what} attempt {i + 1}/{attempts} failed: {ex.Message}"); }
+            await Task.Delay(delay);
+        }
+        throw new InvalidOperationException($"{what} did not succeed after {attempts} attempts", last);
+    }
+
+    private static NodeGuardService.NodeGuardServiceClient CreateClient(out Metadata headers)
+    {
+        var endpoint = Env("NODEGUARD_GRPC_ENDPOINT", "http://localhost:50051");
+        headers = new Metadata { { "auth-token", Env("NODEGUARD_API_TOKEN", DefaultDevToken) } };
+        return new NodeGuardService.NodeGuardServiceClient(GrpcChannel.ForAddress(endpoint));
+    }
+
+    private static RPCClient CreateBitcoindRpc()
+    {
+        var url = Env("BITCOIND_RPC_URL", "http://localhost:18443");
+        var cred = new NetworkCredential(Env("BITCOIND_RPC_USER", "polaruser"), Env("BITCOIND_RPC_PASS", "polarpass"));
+        var rpc = new RPCClient(cred, new Uri(url), Network.RegTest);
+        return rpc.SetWalletContext(Env("BITCOIND_RPC_WALLET", "default"));
+    }
+
+    private static string Env(string name, string fallback)
+        => Environment.GetEnvironmentVariable(name) is { Length: > 0 } v ? v : fallback;
+}

--- a/test/NodeGuard.Tests/E2E/E2ECollection.cs
+++ b/test/NodeGuard.Tests/E2E/E2ECollection.cs
@@ -1,0 +1,30 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+namespace NodeGuard.Tests.E2E;
+
+/// <summary>
+/// All E2E test classes share this collection so they run sequentially: they compete for the
+/// same seeded dev wallets and mine blocks on the same regtest chain, so running them in
+/// parallel makes them flaky.
+/// </summary>
+[CollectionDefinition("E2E", DisableParallelization = true)]
+public class E2ECollection
+{
+}

--- a/test/NodeGuard.Tests/E2E/GetNewWalletAddressE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/GetNewWalletAddressE2ETests.cs
@@ -34,6 +34,7 @@ namespace NodeGuard.Tests.E2E;
 ///   E2E_HOT_WALLET_ID        NodeGuard hot wallet to query (default 3)
 /// </summary>
 [Trait("Category", "E2E")]
+[Collection("E2E")]
 public class GetNewWalletAddressE2ETests
 {
     private const string DefaultDevToken = "8rvSsUGeyXXdDQrHctcTey/xtHdZQEn945KHwccKp9Q=";

--- a/test/NodeGuard.Tests/E2E/RebalanceE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/RebalanceE2ETests.cs
@@ -43,6 +43,7 @@ namespace NodeGuard.Tests.E2E;
 ///   E2E_HOT_WALLET_ID        NodeGuard hot wallet to fund the channel (default 3)
 /// </summary>
 [Trait("Category", "E2E")]
+[Collection("E2E")]
 public class RebalanceE2ETests
 {
     private const string DefaultDevToken = "8rvSsUGeyXXdDQrHctcTey/xtHdZQEn945KHwccKp9Q=";

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -35,6 +35,7 @@ using NBXplorer.Models;
 using Nodeguard;
 using Quartz;
 using Quartz.Impl;
+using NodeGuard.TestHelpers;
 using Channel = NodeGuard.Data.Models.Channel;
 using Key = NodeGuard.Data.Models.Key;
 using LiquidityRule = NodeGuard.Data.Models.LiquidityRule;
@@ -1750,6 +1751,90 @@ namespace NodeGuard.Rpc
             response.Rebalances.Should().HaveCount(1);
             response.Rebalances[0].RebalanceId.Should().Be(1);
             response.Rebalances[0].NodePubkey.Should().Be("pubkey1");
+        }
+
+        [Theory]
+        [InlineData(COIN_SELECTION_STRATEGY.SmallestFirst)]
+        [InlineData(COIN_SELECTION_STRATEGY.BiggestFirst)]
+        [InlineData(COIN_SELECTION_STRATEGY.ClosestToTargetFirst)]
+        [InlineData(COIN_SELECTION_STRATEGY.UpToAmount)]
+        public async Task GetAvailableUtxos_ExcludesDustUtxos(COIN_SELECTION_STRATEGY strategy)
+        {
+            // Arrange
+            var wallet = CreateWallet.SingleSig(CreateWallet.CreateInternalWallet());
+            var walletRepository = new Mock<IWalletRepository>();
+            walletRepository.Setup(x => x.GetById(It.IsAny<int>())).ReturnsAsync(wallet);
+
+            var address = BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", Network.RegTest);
+            var dustUtxo = new UTXO()
+            {
+                Outpoint = new OutPoint(new uint256(1), 0),
+                Value = new Money(Constants.MINIMUM_UTXO_VALUE_SATS),
+                Address = address
+            };
+            var availableUtxo = new UTXO()
+            {
+                Outpoint = new OutPoint(new uint256(2), 0),
+                Value = new Money(10_000L),
+                Address = address
+            };
+            var unconfirmedDustUtxo = new UTXO()
+            {
+                Outpoint = new OutPoint(new uint256(3), 0),
+                Value = new Money(100L),
+                Address = address
+            };
+
+            var nbxplorerService = new Mock<INBXplorerService>();
+            nbxplorerService.Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { dustUtxo, availableUtxo } },
+                    Unconfirmed = new UTXOChange() { UTXOs = new List<UTXO>() { unconfirmedDustUtxo } }
+                });
+            List<string>? ignoredOutpoints = null;
+            nbxplorerService.Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .Callback<DerivationStrategyBase, CoinSelectionStrategy, int, long, long, List<string>?,
+                    CancellationToken>((_, _, _, _, _, ignore, _) => ignoredOutpoints = ignore)
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    // The fork would not return ignored dust, but keep it here to prove the local
+                    // defense-in-depth filter strips it from the response either way
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { dustUtxo, availableUtxo } },
+                    Unconfirmed = new UTXOChange() { UTXOs = new List<UTXO>() { unconfirmedDustUtxo } }
+                });
+
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository.Setup(x => x.GetLockedUTXOsByWalletId(It.IsAny<int>()))
+                .ReturnsAsync(new List<FMUTXO>());
+
+            var coinSelectionService = new Mock<ICoinSelectionService>();
+            coinSelectionService.Setup(x => x.GetFrozenUTXOs()).ReturnsAsync(new List<string>());
+
+            var service = CreateNodeGuardService(
+                walletRepository: walletRepository.Object,
+                nbXplorerService: nbxplorerService.Object,
+                fmutxoRepository: fmutxoRepository.Object,
+                coinSelectionService: coinSelectionService.Object);
+
+            // Act
+            var response = await service.GetAvailableUtxos(
+                new GetAvailableUtxosRequest { WalletId = 1, Strategy = strategy, Amount = 10_000 },
+                TestServerCallContext.Create());
+
+            // Assert
+            response.Confirmed.Should().ContainSingle();
+            response.Confirmed[0].Outpoint.Should().Be(availableUtxo.Outpoint.ToString());
+            response.Unconfirmed.Should().BeEmpty();
+
+            // Both dust UTXOs must also be ignored server-side so the fork does not count them
+            // towards the requested amount
+            ignoredOutpoints.Should().NotBeNull();
+            ignoredOutpoints.Should().Contain(dustUtxo.Outpoint.ToString());
+            ignoredOutpoints.Should().Contain(unconfirmedDustUtxo.Outpoint.ToString());
+            ignoredOutpoints.Should().NotContain(availableUtxo.Outpoint.ToString());
         }
     }
 }

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -1800,10 +1800,8 @@ namespace NodeGuard.Rpc
                     CancellationToken>((_, _, _, _, _, ignore, _) => ignoredOutpoints = ignore)
                 .ReturnsAsync(new UTXOChanges()
                 {
-                    // The fork would not return ignored dust, but keep it here to prove the local
-                    // defense-in-depth filter strips it from the response either way
-                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { dustUtxo, availableUtxo } },
-                    Unconfirmed = new UTXOChange() { UTXOs = new List<UTXO>() { unconfirmedDustUtxo } }
+                    // The backend honors the ignore list, so the dust UTXOs never come back
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { availableUtxo } }
                 });
 
             var fmutxoRepository = new Mock<IFMUTXORepository>();

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -1836,5 +1836,44 @@ namespace NodeGuard.Rpc
             ignoredOutpoints.Should().Contain(unconfirmedDustUtxo.Outpoint.ToString());
             ignoredOutpoints.Should().NotContain(availableUtxo.Outpoint.ToString());
         }
+
+        [Fact]
+        public async Task GetAvailableUtxos_CustomBackendFails_ReturnsEmptySelection()
+        {
+            // Arrange
+            var wallet = CreateWallet.SingleSig(CreateWallet.CreateInternalWallet());
+            var walletRepository = new Mock<IWalletRepository>();
+            walletRepository.Setup(x => x.GetById(It.IsAny<int>())).ReturnsAsync(wallet);
+
+            var nbxplorerService = new Mock<INBXplorerService>();
+            nbxplorerService.Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges());
+            nbxplorerService.Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .ThrowsAsync(new HttpRequestException("selectutxos request failed with status code 400"));
+
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository.Setup(x => x.GetLockedUTXOsByWalletId(It.IsAny<int>()))
+                .ReturnsAsync(new List<FMUTXO>());
+
+            var coinSelectionService = new Mock<ICoinSelectionService>();
+            coinSelectionService.Setup(x => x.GetFrozenUTXOs()).ReturnsAsync(new List<string>());
+
+            var service = CreateNodeGuardService(
+                walletRepository: walletRepository.Object,
+                nbXplorerService: nbxplorerService.Object,
+                fmutxoRepository: fmutxoRepository.Object,
+                coinSelectionService: coinSelectionService.Object);
+
+            // Act
+            var response = await service.GetAvailableUtxos(
+                new GetAvailableUtxosRequest { WalletId = 1, Amount = 10_000 },
+                TestServerCallContext.Create());
+
+            // Assert: the RPC keeps its previous contract and returns an empty selection
+            response.Confirmed.Should().BeEmpty();
+            response.Unconfirmed.Should().BeEmpty();
+        }
     }
 }

--- a/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
@@ -114,6 +114,89 @@ public class CoinSelectionServiceTests
     }
 
     [Fact]
+    public async Task GetAvailableUTXOsAsync_WithCustomBackend_IgnoresLockedFrozenAndDustServerSide()
+    {
+        var previousCustomBackend = Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND;
+        Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = true;
+        try
+        {
+            // Arrange
+            var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+            var dustUtxo = CreateUtxo(1, Constants.MINIMUM_UTXO_VALUE_SATS);
+            var lockedUtxo = CreateUtxo(2, 20_000);
+            var frozenUtxo = CreateUtxo(3, 30_000);
+            var availableUtxo = CreateUtxo(4, 40_000);
+
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository
+                .Setup(x => x.GetLockedUTXOs(null, null))
+                .ReturnsAsync(new List<FMUTXO>()
+                {
+                    new()
+                    {
+                        TxId = lockedUtxo.Outpoint.Hash.ToString(),
+                        OutputIndex = lockedUtxo.Outpoint.N,
+                        SatsAmount = 20_000
+                    }
+                });
+
+            var utxoTagRepository = new Mock<IUTXOTagRepository>();
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsFrozenTag, "true"))
+                .ReturnsAsync(new List<UTXOTag>() { new() { Outpoint = frozenUtxo.Outpoint.ToString() } });
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsManuallyFrozenTag, It.IsAny<string>()))
+                .ReturnsAsync(new List<UTXOTag>());
+
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService
+                .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange()
+                    {
+                        UTXOs = new List<UTXO>() { dustUtxo, lockedUtxo, frozenUtxo, availableUtxo }
+                    }
+                });
+            List<string>? ignoredOutpoints = null;
+            nbXplorerService
+                .Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .Callback<DerivationStrategyBase, CoinSelectionStrategy, int, long, long, List<string>?,
+                    CancellationToken>((_, _, _, _, _, ignore, _) => ignoredOutpoints = ignore)
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { availableUtxo } }
+                });
+
+            var mapper = new Mock<IMapper>();
+            var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object,
+                nbXplorerService.Object, null, null, utxoTagRepository.Object);
+
+            // Act
+            var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(
+                derivationStrategy, CoinSelectionStrategy.SmallestFirst, 0, 40_000, 0);
+
+            // Assert
+            availableUTXOs.Should().ContainSingle();
+            availableUTXOs[0].Outpoint.Should().Be(availableUtxo.Outpoint);
+
+            // Locked, frozen and dust UTXOs must all be ignored server-side so the backend does
+            // not count them towards the requested amount and return a short selection
+            ignoredOutpoints.Should().NotBeNull();
+            ignoredOutpoints.Should().Contain(dustUtxo.Outpoint.ToString());
+            ignoredOutpoints.Should().Contain($"{lockedUtxo.Outpoint.Hash}-{lockedUtxo.Outpoint.N}");
+            ignoredOutpoints.Should().Contain(frozenUtxo.Outpoint.ToString());
+            ignoredOutpoints.Should().NotContain(availableUtxo.Outpoint.ToString());
+        }
+        finally
+        {
+            Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = previousCustomBackend;
+        }
+    }
+
+    [Fact]
     public async Task GetAvailableUTXOsAsync_ExcludesDustAndLockedUTXOs()
     {
         // Arrange

--- a/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
@@ -197,6 +197,71 @@ public class CoinSelectionServiceTests
     }
 
     [Fact]
+    public async Task GetAvailableUTXOsAsync_WithCustomBackendFailing_FallsBackToPlainListingAndLocalFilter()
+    {
+        var previousCustomBackend = Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND;
+        Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = true;
+        try
+        {
+            // Arrange
+            var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+            var dustUtxo = CreateUtxo(1, Constants.MINIMUM_UTXO_VALUE_SATS);
+            var lockedUtxo = CreateUtxo(2, 20_000);
+            var availableUtxo = CreateUtxo(3, 30_000);
+
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository
+                .Setup(x => x.GetLockedUTXOs(null, null))
+                .ReturnsAsync(new List<FMUTXO>()
+                {
+                    new()
+                    {
+                        TxId = lockedUtxo.Outpoint.Hash.ToString(),
+                        OutputIndex = lockedUtxo.Outpoint.N,
+                        SatsAmount = 20_000
+                    }
+                });
+
+            var utxoTagRepository = new Mock<IUTXOTagRepository>();
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new List<UTXOTag>());
+
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService
+                .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange()
+                    {
+                        UTXOs = new List<UTXO>() { dustUtxo, lockedUtxo, availableUtxo }
+                    }
+                });
+            nbXplorerService
+                .Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .ThrowsAsync(new HttpRequestException("custom backend unavailable"));
+
+            var mapper = new Mock<IMapper>();
+            var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object,
+                nbXplorerService.Object, null, null, utxoTagRepository.Object);
+
+            // Act
+            var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(
+                derivationStrategy, CoinSelectionStrategy.SmallestFirst, 0, 30_000, 0);
+
+            // Assert: the plain listing is used and locked/dust UTXOs are still filtered locally
+            availableUTXOs.Should().ContainSingle();
+            availableUTXOs[0].Outpoint.Should().Be(availableUtxo.Outpoint);
+        }
+        finally
+        {
+            Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = previousCustomBackend;
+        }
+    }
+
+    [Fact]
     public async Task GetAvailableUTXOsAsync_ExcludesDustAndLockedUTXOs()
     {
         // Arrange

--- a/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
@@ -1,0 +1,141 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+using AutoMapper;
+using FluentAssertions;
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.TestHelpers;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
+
+namespace NodeGuard.Services;
+
+public class CoinSelectionServiceTests
+{
+    private readonly ILogger<BitcoinService> _logger = new Mock<ILogger<BitcoinService>>().Object;
+    private readonly InternalWallet _internalWallet = CreateWallet.CreateInternalWallet();
+
+    private static UTXO CreateUtxo(uint index, long satoshis)
+    {
+        return new UTXO
+        {
+            Outpoint = new OutPoint(new uint256(index), 0),
+            Value = new Money(satoshis)
+        };
+    }
+
+    private CoinSelectionService CreateCoinSelectionService(List<UTXO> confirmedUtxos, List<FMUTXO>? lockedUtxos = null)
+    {
+        var fmutxoRepository = new Mock<IFMUTXORepository>();
+        var nbXplorerService = new Mock<INBXplorerService>();
+        var utxoTagRepository = new Mock<IUTXOTagRepository>();
+        var mapper = new Mock<IMapper>();
+
+        nbXplorerService
+            .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+            .ReturnsAsync(new UTXOChanges()
+            {
+                Confirmed = new UTXOChange()
+                {
+                    UTXOs = confirmedUtxos
+                }
+            });
+        fmutxoRepository
+            .Setup(x => x.GetLockedUTXOs(null, null))
+            .ReturnsAsync(lockedUtxos ?? new List<FMUTXO>());
+        utxoTagRepository
+            .Setup(x => x.GetByKeyValue(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<UTXOTag>());
+
+        return new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object, nbXplorerService.Object, null, null, utxoTagRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetAvailableUTXOsAsync_ExcludesDustUTXOs()
+    {
+        // Arrange
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+        var coinSelectionService = CreateCoinSelectionService(new List<UTXO>()
+        {
+            CreateUtxo(1, 100),
+            CreateUtxo(2, Constants.MINIMUM_UTXO_VALUE_SATS), // 546, boundary: excluded (inclusive comparison)
+            CreateUtxo(3, Constants.MINIMUM_UTXO_VALUE_SATS + 1),
+            CreateUtxo(4, 10_000)
+        });
+
+        // Act
+        var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(derivationStrategy);
+
+        // Assert
+        availableUTXOs
+            .Select(utxo => ((Money)utxo.Value).Satoshi)
+            .Should()
+            .BeEquivalentTo(new[] { Constants.MINIMUM_UTXO_VALUE_SATS + 1, 10_000L });
+    }
+
+    [Theory]
+    [InlineData(CoinSelectionStrategy.SmallestFirst)]
+    [InlineData(CoinSelectionStrategy.BiggestFirst)]
+    [InlineData(CoinSelectionStrategy.ClosestToTargetFirst)]
+    [InlineData(CoinSelectionStrategy.UpToAmount)]
+    public async Task GetAvailableUTXOsAsync_WithStrategy_ExcludesDustUTXOs(CoinSelectionStrategy strategy)
+    {
+        // Arrange
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+        var dustUtxo = CreateUtxo(1, Constants.MINIMUM_UTXO_VALUE_SATS);
+        var availableUtxo = CreateUtxo(2, 10_000);
+        var coinSelectionService = CreateCoinSelectionService(new List<UTXO>() { dustUtxo, availableUtxo });
+
+        // Act
+        var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(
+            derivationStrategy, strategy, 0, 10_000, Constants.MINIMUM_UTXO_VALUE_SATS);
+
+        // Assert
+        availableUTXOs.Should().ContainSingle();
+        availableUTXOs[0].Outpoint.Should().Be(availableUtxo.Outpoint);
+    }
+
+    [Fact]
+    public async Task GetAvailableUTXOsAsync_ExcludesDustAndLockedUTXOs()
+    {
+        // Arrange
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+        var dustUtxo = CreateUtxo(1, 546);
+        var lockedUtxo = CreateUtxo(2, 20_000);
+        var availableUtxo = CreateUtxo(3, 30_000);
+        var lockedFmutxo = new FMUTXO()
+        {
+            TxId = lockedUtxo.Outpoint.Hash.ToString(),
+            OutputIndex = lockedUtxo.Outpoint.N,
+            SatsAmount = 20_000
+        };
+        var coinSelectionService = CreateCoinSelectionService(
+            new List<UTXO>() { dustUtxo, lockedUtxo, availableUtxo },
+            new List<FMUTXO>() { lockedFmutxo });
+
+        // Act
+        var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(derivationStrategy);
+
+        // Assert
+        availableUTXOs.Should().ContainSingle();
+        availableUTXOs[0].Outpoint.Should().Be(availableUtxo.Outpoint);
+    }
+}


### PR DESCRIPTION
Implement logic to prevent the selection of dust coins during transaction creation, this shall prevent dust attacks.

Dust UTXOs are tagged accordinly and cannot be frozen/unfrozen.

<img width="2248" height="584" alt="image" src="https://github.com/user-attachments/assets/397f6bea-dd05-431a-8753-189d0a2f9eb2" />

