### PR TITLE
Fix lost HTLC/channel events by reconnecting lnd subscriptions on drop

### DIFF
--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -112,6 +112,13 @@ services:
       BITCOIND_RPC_PASS: "polarpass"
       BITCOIND_RPC_WALLET: "default"
       E2E_HOT_WALLET_ID: "3"
+      # The HTLC-reconnect test reads persisted ForwardingHtlcEvents straight from Postgres
+      # (there is no gRPC to list them) and restarts a forwarding LND node mid-test.
+      POSTGRES_CONNECTIONSTRING: "Host=postgres;Port=5432;Database=nodeguard;User ID=postgres;"
+      E2E_FORWARDING_NODE_CONTAINER: "polar-n1-bob"
+    volumes:
+      # Lets the reconnect test restart an LND container via the Docker Engine API socket.
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: "no"
 
 volumes:

--- a/src/Helpers/SubscriptionStreamRunner.cs
+++ b/src/Helpers/SubscriptionStreamRunner.cs
@@ -76,7 +76,7 @@ public static class SubscriptionStreamRunner
                     return;
                 }
 
-                var stream = subscribe(node);
+                using var stream = subscribe(node);
                 while (await stream.ResponseStream.MoveNext(context.CancellationToken))
                 {
                     // A received event proves the connection is healthy: reset the backoff.

--- a/src/Helpers/SubscriptionStreamRunner.cs
+++ b/src/Helpers/SubscriptionStreamRunner.cs
@@ -1,0 +1,115 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using Grpc.Core;
+using NodeGuard.Data.Models;
+using Quartz;
+
+namespace NodeGuard.Helpers;
+
+public static class SubscriptionStreamRunner
+{
+    private static readonly TimeSpan InitialBackoff = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Keeps a long-lived lnd streaming subscription alive for the lifetime of a Quartz job.
+    /// lnd's streaming RPCs are live-only with no replay, so any gap between the stream dropping
+    /// and us resubscribing loses events permanently. This resubscribes on *any* stream
+    /// termination — a thrown error OR a clean end-of-stream (MoveNext -> false, which a graceful
+    /// lnd shutdown/release produces) — with exponential backoff, invalidating the cached gRPC
+    /// channel on error so a half-open connection is rebuilt on the next attempt. It stops only
+    /// when the job is cancelled (NodeGuard shutting down) or <paramref name="getEligibleNode"/>
+    /// returns null (the node was removed or is no longer eligible).
+    /// </summary>
+    /// <param name="getEligibleNode">Fetches the node and returns it if the subscription should
+    /// (still) run, or null to stop the worker. Called once per (re)subscription, not per event.</param>
+    /// <param name="subscribe">Opens the streaming call for the given node.</param>
+    /// <param name="handleEvent">Processes a single received event. It must swallow its own
+    /// per-event errors; anything it throws is treated as a stream failure and triggers a
+    /// channel invalidation + resubscribe.</param>
+    /// <param name="invalidateClient">Evicts the cached gRPC channel for the given endpoint.</param>
+    /// <param name="initialBackoff">Delay before the first reconnect attempt (defaults to 2s;
+    /// overridable mainly for tests).</param>
+    /// <param name="maxBackoff">Upper bound the backoff grows to (defaults to 30s).</param>
+    public static async Task RunAsync<TResponse>(
+        IJobExecutionContext context,
+        ILogger logger,
+        string jobName,
+        int nodeId,
+        Func<Task<Node?>> getEligibleNode,
+        Func<Node, AsyncServerStreamingCall<TResponse>> subscribe,
+        Func<TResponse, Node, Task> handleEvent,
+        Action<string?> invalidateClient,
+        TimeSpan? initialBackoff = null,
+        TimeSpan? maxBackoff = null)
+    {
+        var initial = initialBackoff ?? InitialBackoff;
+        var max = maxBackoff ?? MaxBackoff;
+        var backoff = initial;
+
+        while (!context.CancellationToken.IsCancellationRequested)
+        {
+            Node? node = null;
+            try
+            {
+                node = await getEligibleNode();
+                if (node == null)
+                {
+                    logger.LogInformation("Node {NodeId} is no longer eligible for {JobName}; stopping worker", nodeId, jobName);
+                    return;
+                }
+
+                var stream = subscribe(node);
+                while (await stream.ResponseStream.MoveNext(context.CancellationToken))
+                {
+                    // A received event proves the connection is healthy: reset the backoff.
+                    backoff = initial;
+                    await handleEvent(stream.ResponseStream.Current, node);
+                }
+
+                // MoveNext returned false: lnd closed the stream cleanly (e.g. it is restarting).
+                // Fall through to backoff + resubscribe instead of exiting the worker.
+                logger.LogWarning("{JobName} stream for node {NodeId} ended; will resubscribe", jobName, nodeId);
+            }
+            catch (Exception) when (context.CancellationToken.IsCancellationRequested)
+            {
+                logger.LogInformation("{JobName} for node {NodeId} cancelled (shutdown)", jobName, nodeId);
+                return;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error in {JobName} for node {NodeId}; will resubscribe", jobName, nodeId);
+                // Drop the (possibly half-open) cached channel so the next attempt rebuilds it.
+                invalidateClient(node?.Endpoint);
+            }
+
+            try
+            {
+                await Task.Delay(backoff, context.CancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            backoff = TimeSpan.FromSeconds(Math.Min(max.TotalSeconds, backoff.TotalSeconds * 2));
+        }
+    }
+}

--- a/src/Jobs/NodeChannelSubscribeJob.cs
+++ b/src/Jobs/NodeChannelSubscribeJob.cs
@@ -18,8 +18,8 @@
  */
 
 using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
 using NodeGuard.Services;
-using Grpc.Core;
 using Lnrpc;
 using Quartz;
 using Channel = NodeGuard.Data.Models.Channel;
@@ -54,53 +54,30 @@ public class NodeChannelSuscribeJob : IJob
         var data = context.JobDetail.JobDataMap;
         var nodeId = data.GetInt("nodeId");
         _logger.LogInformation("Starting {JobName} for node {nodeId}... ", nameof(NodeChannelSuscribeJob), nodeId);
-        try
-        {
-            var node = await _nodeRepository.GetById(nodeId);
 
-            if (node == null)
+        // NodeUpdateManagement only reads the immutable node.Id, so the node is fetched once per
+        // (re)subscription rather than per event. SubscriptionStreamRunner keeps the subscription
+        // alive across reconnects (a release otherwise silently kills it until the next restart).
+        await SubscriptionStreamRunner.RunAsync<ChannelEventUpdate>(
+            context,
+            _logger,
+            nameof(NodeChannelSuscribeJob),
+            nodeId,
+            getEligibleNode: () => _nodeRepository.GetById(nodeId),
+            subscribe: node => _lightningClientService.SubscribeChannelEvents(node),
+            handleEvent: async (channelEventUpdate, node) =>
             {
-                _logger.LogInformation("The node: {@Node} is no longer ready to be supported quartz jobs", node);
-                return;
-            }
-
-            var result = _lightningClientService.SubscribeChannelEvents(node);
-
-            while (await result.ResponseStream.MoveNext())
-            {
-                node = await _nodeRepository.GetById(nodeId);
-
-                if (node == null)
-                {
-                    _logger.LogInformation("The node: {@Node} is no longer ready to be supported quartz jobs", node);
-                    return;
-                }
-
                 try
                 {
-                    var channelEventUpdate = result.ResponseStream.Current;
                     _logger.LogInformation("Channel event update received for node {@NodeId}", node.Id);
                     await NodeUpdateManagement(channelEventUpdate, node);
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e, "Error reading and update event of node {NodeId}", nodeId);
-                    throw new JobExecutionException(e, true);
+                    _logger.LogError(e, "Error reading and updating event of node {NodeId}. Event will be skipped", nodeId);
                 }
-                
-              
-            }
-            
-         
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Error while subscribing for the channel updates of node {NodeId}", nodeId);
-            //Sleep to avoid massive requests
-            await Task.Delay(5000);
-            
-            throw new JobExecutionException(e, true);
-        }
+            },
+            invalidateClient: _lightningClientService.InvalidateClient);
 
         _logger.LogInformation("{JobName} ended", nameof(NodeChannelSuscribeJob));
     }

--- a/src/Jobs/NodeHtlcSubscribeJob.cs
+++ b/src/Jobs/NodeHtlcSubscribeJob.cs
@@ -21,6 +21,7 @@ using System.Numerics;
 using Lnrpc;
 using NodeGuard.Data.Models;
 using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
 using NodeGuard.Services;
 using Quartz;
 using Routerrpc;
@@ -68,51 +69,45 @@ public class NodeHtlcSubscribeJob : IJob
         var nodeId = data.GetInt("nodeId");
         _logger.LogInformation("Starting {JobName} for node {NodeId}... ", nameof(NodeHtlcSubscribeJob), nodeId);
 
-        try
-        {
-            var node = await _nodeRepository.GetById(nodeId, false);
-            if (!IsNodeEligible(node))
+        // lnd's SubscribeHtlcEvents is a live-only stream with no replay, so the subscription is
+        // kept alive across reconnects by SubscriptionStreamRunner. Only immutable node fields
+        // (PubKey/Name) are read while a stream is up, so the node is fetched once per
+        // (re)subscription rather than per event.
+        await SubscriptionStreamRunner.RunAsync<HtlcEvent>(
+            context,
+            _logger,
+            nameof(NodeHtlcSubscribeJob),
+            nodeId,
+            getEligibleNode: async () =>
             {
-                _logger.LogInformation("Node {NodeId} is not eligible for HTLC monitoring", nodeId);
-                return;
-            }
-
-            var stream = _lightningRouterService.SubscribeHtlcEvents(node!);
-            while (await stream.ResponseStream.MoveNext(context.CancellationToken))
+                var node = await _nodeRepository.GetById(nodeId, false);
+                return IsNodeEligible(node) ? node : null;
+            },
+            subscribe: node => _lightningRouterService.SubscribeHtlcEvents(node),
+            handleEvent: async (htlcEvent, node) =>
             {
-                node = await _nodeRepository.GetById(nodeId, false);
-
                 try
                 {
-                    var htlcEvent = stream.ResponseStream.Current;
-                    var eventToPersist = MapForwardingEvent(node!, htlcEvent);
+                    var eventToPersist = MapForwardingEvent(node, htlcEvent);
                     if (eventToPersist == null)
                     {
-                        continue;
+                        return;
                     }
 
-                    await EnrichForwardingEventAsync(node!, eventToPersist);
+                    await EnrichForwardingEventAsync(node, eventToPersist);
 
                     var addResult = await _forwardingHtlcEventRepository.UpsertAsync(eventToPersist);
                     if (!addResult.Item1)
                     {
                         _logger.LogWarning("HTLC event was not persisted for node {NodeId}: {Error}", nodeId, addResult.Item2);
-                        continue;
                     }
                 }
                 catch (Exception e)
                 {
                     _logger.LogError(e, "Error processing HTLC event for node {NodeId}. Event will be skipped", nodeId);
-                    continue;
                 }
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Error while subscribing HTLC events for node {NodeId}", nodeId);
-            await Task.Delay(5000);
-            throw new JobExecutionException(e, true);
-        }
+            },
+            invalidateClient: _lightningRouterService.InvalidateClient);
 
         _logger.LogInformation("{JobName} ended", nameof(NodeHtlcSubscribeJob));
     }

--- a/src/Services/LightningClientService.cs
+++ b/src/Services/LightningClientService.cs
@@ -33,6 +33,7 @@ namespace NodeGuard.Services;
 public interface ILightningClientService
 {
     public Lightning.LightningClient GetLightningClient(string? endpoint);
+    public void InvalidateClient(string? endpoint);
     public Task<GetInfoResponse?> GetInfo(Node node, Lightning.LightningClient? client = null);
     public Task<ListChannelsResponse?> ListChannels(Node node, Lightning.LightningClient? client = null);
     public Task<ChannelBalanceResponse?> ChannelBalanceAsync(Node node, Lightning.LightningClient? client = null);
@@ -79,6 +80,35 @@ public class LightningClientService : ILightningClientService
         _logger.LogInformation("New grpc channel created for endpoint {endpoint}", endpoint);
 
         return grpcChannel;
+    }
+
+    /// <summary>
+    /// Evicts and disposes the cached channel for an endpoint so the next call rebuilds a
+    /// fresh connection. Call this after a stream/RPC failure to avoid reusing a half-open
+    /// channel that would otherwise keep hanging.
+    /// </summary>
+    public void InvalidateClient(string? endpoint)
+    {
+        if (endpoint == null)
+        {
+            return;
+        }
+
+        lock (_clients)
+        {
+            if (_clients.TryRemove(endpoint, out var channel))
+            {
+                _logger.LogInformation("Invalidated cached grpc channel for endpoint {endpoint}", endpoint);
+                try
+                {
+                    channel.Dispose();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogWarning(e, "Error disposing grpc channel for endpoint {endpoint}", endpoint);
+                }
+            }
+        }
     }
 
     public Lightning.LightningClient GetLightningClient(string? endpoint)

--- a/src/Services/LightningClientService.cs
+++ b/src/Services/LightningClientService.cs
@@ -94,20 +94,25 @@ public class LightningClientService : ILightningClientService
             return;
         }
 
+        GrpcChannel? channel;
         lock (_clients)
         {
-            if (_clients.TryRemove(endpoint, out var channel))
+            if (!_clients.TryRemove(endpoint, out channel))
             {
-                _logger.LogInformation("Invalidated cached grpc channel for endpoint {endpoint}", endpoint);
-                try
-                {
-                    channel.Dispose();
-                }
-                catch (Exception e)
-                {
-                    _logger.LogWarning(e, "Error disposing grpc channel for endpoint {endpoint}", endpoint);
-                }
+                return;
             }
+        }
+
+        // Dispose outside the lock: GrpcChannel.Dispose can block, and holding the lock would
+        // stall every concurrent GetLightningClient call.
+        _logger.LogInformation("Invalidated cached grpc channel for endpoint {endpoint}", endpoint);
+        try
+        {
+            channel.Dispose();
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error disposing grpc channel for endpoint {endpoint}", endpoint);
         }
     }
 

--- a/src/Services/LightningRouterService.cs
+++ b/src/Services/LightningRouterService.cs
@@ -59,20 +59,25 @@ public class LightningRouterService : ILightningRouterService
             return;
         }
 
+        GrpcChannel? channel;
         lock (_clients)
         {
-            if (_clients.TryRemove(endpoint, out var channel))
+            if (!_clients.TryRemove(endpoint, out channel))
             {
-                _logger.LogInformation("Invalidated cached router grpc channel for endpoint {endpoint}", endpoint);
-                try
-                {
-                    channel.Dispose();
-                }
-                catch (Exception e)
-                {
-                    _logger.LogWarning(e, "Error disposing router grpc channel for endpoint {endpoint}", endpoint);
-                }
+                return;
             }
+        }
+
+        // Dispose outside the lock: GrpcChannel.Dispose can block, and holding the lock would
+        // stall every concurrent GetRouterClient call.
+        _logger.LogInformation("Invalidated cached router grpc channel for endpoint {endpoint}", endpoint);
+        try
+        {
+            channel.Dispose();
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Error disposing router grpc channel for endpoint {endpoint}", endpoint);
         }
     }
 

--- a/src/Services/LightningRouterService.cs
+++ b/src/Services/LightningRouterService.cs
@@ -12,6 +12,7 @@ namespace NodeGuard.Services;
 public interface ILightningRouterService
 {
     public Router.RouterClient GetRouterClient(string? endpoint);
+    public void InvalidateClient(string? endpoint);
     public Task<RouteFeeResponse?> EstimateRouteFee(Node node, RouteFeeRequest routeFeeRequest, Router.RouterClient? client = null);
     public AsyncServerStreamingCall<HtlcEvent> SubscribeHtlcEvents(Node node, Router.RouterClient? client = null);
     public AsyncServerStreamingCall<Payment> SendPaymentV2(Node node, SendPaymentRequest request, CancellationToken cancellationToken, Router.RouterClient? client = null);
@@ -44,6 +45,35 @@ public class LightningRouterService : ILightningRouterService
         _logger.LogInformation("New grpc channel created for router endpoint {endpoint}", endpoint);
 
         return grpcChannel;
+    }
+
+    /// <summary>
+    /// Evicts and disposes the cached router channel for an endpoint so the next call rebuilds
+    /// a fresh connection. Call this after a stream/RPC failure to avoid reusing a half-open
+    /// channel that would otherwise keep hanging.
+    /// </summary>
+    public void InvalidateClient(string? endpoint)
+    {
+        if (endpoint == null)
+        {
+            return;
+        }
+
+        lock (_clients)
+        {
+            if (_clients.TryRemove(endpoint, out var channel))
+            {
+                _logger.LogInformation("Invalidated cached router grpc channel for endpoint {endpoint}", endpoint);
+                try
+                {
+                    channel.Dispose();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogWarning(e, "Error disposing router grpc channel for endpoint {endpoint}", endpoint);
+                }
+            }
+        }
     }
 
     public Router.RouterClient GetRouterClient(string? endpoint)

--- a/test/NodeGuard.Tests/E2E/HtlcSubscriptionReconnectE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/HtlcSubscriptionReconnectE2ETests.cs
@@ -1,0 +1,274 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using NBitcoin;
+using NBitcoin.RPC;
+using Nodeguard;
+using Npgsql;
+using Xunit.Abstractions;
+
+namespace NodeGuard.Tests.E2E;
+
+/// <summary>
+/// End-to-end proof of the HTLC-subscription self-healing fix: a managed forwarding node's lnd is
+/// restarted mid-test, and NodeGuard must resubscribe and keep persisting the HTLCs it forwards.
+///
+/// Flow:
+///   GetNodes → OpenChannel(Alice→Bob) → circular rebalance (Alice→Bob→Carol→Alice) so Bob forwards
+///   HTLCs → assert Bob's ForwardingHtlcEvents appear in Postgres → RESTART Bob's lnd container →
+///   rebalance again → assert Bob's ForwardingHtlcEvents count INCREASED.
+///
+/// Bob is the node under test because in a circular rebalance only the intermediate hops (Bob,
+/// Carol) emit lnd <c>Forward</c> events — the only kind <c>NodeHtlcSubscribeJob</c> persists.
+/// Without the reconnect fix, Bob's subscription would exit on the clean stream-end its lnd restart
+/// produces and stay dead until NodeGuard itself restarts, so the post-restart forward would never
+/// be persisted and the final assertion would fail.
+///
+/// Gated by <see cref="E2EFactAttribute"/> (RUN_E2E_TESTS=1). Extra env beyond the other e2e tests:
+///   POSTGRES_CONNECTIONSTRING        NodeGuard DB (there is no gRPC to read forwarding events)
+///   E2E_FORWARDING_NODE_CONTAINER    LND container to restart (default polar-n1-bob)
+///   DOCKER_SOCKET                    Docker Engine API socket (default /var/run/docker.sock)
+/// </summary>
+[Trait("Category", "E2E")]
+[Collection("E2E")]
+public class HtlcSubscriptionReconnectE2ETests
+{
+    private const string DefaultDevToken = "8rvSsUGeyXXdDQrHctcTey/xtHdZQEn945KHwccKp9Q=";
+
+    private readonly ITestOutputHelper _output;
+
+    public HtlcSubscriptionReconnectE2ETests(ITestOutputHelper output)
+    {
+        _output = output;
+        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+    }
+
+    [E2EFact]
+    public async Task HtlcSubscription_SurvivesForwardingNodeRestart_AndKeepsPersistingEvents()
+    {
+        var client = CreateClient(out var headers);
+        var rpc = CreateBitcoindRpc();
+
+        // 0. Wait for NodeGuard and its seeded, managed nodes (alice/bob/carol).
+        var nodes = await WaitForNodesAsync(client, headers);
+        var alice = nodes.Single(n => n.Name == "alice");
+        var bob = nodes.Single(n => n.Name == "bob");
+        var carol = nodes.Single(n => n.Name == "carol");
+        _output.WriteLine($"alice={alice.PubKey} bob={bob.PubKey} carol={carol.PubKey}");
+
+        // 1. Open Alice→Bob so the circular rebalance forwards HTLCs through Bob.
+        var channelId = await OpenAliceBobChannelAsync(client, headers, rpc, alice, bob);
+
+        // 2. First rebalance → Bob forwards → Bob's subscription persists the forward event(s).
+        await RetryAsync(async () => { await RebalanceAsync(client, headers, alice, carol, channelId); return true; },
+            attempts: 10, delay: TimeSpan.FromSeconds(6), what: "initial rebalance");
+
+        // 3. Baseline: Bob's forwarding events must be visible in Postgres before we restart it —
+        //    this proves the subscription pipeline works pre-restart.
+        var baseline = await PollUntilAsync(
+            () => CountForwardingEventsAsync(bob.PubKey), c => c > 0,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: "baseline Bob forwarding events > 0");
+        _output.WriteLine($"baseline Bob forwarding events = {baseline}");
+
+        // 4. Restart Bob's lnd → its HTLC stream drops. The fix must make NodeGuard resubscribe.
+        var container = Env("E2E_FORWARDING_NODE_CONTAINER", "polar-n1-bob");
+        _output.WriteLine($"restarting {container} to drop Bob's HTLC subscription");
+        await RestartContainerAsync(container);
+
+        // 5. Rebalance again once Bob's lnd is back and its channels reactivate. Retry while that
+        //    happens (and while NodeGuard resubscribes — backoff up to 30s). Route failures while
+        //    Bob is down fail fast (no route), so the loop just spins cheaply until it recovers.
+        await RetryAsync(async () =>
+        {
+            await MineAsync(rpc, 2); // nudge channel reactivation / gossip
+            await RebalanceAsync(client, headers, alice, carol, channelId);
+            return true;
+        }, attempts: 40, delay: TimeSpan.FromSeconds(6), what: "post-restart rebalance");
+
+        // 6. The real assertion: Bob's forwarding events increased after the restart. That can only
+        //    happen if Bob's HTLC subscription reconnected and captured the post-restart forward.
+        var after = await PollUntilAsync(
+            () => CountForwardingEventsAsync(bob.PubKey), c => c > baseline,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: $"Bob forwarding events > baseline ({baseline})");
+        _output.WriteLine($"post-reconnect Bob forwarding events = {after}");
+
+        after.Should().BeGreaterThan(baseline,
+            "Bob's HTLC subscription must resubscribe after its lnd restarts and keep persisting forwarded HTLCs");
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------
+
+    private async Task<long> OpenAliceBobChannelAsync(
+        NodeGuardService.NodeGuardServiceClient client, Metadata headers, RPCClient rpc, Node alice, Node bob)
+    {
+        var walletId = int.Parse(Env("E2E_HOT_WALLET_ID", "3"));
+        var openReq = new OpenChannelRequest
+        {
+            SourcePubKey = alice.PubKey,
+            DestinationPubKey = bob.PubKey,
+            WalletId = walletId,
+            SatsAmount = 5_000_000,
+            Private = false,
+            Changeless = false,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = 2,
+        };
+        var opId = await RetryAsync(
+            async () => (await client.OpenChannelAsync(openReq, headers)).ChannelOperationRequestId,
+            attempts: 10, delay: TimeSpan.FromSeconds(6), what: "OpenChannel");
+        _output.WriteLine($"OpenChannel → operation {opId}");
+
+        long channelId = 0;
+        for (var i = 0; i < 40 && channelId == 0; i++)
+        {
+            await MineAsync(rpc, 2);
+            var st = await client.GetChannelOperationRequestAsync(
+                new GetChannelOperationRequestRequest { ChannelOperationRequestId = opId }, headers);
+            if (st.HasChannelId && st.ChannelId > 0) channelId = st.ChannelId;
+            else await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+        channelId.Should().BeGreaterThan(0, "NodeGuard should record the opened Alice→Bob channel id");
+
+        await MineAsync(rpc, 6); // let lnd mark the channel active and gossip propagate
+        await Task.Delay(TimeSpan.FromSeconds(4));
+        return channelId;
+    }
+
+    private async Task RebalanceAsync(
+        NodeGuardService.NodeGuardServiceClient client, Metadata headers, Node alice, Node carol, long channelId)
+    {
+        var resp = await client.RequestRebalanceAsync(new RequestRebalanceRequest
+        {
+            NodePubkey = alice.PubKey,
+            SourceChannelId = (int)channelId,
+            TargetPubkey = carol.PubKey,
+            AmountSats = 200_000,
+            MaxFeePct = 0.5,
+            MaxAttempts = 2,
+        }, headers);
+        _output.WriteLine($"rebalance {resp.RebalanceId}: status={resp.Status} feeSats={resp.FeePaidSats}");
+        resp.Status.Should().Be(REBALANCE_STATUS.RebalanceSucceeded);
+    }
+
+    /// <summary>Counts persisted forwarding HTLC events for a managed node, read straight from
+    /// Postgres because NodeGuard exposes no gRPC to list them.</summary>
+    private static async Task<long> CountForwardingEventsAsync(string managedNodePubKey)
+    {
+        var connString = Env("POSTGRES_CONNECTIONSTRING",
+            "Host=localhost;Port=5432;Database=nodeguard;User ID=postgres;");
+        await using var conn = new NpgsqlConnection(connString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM \"ForwardingHtlcEvents\" WHERE \"ManagedNodePubKey\" = @pk", conn);
+        cmd.Parameters.AddWithValue("pk", managedNodePubKey);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+
+    /// <summary>Restarts a container via the Docker Engine API over its unix socket (the runner
+    /// mounts /var/run/docker.sock) — no docker CLI needed in the image.</summary>
+    private async Task RestartContainerAsync(string containerName)
+    {
+        var socketPath = Env("DOCKER_SOCKET", "/var/run/docker.sock");
+        using var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = async (_, ct) =>
+            {
+                var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                await socket.ConnectAsync(new UnixDomainSocketEndPoint(socketPath), ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+        };
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        // t = seconds to wait for a graceful stop before SIGKILL; either way lnd's stream drops.
+        using var resp = await http.PostAsync($"/containers/{containerName}/restart?t=15", content: null);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync();
+            throw new InvalidOperationException(
+                $"docker restart {containerName} failed: {(int)resp.StatusCode} {body}");
+        }
+    }
+
+    private async Task<long> PollUntilAsync(
+        Func<Task<long>> read, Func<long, bool> predicate, int attempts, TimeSpan delay, string what)
+    {
+        long last = 0;
+        for (var i = 0; i < attempts; i++)
+        {
+            last = await read();
+            if (predicate(last)) return last;
+            await Task.Delay(delay);
+        }
+        throw new InvalidOperationException($"{what} not met after {attempts} attempts (last={last})");
+    }
+
+    private async Task<IReadOnlyList<Node>> WaitForNodesAsync(
+        NodeGuardService.NodeGuardServiceClient client, Metadata headers)
+    {
+        return await RetryAsync(async () =>
+        {
+            var resp = await client.GetNodesAsync(new GetNodesRequest(), headers);
+            var seeded = resp.Nodes.Where(n => n.Name is "alice" or "bob" or "carol").ToList();
+            if (seeded.Count < 3) throw new InvalidOperationException($"only {seeded.Count}/3 nodes seeded");
+            return (IReadOnlyList<Node>)seeded;
+        }, attempts: 90, delay: TimeSpan.FromSeconds(4), what: "GetNodes (NodeGuard readiness)");
+    }
+
+    private async Task MineAsync(RPCClient rpc, int blocks)
+    {
+        var addr = await rpc.GetNewAddressAsync();
+        await rpc.GenerateToAddressAsync(blocks, addr);
+    }
+
+    private async Task<T> RetryAsync<T>(Func<Task<T>> action, int attempts, TimeSpan delay, string what)
+    {
+        Exception? last = null;
+        for (var i = 0; i < attempts; i++)
+        {
+            try { return await action(); }
+            catch (Exception ex) { last = ex; _output.WriteLine($"{what} attempt {i + 1}/{attempts} failed: {ex.Message}"); }
+            await Task.Delay(delay);
+        }
+        throw new InvalidOperationException($"{what} did not succeed after {attempts} attempts", last);
+    }
+
+    private static NodeGuardService.NodeGuardServiceClient CreateClient(out Metadata headers)
+    {
+        var endpoint = Env("NODEGUARD_GRPC_ENDPOINT", "http://localhost:50051");
+        headers = new Metadata { { "auth-token", Env("NODEGUARD_API_TOKEN", DefaultDevToken) } };
+        return new NodeGuardService.NodeGuardServiceClient(GrpcChannel.ForAddress(endpoint));
+    }
+
+    private static RPCClient CreateBitcoindRpc()
+    {
+        var url = Env("BITCOIND_RPC_URL", "http://localhost:18443");
+        var cred = new NetworkCredential(Env("BITCOIND_RPC_USER", "polaruser"), Env("BITCOIND_RPC_PASS", "polarpass"));
+        var rpc = new RPCClient(cred, new Uri(url), Network.RegTest);
+        return rpc.SetWalletContext(Env("BITCOIND_RPC_WALLET", "default"));
+    }
+
+    private static string Env(string name, string fallback)
+        => Environment.GetEnvironmentVariable(name) is { Length: > 0 } v ? v : fallback;
+}

--- a/test/NodeGuard.Tests/Helpers/SubscriptionStreamRunnerTests.cs
+++ b/test/NodeGuard.Tests/Helpers/SubscriptionStreamRunnerTests.cs
@@ -1,0 +1,216 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodeGuard.Helpers;
+using Quartz;
+using Node = NodeGuard.Data.Models.Node;
+
+namespace NodeGuard.Tests.Helpers;
+
+public class SubscriptionStreamRunnerTests
+{
+    // Tiny backoff so reconnect tests don't wait real seconds.
+    private static readonly TimeSpan FastBackoff = TimeSpan.FromMilliseconds(1);
+
+    [Fact]
+    public async Task RunAsync_WhenNodeNotEligible_DoesNotSubscribe()
+    {
+        using var cts = new CancellationTokenSource();
+        var subscribeCount = 0;
+
+        await SubscriptionStreamRunner.RunAsync<string>(
+            ContextWith(cts.Token),
+            NullLogger.Instance,
+            "test",
+            nodeId: 1,
+            getEligibleNode: () => Task.FromResult<Node?>(null),
+            subscribe: _ => { subscribeCount++; return StreamOf(Array.Empty<string>()); },
+            handleEvent: (_, _) => Task.CompletedTask,
+            invalidateClient: _ => { },
+            initialBackoff: FastBackoff,
+            maxBackoff: FastBackoff);
+
+        subscribeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenAlreadyCancelled_DoesNothing()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var eligibleCalls = 0;
+
+        await SubscriptionStreamRunner.RunAsync<string>(
+            ContextWith(cts.Token),
+            NullLogger.Instance,
+            "test",
+            nodeId: 1,
+            getEligibleNode: () => { eligibleCalls++; return Task.FromResult<Node?>(new Node()); },
+            subscribe: _ => StreamOf(Array.Empty<string>()),
+            handleEvent: (_, _) => Task.CompletedTask,
+            invalidateClient: _ => { },
+            initialBackoff: FastBackoff,
+            maxBackoff: FastBackoff);
+
+        eligibleCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_HandlesEachEvent_UntilCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        var handled = new List<string>();
+        var node = new Node { Endpoint = "host:1" };
+
+        await SubscriptionStreamRunner.RunAsync<string>(
+            ContextWith(cts.Token),
+            NullLogger.Instance,
+            "test",
+            nodeId: 1,
+            getEligibleNode: () => Task.FromResult<Node?>(node),
+            subscribe: _ => StreamOf(new[] { "a", "b" }),
+            handleEvent: (ev, _) =>
+            {
+                handled.Add(ev);
+                if (ev == "b") cts.Cancel(); // stop after consuming both events
+                return Task.CompletedTask;
+            },
+            invalidateClient: _ => { },
+            initialBackoff: FastBackoff,
+            maxBackoff: FastBackoff);
+
+        handled.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public async Task RunAsync_ResubscribesAfterCleanStreamEnd()
+    {
+        // The core fix: a stream that ends cleanly (MoveNext -> false) must resubscribe, not exit.
+        using var cts = new CancellationTokenSource();
+        var subscribeCount = 0;
+        var handled = new List<string>();
+        var node = new Node { Endpoint = "host:1" };
+
+        await SubscriptionStreamRunner.RunAsync<string>(
+            ContextWith(cts.Token),
+            NullLogger.Instance,
+            "test",
+            nodeId: 1,
+            getEligibleNode: () => Task.FromResult<Node?>(node),
+            subscribe: _ =>
+            {
+                subscribeCount++;
+                // First stream ends cleanly with no events; the second yields one.
+                return subscribeCount == 1
+                    ? StreamOf(Array.Empty<string>())
+                    : StreamOf(new[] { "x" });
+            },
+            handleEvent: (ev, _) =>
+            {
+                handled.Add(ev);
+                cts.Cancel();
+                return Task.CompletedTask;
+            },
+            invalidateClient: _ => { },
+            initialBackoff: FastBackoff,
+            maxBackoff: FastBackoff);
+
+        subscribeCount.Should().Be(2);
+        handled.Should().Equal("x");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenStreamThrows_InvalidatesChannelAndRetries()
+    {
+        using var cts = new CancellationTokenSource();
+        var invalidated = new List<string?>();
+        var node = new Node { Endpoint = "host:1" };
+        var eligibleCalls = 0;
+
+        await SubscriptionStreamRunner.RunAsync<string>(
+            ContextWith(cts.Token),
+            NullLogger.Instance,
+            "test",
+            nodeId: 1,
+            // Run one failing subscription, then report the node ineligible to stop the loop.
+            getEligibleNode: () =>
+            {
+                eligibleCalls++;
+                return Task.FromResult(eligibleCalls == 1 ? node : null);
+            },
+            subscribe: _ => StreamOf<string>(Array.Empty<string>(), new InvalidOperationException("boom")),
+            handleEvent: (_, _) => Task.CompletedTask,
+            invalidateClient: endpoint => invalidated.Add(endpoint),
+            initialBackoff: FastBackoff,
+            maxBackoff: FastBackoff);
+
+        invalidated.Should().Equal("host:1");
+    }
+
+    private static IJobExecutionContext ContextWith(CancellationToken token)
+    {
+        var context = new Mock<IJobExecutionContext>();
+        context.Setup(c => c.CancellationToken).Returns(token);
+        return context.Object;
+    }
+
+    private static AsyncServerStreamingCall<T> StreamOf<T>(IEnumerable<T> items, Exception? throwWhenExhausted = null)
+        => TestCalls.AsyncServerStreamingCall(
+            new FakeAsyncStreamReader<T>(items, throwWhenExhausted),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+
+    private sealed class FakeAsyncStreamReader<T> : IAsyncStreamReader<T>
+    {
+        private readonly IEnumerator<T> _items;
+        private readonly Exception? _throwWhenExhausted;
+
+        public FakeAsyncStreamReader(IEnumerable<T> items, Exception? throwWhenExhausted)
+        {
+            _items = items.GetEnumerator();
+            _throwWhenExhausted = throwWhenExhausted;
+        }
+
+        public T Current { get; private set; } = default!;
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_items.MoveNext())
+            {
+                Current = _items.Current;
+                return Task.FromResult(true);
+            }
+
+            if (_throwWhenExhausted != null)
+            {
+                throw _throwWhenExhausted;
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}


### PR DESCRIPTION
LND's HTLC/channel event streams are live-only with no replay, so when a stream dropped (e.g. on a release) the subscription job exited silently and stayed dead until the next NodeGuard restart — losing every event in the gap.
This adds SubscriptionStreamRunner, a shared resubscribe-with-backoff loop that reconnects on any stream termination (clean end or error) and evicts the stale gRPC channel via a new InvalidateClient before retrying.
Covered by 5 new unit tests; TCP-keepalive/half-open-connection hardening is intentionally deferred to a follow-up PR.