### PR TITLE
Reject 2-of-2 wallets co-signed by internal wallet

### DIFF
--- a/src/Data/Models/Wallet.cs
+++ b/src/Data/Models/Wallet.cs
@@ -115,6 +115,24 @@ namespace NodeGuard.Data.Models
 
         [NotMapped] public bool RequiresInternalWalletSigning => IsBIP39Imported || IsWatchOnly ? false : Keys != null ? Keys.Count == MofN : false;
 
+        /// <summary>
+        /// A 2-of-2 whose two required keys are one human key plus NodeGuard's internal co-signing key.
+        /// Because NodeGuard co-signs automatically (see <see cref="RequiresInternalWalletSigning"/>), a
+        /// single human approval is the entire threshold: the wallet is effectively single-sig, and one
+        /// keyholder can move funds. These are disallowed at creation and finalisation — a substituted PSBT
+        /// from a lone keyholder plus NodeGuard's automatic co-signature is enough to drain the wallet.
+        /// Watch-only, BIP39 and hot wallets are excluded (NodeGuard does not auto co-sign those).
+        /// </summary>
+        [NotMapped]
+        public bool IsEffectivelySingleSigTwoOfTwo => RequiresInternalWalletSigning && MofN == 2;
+
+        /// <summary>Rejection message shared by the creation and finalisation guards and by tests.</summary>
+        public const string TwoOfTwoNotAllowedMessage =
+            "2-of-2 wallets are not allowed: NodeGuard's internal wallet is one of the two keys and " +
+            "co-signs automatically, so a single human signature meets the threshold and the wallet would " +
+            "be effectively single-sig. Add another human key and use a 2-of-3 (two human signers), or " +
+            "require all three keys with a 3-of-3.";
+
         #region Relationships
 
         public ICollection<ChannelOperationRequest> ChannelOperationRequestsAsSource { get; set; }

--- a/src/Data/Repositories/WalletRepository.cs
+++ b/src/Data/Repositories/WalletRepository.cs
@@ -204,6 +204,14 @@ namespace NodeGuard.Data.Repositories
             type.SetCreationDatetime();
             type.SetUpdateDatetime();
 
+            // Defence in depth: reject a NodeGuard-co-signed 2-of-2 that arrives already populated (e.g. a
+            // direct/API insert). Normal UI creation adds the internal key after this call, so the wallet is
+            // not yet a 2-of-2 here — FinaliseWallet is the guard that catches that path.
+            if (type.IsEffectivelySingleSigTwoOfTwo)
+            {
+                return (false, Wallet.TwoOfTwoNotAllowedMessage);
+            }
+
 
             if (type.IsBIP39Imported || type.IsWatchOnly)
             {
@@ -332,6 +340,13 @@ namespace NodeGuard.Data.Repositories
             if (selectedWalletToFinalise.Keys.Count < selectedWalletToFinalise.MofN)
             {
                 return (false, "Invalid number of keys for the given threshold");
+            }
+
+            // A 2-of-2 co-signed by NodeGuard collapses to single-sig (one human + NodeGuard's automatic
+            // signature). Reject it here, where Keys and MofN are final, so it never becomes usable.
+            if (selectedWalletToFinalise.IsEffectivelySingleSigTwoOfTwo)
+            {
+                return (false, Wallet.TwoOfTwoNotAllowedMessage);
             }
 
             selectedWalletToFinalise.IsFinalised = true;

--- a/src/Pages/Wallets.razor
+++ b/src/Pages/Wallets.razor
@@ -348,14 +348,25 @@
             <CloseButton />
         </ModalHeader>
         <ModalBody>
-            <p>If you confirm to finalise this wallet, it will become a ready-to-use wallet for the system but at the
-                same time you won't be allowed to update it in terms of keys, thresholds and other configuration
-                parameters
-            </p>
+            @if (_selectedWalletToFinalise?.IsEffectivelySingleSigTwoOfTwo == true)
+            {
+                <Alert Color="Color.Danger" Visible>
+                    <AlertMessage>This wallet cannot be finalised</AlertMessage>
+                    <AlertDescription>@Wallet.TwoOfTwoNotAllowedMessage</AlertDescription>
+                </Alert>
+            }
+            else
+            {
+                <p>If you confirm to finalise this wallet, it will become a ready-to-use wallet for the system but at the
+                    same time you won't be allowed to update it in terms of keys, thresholds and other configuration
+                    parameters
+                </p>
+            }
         </ModalBody>
         <ModalFooter>
             <Button Color="Color.Secondary" Clicked="@CloseAndCleanFinaliseModal">Close</Button>
-            <Button Color="Color.Primary" Clicked="@FinaliseWallet">Finalise</Button>
+            <Button Color="Color.Primary" Clicked="@FinaliseWallet"
+                    Disabled="@(_selectedWalletToFinalise?.IsEffectivelySingleSigTwoOfTwo == true)">Finalise</Button>
 
         </ModalFooter>
     </ModalContent>
@@ -1341,6 +1352,24 @@ KeyPath($"0/{i}")).ScriptPubKey.GetDestinationAddress(CurrentNetworkHelper.GetCu
         var walletId = _selectedWalletToFinalise.Id;
         var walletName = _selectedWalletToFinalise.Name;
 
+        // Mirrors the repository guard: a NodeGuard-co-signed 2-of-2 is effectively single-sig, so refuse to
+        // finalise it. Checked here too in case the modal state is stale and the button was not disabled.
+        if (_selectedWalletToFinalise.IsEffectivelySingleSigTwoOfTwo)
+        {
+            ToastService.ShowError(Wallet.TwoOfTwoNotAllowedMessage);
+            await AuditService.LogAsync(
+                AuditActionType.Finalise,
+                AuditEventType.Failure,
+                AuditObjectType.Wallet,
+                walletId.ToString(),
+                new { Name = walletName, Error = Wallet.TwoOfTwoNotAllowedMessage });
+
+            _selectedWalletToFinalise = null;
+            await _finaliseModalRef.Close(CloseReason.UserClosing);
+
+            return;
+        }
+
         var result = await WalletRepository.FinaliseWallet(_selectedWalletToFinalise);
 
         if (result.Item1)
@@ -1355,7 +1384,7 @@ KeyPath($"0/{i}")).ScriptPubKey.GetDestinationAddress(CurrentNetworkHelper.GetCu
         }
         else
         {
-            ToastService.ShowError("Error while marking wallet as finalised");
+            ToastService.ShowError(result.Item2 ?? "Error while marking wallet as finalised");
             await AuditService.LogAsync(
                 AuditActionType.Finalise,
                 AuditEventType.Failure,

--- a/test/NodeGuard.Tests/Data/Models/WalletTests.cs
+++ b/test/NodeGuard.Tests/Data/Models/WalletTests.cs
@@ -11,6 +11,59 @@ public class WalletTests
 {
     private InternalWallet _internalWallet = CreateWallet.CreateInternalWallet();
 
+    private static NodeGuard.Data.Models.Key K() => new() { Name = "k", XPUB = "x" };
+
+    [Fact]
+    void IsEffectivelySingleSigTwoOfTwo_TrueForNodeGuardCosigned2Of2()
+    {
+        // 1 human key + NodeGuard's internal key, threshold 2 => NodeGuard auto-co-signs => single human.
+        var wallet = new Wallet { MofN = 2, Keys = new List<NodeGuard.Data.Models.Key> { K(), K() } };
+
+        wallet.RequiresInternalWalletSigning.Should().BeTrue();
+        wallet.IsEffectivelySingleSigTwoOfTwo.Should().BeTrue();
+    }
+
+    [Fact]
+    void IsEffectivelySingleSigTwoOfTwo_FalseFor2Of3()
+    {
+        // 2 human keys + internal, threshold 2 => NodeGuard does NOT auto-sign => two humans required.
+        var wallet = new Wallet { MofN = 2, Keys = new List<NodeGuard.Data.Models.Key> { K(), K(), K() } };
+
+        wallet.RequiresInternalWalletSigning.Should().BeFalse();
+        wallet.IsEffectivelySingleSigTwoOfTwo.Should().BeFalse();
+    }
+
+    [Fact]
+    void IsEffectivelySingleSigTwoOfTwo_FalseFor3Of3()
+    {
+        var wallet = new Wallet { MofN = 3, Keys = new List<NodeGuard.Data.Models.Key> { K(), K(), K() } };
+
+        wallet.RequiresInternalWalletSigning.Should().BeTrue();
+        wallet.IsEffectivelySingleSigTwoOfTwo.Should().BeFalse("3-of-3 still requires two human signatures");
+    }
+
+    [Fact]
+    void IsEffectivelySingleSigTwoOfTwo_FalseForWatchOnly2Of2()
+    {
+        // Imported descriptor => watch-only => NodeGuard never co-signs, so a 2-of-2 of external keys is fine.
+        var wallet = new Wallet
+        {
+            MofN = 2,
+            Keys = new List<NodeGuard.Data.Models.Key> { K(), K() },
+            ImportedOutputDescriptor = "wsh(multi(2,xpubA,xpubB))",
+        };
+
+        wallet.RequiresInternalWalletSigning.Should().BeFalse();
+        wallet.IsEffectivelySingleSigTwoOfTwo.Should().BeFalse();
+    }
+
+    [Fact]
+    void IsEffectivelySingleSigTwoOfTwo_FalseForHotAndBip39()
+    {
+        CreateWallet.SingleSig(_internalWallet).IsEffectivelySingleSigTwoOfTwo.Should().BeFalse();
+        CreateWallet.BIP39Singlesig().IsEffectivelySingleSigTwoOfTwo.Should().BeFalse();
+    }
+
     [Fact]
     void GetDerivationStrategy_NoKeys()
     {

--- a/test/NodeGuard.Tests/Data/Repositories/WalletRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/WalletRepositoryTests.cs
@@ -204,6 +204,55 @@ public class WalletRepositoryTests
     }
 
 
+    private static Key DummyKey() => new() { Name = "k", XPUB = "x" };
+
+    [Fact]
+    public async Task FinaliseWallet_Rejects2Of2()
+    {
+        var dbContextFactory = SetupDbContextFactory();
+        var walletRepository = new WalletRepository(null, null, dbContextFactory.Object, null, null, null);
+
+        // 1 human + internal, threshold 2: Keys.Count (2) == MofN (2) => NodeGuard-co-signed 2-of-2.
+        var wallet = new Wallet { Name = "bad", MofN = 2, Keys = new List<Key> { DummyKey(), DummyKey() } };
+
+        var (ok, message) = await walletRepository.FinaliseWallet(wallet);
+
+        ok.Should().BeFalse();
+        message.Should().Be(Wallet.TwoOfTwoNotAllowedMessage);
+        wallet.IsFinalised.Should().BeFalse("a rejected wallet must not be marked finalised");
+    }
+
+    [Fact]
+    public async Task FinaliseWallet_DoesNotRejectA2Of3OnThe2Of2Guard()
+    {
+        var dbContextFactory = SetupDbContextFactory();
+        // A real logger is needed because a 2-of-3 gets PAST the 2-of-2 guard into normal finalisation,
+        // which (with dummy keys and no nbxplorer) logs and returns a generic error — the point being it is
+        // NOT the 2-of-2 rejection.
+        var logger = new Mock<ILogger<WalletRepository>>();
+        var walletRepository = new WalletRepository(null, logger.Object, dbContextFactory.Object, null, null, null);
+
+        var wallet = new Wallet { Name = "ok", MofN = 2, Keys = new List<Key> { DummyKey(), DummyKey(), DummyKey() } };
+
+        var (_, message) = await walletRepository.FinaliseWallet(wallet);
+
+        message.Should().NotBe(Wallet.TwoOfTwoNotAllowedMessage);
+    }
+
+    [Fact]
+    public async Task AddAsync_RejectsAPrePopulated2Of2()
+    {
+        var dbContextFactory = SetupDbContextFactory();
+        var walletRepository = new WalletRepository(null, null, dbContextFactory.Object, null, null, null);
+
+        var wallet = new Wallet { Name = "bad", MofN = 2, Keys = new List<Key> { DummyKey(), DummyKey() } };
+
+        var (ok, message) = await walletRepository.AddAsync(wallet);
+
+        ok.Should().BeFalse();
+        message.Should().Be(Wallet.TwoOfTwoNotAllowedMessage);
+    }
+
     [Fact]
     public async Task ImportBIP39Wallet_WhenValidInput_ShouldReturnSuccess()
     {


### PR DESCRIPTION
Block creation and finalisation of 2-of-2 multisig wallets where one of the two required keys is NodeGuard's internal co-signing key. Because NodeGuard co-signs automatically, such wallets collapse to single-sig — a lone human keyholder combined with the automatic co-signature is enough to move funds.

- Add `IsEffectivelySingleSigTwoOfTwo` helper and a shared `TwoOfTwoNotAllowedMessage` on `Wallet` for reuse by guards, UI and tests.
- Guard `WalletRepository.AddAsync` (defence in depth for direct/API inserts) and `FinaliseWallet` (the primary UI path, where `Keys` and `MofN` are final).
- Block finalisation in the UI too: the finalise modal explains the rejection and disables its confirm button for such a wallet, `FinaliseWallet` mirrors the repository guard in case the modal state is stale, and the failure toast now surfaces the repository's reason instead of a generic message.
- Exclude watch-only, BIP39 and hot wallets, which NodeGuard does not auto co-sign.