### PR TITLE
Enable dynamic fee management for new channels

### DIFF
--- a/src/Jobs/NodeChannelSubscribeJob.cs
+++ b/src/Jobs/NodeChannelSubscribeJob.cs
@@ -87,18 +87,18 @@ public class NodeChannelSuscribeJob : IJob
                     _logger.LogError(e, "Error reading and update event of node {NodeId}", nodeId);
                     throw new JobExecutionException(e, true);
                 }
-                
-              
+
+
             }
-            
-         
+
+
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error while subscribing for the channel updates of node {NodeId}", nodeId);
             //Sleep to avoid massive requests
             await Task.Delay(5000);
-            
+
             throw new JobExecutionException(e, true);
         }
 
@@ -125,7 +125,8 @@ public class NodeChannelSuscribeJob : IJob
                     CreatedByNodeGuard = false,
                     CreationDatetime = DateTimeOffset.Now,
                     UpdateDatetime = DateTimeOffset.Now,
-                    IsPrivate = channelOpened.Private
+                    IsPrivate = channelOpened.Private,
+                    IsDynamicFeeEnabled = node.DynamicFeeManagementEnabled
                 };
 
                 var remoteNode = await _nodeRepository.GetOrCreateByPubKey(channelOpened.RemotePubkey, _lightningService);

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -187,7 +187,7 @@ namespace NodeGuard.Services
         /// </summary>
         Task<long?> GetLocalOutboundFeeRatePpmByPeerAsync
         (Node node, string peerPubkey);
-        
+
         /// <summary>
         /// Sets the channel fee policy for a given channel identified by its chanPoint
         /// </summary>
@@ -800,7 +800,8 @@ namespace NodeGuard.Services
                 SourceNodeId = sourceNodeId,
                 DestinationNodeId = destinationNodeId,
                 CreatedByNodeGuard = true,
-                IsPrivate = currentChannel.Private
+                IsPrivate = currentChannel.Private,
+                IsDynamicFeeEnabled = source.DynamicFeeManagementEnabled
             };
 
             return channel;

--- a/test/NodeGuard.Tests/Jobs/NodeChannelSubscribeJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/NodeChannelSubscribeJobTests.cs
@@ -17,6 +17,7 @@
  *
  */
 
+using System.Runtime.CompilerServices;
 using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.Jobs;
 using NodeGuard.Services;
@@ -96,5 +97,94 @@ public class NodeChannelSubscribeJobTests
         // Assert
         Assert.Equal(Channel.ChannelStatus.Closed, channelToClose.Status);
         _channelRepositoryMock.Verify(repo => repo.Update(channelToClose), Times.Once);
+    }
+
+    [Fact]
+    public async Task NodeUpdateManagement_SetsDynamicFeeFromLocalNode_WhenLocalNodeIsInitiator()
+    {
+        // Arrange
+        var localNode = new Node { Id = 1, Endpoint = "10.0.0.1", DynamicFeeManagementEnabled = true };
+        var remoteNode = new Node { Id = 2, PubKey = "03remote", DynamicFeeManagementEnabled = false }; // unmanaged (no Endpoint)
+
+        var channelEventUpdate = new ChannelEventUpdate
+        {
+            Type = ChannelEventUpdate.Types.UpdateType.OpenChannel,
+            OpenChannel = new Lnrpc.Channel
+            {
+                ChanId = 123,
+                ChannelPoint = "abc:0",
+                Capacity = 1000,
+                RemotePubkey = remoteNode.PubKey,
+                CloseAddress = "bcrt1qclose",
+                Initiator = true,
+            },
+        };
+
+        var captured = SetupOpenChannelCapture(remoteNode);
+
+        // Act
+        await _nodeUpdateManager.NodeUpdateManagement(channelEventUpdate, localNode);
+
+        // Assert: source is the initiator (local node) and the flag follows it
+        Assert.NotNull(captured.Value);
+        Assert.Equal(localNode.Id, captured.Value!.SourceNodeId);
+        Assert.True(captured.Value!.IsDynamicFeeEnabled);
+    }
+
+    [Fact]
+    public async Task NodeUpdateManagement_SetsDynamicFeeFromLocalNode_WhenBothManagedAndLocalNodeIsNotInitiator()
+    {
+        // Arrange: both nodes managed. The handler de-dupes by bailing out on the initiator's event,
+        // so the record is created here on the non-initiator's event. The source is the initiator
+        // (the remote node), while the dynamic-fee flag follows the local subscribing node.
+        var localNode = new Node { Id = 2, Endpoint = "10.0.0.2", DynamicFeeManagementEnabled = true };
+        var remoteNode = new Node { Id = 1, PubKey = "03remote", Endpoint = "10.0.0.1", DynamicFeeManagementEnabled = false };
+
+        var channelEventUpdate = new ChannelEventUpdate
+        {
+            Type = ChannelEventUpdate.Types.UpdateType.OpenChannel,
+            OpenChannel = new Lnrpc.Channel
+            {
+                ChanId = 123,
+                ChannelPoint = "abc:0",
+                Capacity = 1000,
+                RemotePubkey = remoteNode.PubKey,
+                CloseAddress = "bcrt1qclose",
+                Initiator = false,
+            },
+        };
+
+        var captured = SetupOpenChannelCapture(remoteNode);
+
+        // Act
+        await _nodeUpdateManager.NodeUpdateManagement(channelEventUpdate, localNode);
+
+        // Assert: source is the initiator (remote node), and the flag follows the local subscribing node
+        Assert.NotNull(captured.Value);
+        Assert.Equal(remoteNode.Id, captured.Value!.SourceNodeId);
+        Assert.Equal(localNode.DynamicFeeManagementEnabled, captured.Value!.IsDynamicFeeEnabled);
+    }
+
+    /// <summary>
+    /// Wires the node/channel repositories so an OpenChannel event reaches AddAsync, and returns a
+    /// holder that captures the channel the handler tries to persist.
+    /// </summary>
+    private StrongBox<Channel?> SetupOpenChannelCapture(Node remoteNode)
+    {
+        var captured = new StrongBox<Channel?>(null);
+        _nodeRepositoryMock
+            .Setup(r => r.GetOrCreateByPubKey(remoteNode.PubKey, It.IsAny<ILightningService>()))
+            .ReturnsAsync(remoteNode);
+        _nodeRepositoryMock
+            .Setup(r => r.GetByPubkey(remoteNode.PubKey))
+            .ReturnsAsync(remoteNode);
+        _channelRepositoryMock
+            .Setup(r => r.GetByChanId(It.IsAny<ulong>()))
+            .ReturnsAsync((Channel?)null);
+        _channelRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<Channel>()))
+            .Callback<Channel>(c => captured.Value = c)
+            .ReturnsAsync((true, (string?)null));
+        return captured;
     }
 }

--- a/test/NodeGuard.Tests/Services/LightningServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningServiceTests.cs
@@ -1679,6 +1679,63 @@ namespace NodeGuard.Services
             await act.Should().NotThrowAsync();
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CreateChannel_SetsIsDynamicFeeEnabled_FromSourceNode(bool dynamicFeeEnabled)
+        {
+            // Arrange
+            var source = new Node
+            {
+                Id = 1,
+                PubKey = "03b48034270e522e4033afdbe43383d66d426638927b940d09a8a7a0de4d96e807",
+                ChannelAdminMacaroon = "abc",
+                Endpoint = "10.0.0.1",
+                DynamicFeeManagementEnabled = dynamicFeeEnabled
+            };
+            const int destId = 2;
+
+            var channelPoint = new ChannelPoint
+            {
+                FundingTxidBytes =
+                    ByteString.CopyFromUtf8("e59fa8edcd772213239daef2834d9021d1aecc591d605b426ae32c4bec5fdd7d"),
+                OutputIndex = 1
+            };
+
+            // ListChannels must return the just-opened channel so CreateChannel can resolve its real ChanId
+            var listChannelsResponse = new ListChannelsResponse
+            {
+                Channels =
+                {
+                    new Lnrpc.Channel
+                    {
+                        ChanId = 123,
+                        Initiator = true,
+                        Private = false,
+                        ChannelPoint =
+                            $"{LightningHelper.DecodeTxId(channelPoint.FundingTxidBytes)}:{channelPoint.OutputIndex}"
+                    }
+                }
+            };
+
+            var lightningClientService = new Mock<ILightningClientService>();
+            lightningClientService
+                .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lightning.LightningClient>()))
+                .ReturnsAsync(listChannelsResponse);
+
+            var lightningService = new LightningService(_logger,
+                null, null, null, null, null, null, null, null,
+                lightningClientService.Object,
+                null, null);
+
+            // Act
+            var channel = await lightningService.CreateChannel(source, destId, channelPoint, 1000);
+
+            // Assert: the dynamic-fee flag is derived from the source node's setting
+            channel.IsDynamicFeeEnabled.Should().Be(dynamicFeeEnabled);
+            channel.SourceNodeId.Should().Be(source.Id);
+        }
+
         [Fact]
         public async Task CloseChannel_Succeeds()
         {


### PR DESCRIPTION
Introduce dynamic fee management for newly created channels when the node has dynamic fee enabled, allowing for more flexible fee handling based on node settings. This change enhances the channel creation and update processes to incorporate dynamic fee capabilities.