### PR TITLE
[GEN-1815] Add naive approach to avoid utxo selection to leave no margin for fees

### DIFF
--- a/src/Helpers/UTXOSelectionAlgorithms.cs
+++ b/src/Helpers/UTXOSelectionAlgorithms.cs
@@ -115,7 +115,8 @@ namespace NodeGuard.Helpers
         /// Selects utxos from a wallet for requests (Withdrawals, ChannelOperationRequest) by closest, i.e.
         /// the UTXOs whose amount differs the least from the requested one are taken first. A single UTXO
         /// covering the whole amount is therefore preferred over several smaller ones, as long as it is the
-        /// closest to the amount.
+        /// closest to the amount and holds more than it, so that the transaction has something to pay its
+        /// miner fee with.
         /// </summary>
         /// <param name="wallet"></param>
         /// <param name="satsAmount"></param>
@@ -136,10 +137,10 @@ namespace NodeGuard.Helpers
             var utxosQueue = new Queue<UTXO>(
                 availableUTXOs.OrderBy(x => Math.Abs(((Money)x.Value).Satoshi - satsAmount)));
 
-            //Take UTXOs off the queue until the amount is covered. The first one already covers it whenever
-            //it holds at least the requested amount, so it ends up being the only one selected
+            //Take UTXOs off the queue until the total is strictly over the amount: the miner fee is paid out of
+            //whatever the inputs hold above it, so matching the amount exactly leaves nothing to pay it with
             var remainingSats = satsAmount;
-            while (remainingSats > 0 && utxosQueue.TryDequeue(out var utxo))
+            while (remainingSats >= 0 && utxosQueue.TryDequeue(out var utxo))
             {
                 selectedUTXOs.Add(utxo);
                 remainingSats -= ((Money)utxo.Value).Satoshi;

--- a/test/NodeGuard.Tests/Helpers/UTXOSelectionAlgorithmsTests.cs
+++ b/test/NodeGuard.Tests/Helpers/UTXOSelectionAlgorithmsTests.cs
@@ -58,18 +58,19 @@ namespace NodeGuard.Tests
         }
 
         [Fact]
-        public void SelectUTXOsByClosest_WithAnExactMatch_SelectsOnlyTheExactMatch()
+        public void SelectUTXOsByClosest_WithAnExactMatch_TakesTheNextClosestAsWell()
         {
             // Arrange: distances to the 50_000 requested are 40_000 | 0 | 70_000
-            var tooSmall = UtxoOf(10_000);
+            var secondClosest = UtxoOf(10_000);
             var exactMatch = UtxoOf(50_000);
-            var tooBig = UtxoOf(120_000);
+            var furthest = UtxoOf(120_000);
 
             // Act
-            var selectedUTXOs = SelectByClosest(tooSmall, exactMatch, tooBig);
+            var selectedUTXOs = SelectByClosest(secondClosest, exactMatch, furthest);
 
-            // Assert: the exact match is the closest one and covers the amount by itself
-            selectedUTXOs.Should().Equal(exactMatch);
+            // Assert: the exact match is taken first, but it leaves nothing to pay the miner fee with, so the
+            // next closest one is taken too
+            selectedUTXOs.Should().Equal(exactMatch, secondClosest);
         }
 
         [Fact]
@@ -84,8 +85,24 @@ namespace NodeGuard.Tests
             // Act
             var selectedUTXOs = SelectByClosest(closestAndAboveTheAmount, belowTheAmount, furtherBelowTheAmount);
 
-            // Assert: it covers the amount on its own, so no other UTXO is needed
+            // Assert: it covers the amount on its own and leaves a surplus, so no other UTXO is needed
             selectedUTXOs.Should().Equal(closestAndAboveTheAmount);
+        }
+
+        [Fact]
+        public void SelectUTXOsByClosest_WhenTheClosestUTXOIsOneSatAboveTheAmount_SelectsOnlyThatUTXO()
+        {
+            // Arrange: distances to the 50_000 requested are 1 | 10_000, so the closest UTXO leaves a single
+            // sat of surplus, which is all this algorithm asks for. That sat is not necessarily enough to pay
+            // the miner fee, the same known limitation SelectUTXOsByOldest has
+            var oneSatAboveTheAmount = UtxoOf(RequestedSats + 1);
+            var secondClosest = UtxoOf(40_000);
+
+            // Act
+            var selectedUTXOs = SelectByClosest(oneSatAboveTheAmount, secondClosest);
+
+            // Assert
+            selectedUTXOs.Should().Equal(oneSatAboveTheAmount);
         }
 
         [Fact]


### PR DESCRIPTION
Idea taken by `SelectUTXOsByOldest` approach. UTXOs are selected even after satsAmount is hit by the sum of utxo values. So this will be the stopper for `SelectUTXOsByClosest` as well. Other approaches will imply bigger and potentially riskier changes.







---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>