### PR TITLE
Halve routing-engine EMA window to ~12h (α 0.04 → 0.08)

### DIFF
--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -261,11 +261,11 @@ public class Constants
     public static double ROUTING_ENGINE_TARGET_ALPHA = 0.10;
 
     /// <summary>
-    /// EWMA smoothing factor for EmaLocalRatio (~24h effective window at 30-min sampling).
-    /// Default 0.04 (49 cycles to converge). ⍺ = 2/(cycles+1). It smooths out the observed
+    /// EWMA smoothing factor for EmaLocalRatio (~12h effective window at 30-min sampling).
+    /// Default 0.08 (24 cycles to converge). ⍺ = 2/(cycles+1). It smooths out the observed
     /// local ratio to avoid overreacting to transient flow spikes.
     /// </summary>
-    public static double ROUTING_ENGINE_FEE_EMA_ALPHA = 0.04;
+    public static double ROUTING_ENGINE_FEE_EMA_ALPHA = 0.08;
 
     /// <summary>
     /// Consecutive divergent cycles required before a category flip commits (anti-flap hysteresis).


### PR DESCRIPTION
## What

Halves the routing engine's `EmaLocalRatio` smoothing window from ~24h to ~12h by changing `ROUTING_ENGINE_FEE_EMA_ALPHA` from `0.04` to `0.08`.

## Why

`EmaLocalRatio` is the EMA-smoothed `local/(local+remote)` ratio that both the dynamic fee engine and the rebalancer use as their control signal. The smoothing factor follows `α = 2/(cycles+1)`:

| α | cycles | window @ 30-min sampling |
|---|--------|--------------------------|
| `0.04` (old) | 49 | ~24h |
| `0.08` (new) | 24 | ~12h |

A ~12h window makes the signal respond about twice as fast to a **sustained** balance shift while still filtering per-HTLC noise, so fee and rebalance decisions track real liquidity trends with less lag.

## Scope

- One constant value + its doc comment. `TargetRatioReevaluationJob.SmoothEma` reads the constant unchanged — no logic change.
- Still env-overridable via `ROUTING_ENGINE_FEE_EMA_ALPHA`.
- No test changes (nothing pins the value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
