### PR TITLE
Add feature to change maximum HTLC value

### DIFF
--- a/src/Pages/Channels.razor
+++ b/src/Pages/Channels.razor
@@ -566,6 +566,10 @@
                                                                     <td class="fw-bold">Time Lock Delta:</td>
                                                                     <td><Badge Color="Color.Light">@_currentFeePolicies.ManagedNodePolicy.TimeLockDelta</Badge></td>
                                                                 </tr>
+                                                                <tr>
+                                                                    <td class="fw-bold">Max HTLC (sats):</td>
+                                                                    <td><Badge Color="Color.Light">@(_currentFeePolicies.ManagedNodePolicy.MaxHtlcMsat / 1000)</Badge></td>
+                                                                </tr>
                                                                 @if (_currentFeePolicies.ManagedNodePolicy.InboundFeeRateMilliMsat != 0 || _currentFeePolicies.ManagedNodePolicy.InboundFeeBaseMsat != 0)
                                                                 {
                                                                     <tr>
@@ -603,6 +607,10 @@
                                                                     <td class="fw-bold">Time Lock Delta:</td>
                                                                     <td><Badge Color="Color.Light">@_currentFeePolicies.CounterpartyPolicy.TimeLockDelta</Badge></td>
                                                                 </tr>
+                                                                <tr>
+                                                                    <td class="fw-bold">Max HTLC (sats):</td>
+                                                                    <td><Badge Color="Color.Light">@(_currentFeePolicies.CounterpartyPolicy.MaxHtlcMsat / 1000)</Badge></td>
+                                                                </tr>
                                                                 @if (_currentFeePolicies.CounterpartyPolicy.InboundFeeRateMilliMsat != 0 || _currentFeePolicies.CounterpartyPolicy.InboundFeeBaseMsat != 0)
                                                                 {
                                                                     <tr>
@@ -626,6 +634,21 @@
                                         </CardBody>
                                     </Card>
                                 }
+
+                                <Divider class="my-4"></Divider>
+                                <h6 class="mb-3"><strong>Max HTLC</strong></h6>
+                                <Field>
+                                    <Validation Validator="ValidateChannelMaxHtlcSats">
+                                        <FieldLabel>Max HTLC (sats)</FieldLabel>
+                                        <FieldHelp>Largest single HTLC this channel will forward, in satoshis. Leave blank to keep the current value. This can be updated even while dynamic fees are enabled.</FieldHelp>
+                                        <NumericEdit TValue="ulong?" Min="0L" Max="@((ulong)_selectedChannel.SatsAmount)"
+                                                        @bind-Value="_channelFeePolicy.MaxHtlcSats">
+                                            <Feedback>
+                                                <ValidationError />
+                                            </Feedback>
+                                        </NumericEdit>
+                                    </Validation>
+                                </Field>
 
                                 <Divider class="my-4"></Divider>
                                 <h6 class="mb-3"><strong>Set New Fee Policy</strong></h6>
@@ -843,6 +866,8 @@
         public long? TimeLockDelta { get; set; } = Constants.DEFAULT_CHANNEL_FEE_POLICY_TIMELOCK_DELTA_BLOCKS;
         public int? InboundBaseFeeMsat { get; set; }
         public int? InboundFeeRatePpm { get; set; }
+
+        public ulong? MaxHtlcSats { get; set; }
     }
 
     private sealed class CurrentFeePolicies
@@ -1112,6 +1137,16 @@
                 CounterpartyPolicy = result.Item2,
                 IsLoading = false
             };
+
+            if (result.Item1 != null)
+            {
+                _channelFeePolicy.BaseFeeMsat = result.Item1.FeeBaseMsat;
+                _channelFeePolicy.FeeRatePpm = result.Item1.FeeRateMilliMsat;
+                _channelFeePolicy.TimeLockDelta = result.Item1.TimeLockDelta;
+                _channelFeePolicy.InboundBaseFeeMsat = result.Item1.InboundFeeBaseMsat;
+                _channelFeePolicy.InboundFeeRatePpm = result.Item1.InboundFeeRateMilliMsat;
+                _channelFeePolicy.MaxHtlcSats = result.Item1.MaxHtlcMsat/1000;
+            }
         }
         catch (Exception ex)
         {
@@ -1224,6 +1259,12 @@
             return;
         }
 
+        if (_channelFeePolicyValidationsRef == null || !await _channelFeePolicyValidationsRef.ValidateAll())
+        {
+            ToastService.ShowError("Please fix the errors");
+            return;
+        }
+
         var channelUpdateResult = ChannelRepository.Update(_selectedChannel);
         if (!channelUpdateResult.Item1)
         {
@@ -1242,21 +1283,44 @@
         // cold-starts from the category baseline rather than resuming from outdated ChannelFeeState.
         await FeeEngineStateService.PurgeChannelStateIfDisabled(_selectedChannel);
 
-        if (_selectedChannel.IsDynamicFeeEnabled)
-        {
-            ToastService.ShowSuccess("Channel dynamic fee management enabled.");
-            await CloseChannelManagementModal();
-            return;
-        }
-
-        if (_channelFeePolicyValidationsRef == null || !await _channelFeePolicyValidationsRef.ValidateAll())
-        {
-            ToastService.ShowError("Please fix the errors");
-            return;
-        }
+        // Blank Max HTLC leaves the current value unchanged (LND treats max_htlc_msat == 0 as "no change").
+        ulong? maxHtlcMsat = _channelFeePolicy.MaxHtlcSats.HasValue
+            ? (ulong)(_channelFeePolicy.MaxHtlcSats.Value * 1000L)
+            : null;
 
         try
         {
+            if (_selectedChannel.IsDynamicFeeEnabled)
+            {
+                // The routing engine owns the fee fields for this channel, so only Max HTLC can be
+                // changed here.
+                if (maxHtlcMsat.HasValue)
+                {
+                    var current = _currentFeePolicies.ManagedNodePolicy;
+                    if (current == null)
+                    {
+                        ToastService.ShowError("The current fee policy could not be loaded, so Max HTLC cannot be updated right now.");
+                        return;
+                    }
+
+                    await LightningService.SetChannelFeePolicy(
+                        _selectedChannelOutpoint,
+                        _selectedChannelNodePubKey,
+                        current.FeeBaseMsat,
+                        checked((uint)current.FeeRateMilliMsat),
+                        current.TimeLockDelta,
+                        inboundBaseFeeMsat: null,
+                        inboundFeeRatePpm: null,
+                        maxHtlcMsat: maxHtlcMsat);
+
+                    ToastService.ShowSuccess("Max HTLC updated successfully");
+                }
+
+                ToastService.ShowSuccess("Channel dynamic fee management enabled.");
+                await CloseChannelManagementModal();
+                return;
+            }
+
             await LightningService.SetChannelFeePolicy(
                 _selectedChannelOutpoint,
                 _selectedChannelNodePubKey,
@@ -1264,7 +1328,8 @@
                 checked((uint)_channelFeePolicy.FeeRatePpm!.Value),
                 checked((uint)_channelFeePolicy.TimeLockDelta!.Value),
                 _channelFeePolicy.InboundBaseFeeMsat,
-                _channelFeePolicy.InboundFeeRatePpm);
+                _channelFeePolicy.InboundFeeRatePpm,
+                maxHtlcMsat);
 
             ToastService.ShowSuccess("Channel fee policy updated successfully");
             await CloseChannelManagementModal();
@@ -1523,6 +1588,30 @@
         {
             arg1.Status = ValidationStatus.Error;
             arg1.ErrorText = $"Time lock delta must be between 0 and {uint.MaxValue}.";
+        }
+    }
+
+    private void ValidateChannelMaxHtlcSats(ValidatorEventArgs arg1)
+    {
+        arg1.Status = ValidationStatus.Success;
+
+        // Optional field: blank leaves the current max HTLC unchanged.
+        if (_channelFeePolicy.MaxHtlcSats == null)
+        {
+            return;
+        }
+
+        if (_channelFeePolicy.MaxHtlcSats <= 0)
+        {
+            arg1.Status = ValidationStatus.Error;
+            arg1.ErrorText = "Max HTLC must be greater than zero.";
+            return;
+        }
+
+        if (_selectedChannel != null && _channelFeePolicy.MaxHtlcSats > (ulong)_selectedChannel.SatsAmount)
+        {
+            arg1.Status = ValidationStatus.Error;
+            arg1.ErrorText = $"Max HTLC cannot exceed the channel capacity ({_selectedChannel.SatsAmount} sats).";
         }
     }
 

--- a/src/Services/LightningClientService.cs
+++ b/src/Services/LightningClientService.cs
@@ -49,7 +49,7 @@ public interface ILightningClientService
     public void FundingStateStepFinalize(Node node, PSBT finalizedPSBT, byte[] pendingChannelId, Lightning.LightningClient? client = null);
     public void FundingStateStepCancel(Node node, byte[] pendingChannelId, Lightning.LightningClient? client = null);
 
-    public Task<PolicyUpdateResponse?> SetChannelFeePolicy(Node node, NBitcoin.OutPoint chanPoint, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, Lightning.LightningClient? client = null);
+    public Task<PolicyUpdateResponse?> SetChannelFeePolicy(Node node, NBitcoin.OutPoint chanPoint, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, ulong? maxHtlcMsat = null, Lightning.LightningClient? client = null);
 }
 
 public class LightningClientService : ILightningClientService
@@ -453,7 +453,7 @@ public class LightningClientService : ILightningClientService
             }, new Metadata { { "macaroon", node.ChannelAdminMacaroon } });
     }
 
-    public async Task<PolicyUpdateResponse?> SetChannelFeePolicy(Node node, NBitcoin.OutPoint chanPoint, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, Lightning.LightningClient? client = null)
+    public async Task<PolicyUpdateResponse?> SetChannelFeePolicy(Node node, NBitcoin.OutPoint chanPoint, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, ulong? maxHtlcMsat = null, Lightning.LightningClient? client = null)
     {
         client ??= GetLightningClient(node.Endpoint);
 
@@ -468,6 +468,11 @@ public class LightningClientService : ILightningClientService
             FeeRatePpm = feeRatePpm,
             TimeLockDelta = timeLockDelta
         };
+
+        if (maxHtlcMsat.HasValue)
+        {
+            request.MaxHtlcMsat = maxHtlcMsat.Value;
+        }
 
         if (inboundBaseFeeMsat.HasValue && inboundFeeRatePpm.HasValue)
         {

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -198,9 +198,10 @@ namespace NodeGuard.Services
         /// <param name="timeLockDelta"></param>
         /// <param name="inboundBaseFeeMsat"></param>
         /// <param name="inboundFeeRatePpm"></param>
+        /// <param name="maxHtlcMsat"></param>
         /// <param name="isEngineDriven"></param>
         /// <returns></returns>
-        public Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, bool isEngineDriven = false);
+        public Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, ulong? maxHtlcMsat = null, bool isEngineDriven = false);
 
         /// <summary>
         /// Gets the channel fee policy for a given channel identified by its chanPoint
@@ -1767,7 +1768,7 @@ namespace NodeGuard.Services
             return await GetLocalOutboundFeeRatePpmAsync(node, match.ChanId);
         }
 
-        public async Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, bool isEngineDriven = false)
+        public async Task SetChannelFeePolicy(string chanPoint, string nodePubKey, long baseFeeMsat, uint feeRatePpm, uint timeLockDelta, int? inboundBaseFeeMsat, int? inboundFeeRatePpm, ulong? maxHtlcMsat = null, bool isEngineDriven = false)
         {
             // Validate chanPoint format
             if (!OutPoint.TryParse(chanPoint, out var outPoint))
@@ -1824,7 +1825,7 @@ namespace NodeGuard.Services
 
             try
             {
-                var response = await _lightningClientService.SetChannelFeePolicy(node, outPoint, baseFeeMsat, feeRatePpm, timeLockDelta, inboundBaseFeeMsat, inboundFeeRatePpm);
+                var response = await _lightningClientService.SetChannelFeePolicy(node, outPoint, baseFeeMsat, feeRatePpm, timeLockDelta, inboundBaseFeeMsat, inboundFeeRatePpm, maxHtlcMsat);
 
                 if (response?.FailedUpdates != null && response.FailedUpdates.Count > 0)
                 {
@@ -1851,7 +1852,8 @@ namespace NodeGuard.Services
                     FeeRatePpm = feeRatePpm,
                     TimeLockDelta = timeLockDelta,
                     InboundBaseFeeMsat = inboundBaseFeeMsat,
-                    InboundFeeRatePpm = inboundFeeRatePpm
+                    InboundFeeRatePpm = inboundFeeRatePpm,
+                    MaxHtlcMsat = maxHtlcMsat
                 };
 
                 if (isEngineDriven)

--- a/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
@@ -155,7 +155,7 @@ public class ChannelFeeOptimizerJobTests
 
         // Sink, d = -0.10, first eval seeds p_last=2500 → outbound 2550, inbound -50.
         _lightningService.Verify(x => x.SetChannelFeePolicy(
-            "txid123:1", NodePubKey, 1000, 2550u, 40u, 0, -50, true), Times.Once);
+            "txid123:1", NodePubKey, 1000, 2550u, 40u, 0, -50, null, true), Times.Once);
     }
 
     [Fact]
@@ -173,7 +173,7 @@ public class ChannelFeeOptimizerJobTests
         _lightningService.Verify(x => x.GetChannelFeePolicy(It.IsAny<ulong>(), It.IsAny<Node>()), Times.Never);
         _lightningService.Verify(x => x.SetChannelFeePolicy(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<uint>(),
-            It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<bool>()), Times.Never);
+            It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<ulong?>(), It.IsAny<bool>()), Times.Never);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class ChannelFeeOptimizerJobTests
     private void VerifyNoFeeWrite() =>
         _lightningService.Verify(x => x.SetChannelFeePolicy(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<uint>(),
-            It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<bool>()), Times.Never);
+            It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<ulong?>(), It.IsAny<bool>()), Times.Never);
 
     [Fact]
     public async Task Execute_DryRunNode_RecordsFeeStateButDoesNotWriteToLnd()
@@ -339,7 +339,7 @@ public class ChannelFeeOptimizerJobTests
             ArrangeSingleSinkChannel(node, inFlightRebalance: false);
             _lightningService.Setup(x => x.SetChannelFeePolicy(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<uint>(),
-                It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<bool>()))
+                It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<ulong?>(), It.IsAny<bool>()))
                 .ThrowsAsync(new Exception("lnd unreachable"));
 
             // Must not surface — Execute swallows per-channel errors so the next cycle retries. If it threw,
@@ -348,7 +348,7 @@ public class ChannelFeeOptimizerJobTests
 
             _lightningService.Verify(x => x.SetChannelFeePolicy(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<uint>(),
-                It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<bool>()), Times.Once);
+                It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<ulong?>(), It.IsAny<bool>()), Times.Once);
             // On write failure the fee state is NOT persisted (LastApplied stays null → next cycle re-seeds).
             _feeStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelFeeState>()), Times.Never);
         }

--- a/test/NodeGuard.Tests/Services/LightningClientServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningClientServiceTests.cs
@@ -99,7 +99,7 @@ public class LightningClientServiceTests
             timeLockDelta: 40,
             inboundBaseFeeMsat: -100,
             inboundFeeRatePpm: -25,
-            lightningClient.Object);
+            client: lightningClient.Object);
 
         // Assert
         response.Should().NotBeNull();
@@ -112,6 +112,8 @@ public class LightningClientServiceTests
         capturedRequest.InboundFee.Should().NotBeNull();
         capturedRequest.InboundFee.BaseFeeMsat.Should().Be(-100);
         capturedRequest.InboundFee.FeeRatePpm.Should().Be(-25);
+        // Max HTLC was not supplied, so LND must be told to leave it unchanged (0).
+        capturedRequest.MaxHtlcMsat.Should().Be(0);
         capturedMetadata.Should().ContainSingle(entry => entry.Key == "macaroon" && entry.Value == "test-macaroon");
     }
 
@@ -152,10 +154,55 @@ public class LightningClientServiceTests
             timeLockDelta: 40,
             inboundBaseFeeMsat: null,
             inboundFeeRatePpm: null,
-            lightningClient.Object);
+            client: lightningClient.Object);
 
         // Assert
         capturedRequest.Should().NotBeNull();
         capturedRequest!.InboundFee.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetChannelFeePolicy_SetsMaxHtlcMsat_WhenProvided()
+    {
+        // Arrange
+        var logger = new Mock<ILogger<LightningClientService>>();
+        var lightningClientService = new LightningClientService(logger.Object);
+        var lightningClient = new Mock<Lightning.LightningClient>();
+        var chanPoint = NBitcoin.OutPoint.Parse("0000000000000000000000000000000000000000000000000000000000000001:2");
+        var node = new Node
+        {
+            Endpoint = "127.0.0.1:10009",
+            ChannelAdminMacaroon = "test-macaroon"
+        };
+
+        PolicyUpdateRequest? capturedRequest = null;
+
+        lightningClient
+            .Setup(x => x.UpdateChannelPolicyAsync(
+                It.IsAny<PolicyUpdateRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PolicyUpdateRequest, Metadata, DateTime?, CancellationToken>((request, _, _, _) =>
+            {
+                capturedRequest = request;
+            })
+            .Returns(MockHelpers.CreateAsyncUnaryCall(new PolicyUpdateResponse()));
+
+        // Act
+        await lightningClientService.SetChannelFeePolicy(
+            node,
+            chanPoint,
+            baseFeeMsat: 1000,
+            feeRatePpm: 250,
+            timeLockDelta: 40,
+            inboundBaseFeeMsat: null,
+            inboundFeeRatePpm: null,
+            maxHtlcMsat: 5_000_000,
+            client: lightningClient.Object);
+
+        // Assert
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.MaxHtlcMsat.Should().Be(5_000_000);
     }
 }

--- a/test/NodeGuard.Tests/Services/LightningServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningServiceTests.cs
@@ -2235,6 +2235,7 @@ namespace NodeGuard.Services
                     40,
                     -100,
                     -25,
+                    null,
                     null))
                 .ReturnsAsync(new PolicyUpdateResponse());
 
@@ -2271,6 +2272,7 @@ namespace NodeGuard.Services
                 40,
                 -100,
                 -25,
+                null,
                 null), Times.Once);
 
             // Manual/UI path (isEngineDriven == false) audits via the user-context LogAsync.
@@ -2393,7 +2395,7 @@ namespace NodeGuard.Services
                 .Setup(x => x.GetByPubkey(node.PubKey))
                 .ReturnsAsync(node);
             lightningClientService
-                .Setup(x => x.SetChannelFeePolicy(node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null))
+                .Setup(x => x.SetChannelFeePolicy(node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null, null))
                 .ReturnsAsync(new PolicyUpdateResponse());
 
             var lightningService = new LightningService(
@@ -2423,7 +2425,7 @@ namespace NodeGuard.Services
 
             // Assert — the positive inbound rate reached LND (no <= 0 throw)...
             lightningClientService.Verify(x => x.SetChannelFeePolicy(
-                node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null), Times.Once);
+                node, It.IsAny<NBitcoin.OutPoint>(), 1000, 250, 40, 0, 50, null, null), Times.Once);
 
             // ...and the write was audited through the system (engine-driven) path.
             auditService.Verify(x => x.LogSystemAsync(


### PR DESCRIPTION
This pull request adds support for configuring the maximum HTLC (Hash Time Locked Contract) value per channel in the application, allowing users to view and update the maximum HTLC (in satoshis) that a channel can forward. The changes include updates to the UI, validation logic, backend service interfaces, and tests to support this new functionality.