### PR TITLE
Add Nodeguard-Remote-Signer as git submodule with just recipes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,7 @@
 [submodule "reference-code/rebalance-lnd"]
 	path = reference-code/rebalance-lnd
 	url = https://github.com/C-Otto/rebalance-lnd
+[submodule "remote-signer"]
+	path = remote-signer
+	url = https://github.com/Elenpay/Nodeguard-Remote-Signer
+	branch = develop

--- a/.justfile
+++ b/.justfile
@@ -92,6 +92,22 @@ mine:
 update-protos:
     ./src/Proto/update-protos.sh
 
+##############
+# Submodules #
+##############
+
+REMOTE_SIGNER_URL := 'https://github.com/Elenpay/Nodeguard-Remote-Signer'
+REMOTE_SIGNER_DIR := 'remote-signer'
+
+# Add the Remote Signer submodule, or initialize it on a fresh clone
+add-remote-signer:
+    git submodule add -b develop {{REMOTE_SIGNER_URL}} {{REMOTE_SIGNER_DIR}} 2>/dev/null || git submodule update --init {{REMOTE_SIGNER_DIR}}
+
+# Sync the Remote Signer submodule config and update it to the latest remote develop commit
+sync-remote-signer:
+    git submodule sync {{REMOTE_SIGNER_DIR}}
+    git submodule update --init --remote {{REMOTE_SIGNER_DIR}}
+
 ##########
 # Docker #
 ##########


### PR DESCRIPTION
Adds https://github.com/Elenpay/Nodeguard-Remote-Signer as a submodule at
remote-signer/ tracking its develop branch, plus just recipes to manage it:
- just add-remote-signer: add or initialize the submodule on a fresh clone
- just sync-remote-signer: sync config and update to latest remote develop

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>