### PR TITLE
Scope coin-selection ignore list to queried wallet

### DIFF
--- a/src/Services/CoinSelectionService.cs
+++ b/src/Services/CoinSelectionService.cs
@@ -160,16 +160,28 @@ public class CoinSelectionService: ICoinSelectionService
     }
 
     /// <summary>
-    /// Outpoints that must never be offered for coin selection: locked, frozen and dust UTXOs.
+    /// Outpoints that must never be offered for coin selection: the locked and frozen UTXOs that
+    /// belong to this wallet.
     /// </summary>
+    /// <remarks>
+    /// Both the locked and the frozen lookups span every wallet in the database, so the result is
+    /// intersected with this wallet's own UTXO set. Outpoints the backend could never return are
+    /// dead weight on the request line, and enough of them push it past Kestrel's 8KB limit, which
+    /// answers with a 414 and knocks the whole selection back to the plain listing.
+    /// Dust is deliberately absent: the backend drops it by value instead, which costs one scalar
+    /// query parameter rather than one parameter per dust UTXO.
+    /// </remarks>
     private async Task<List<string>> GetIgnoredOutpoints(UTXOChanges utxos)
     {
-        var ignoredOutpoints = await GetLockedFrozenOutpoints();
-        ignoredOutpoints.AddRange(utxos.Confirmed.UTXOs
+        var walletOutpoints = utxos.Confirmed.UTXOs
             .Concat(utxos.Unconfirmed.UTXOs)
-            .Where(utxo => ((Money)utxo.Value).Satoshi <= Constants.MINIMUM_UTXO_VALUE_SATS)
-            .Select(utxo => utxo.Outpoint.ToString()));
-        return ignoredOutpoints;
+            .Select(utxo => utxo.Outpoint.ToString())
+            .ToHashSet();
+
+        return (await GetLockedFrozenOutpoints())
+            .Where(walletOutpoints.Contains)
+            .Distinct()
+            .ToList();
     }
 
     private async Task<List<UTXO>> FilterLockedFrozenUTXOs(UTXOChanges? utxoChanges)
@@ -232,9 +244,10 @@ public class CoinSelectionService: ICoinSelectionService
         {
             try
             {
-                // Tell the backend which UTXOs to skip (locked, frozen and dust), otherwise it
-                // counts them towards the requested amount and the local filter below strips them
-                // afterwards, returning a selection that falls short of that amount
+                // Tell the backend which UTXOs to skip, otherwise it counts them towards the
+                // requested amount and the local filter below strips them afterwards, returning a
+                // selection that falls short of that amount. Dust is excluded by the backend on
+                // value, so it does not need listing here
                 var allUtxos = await _nbXplorerService.GetUTXOsAsync(derivationStrategy);
                 allUtxos.RemoveDuplicateUTXOs();
                 var ignoreOutpoints = await GetIgnoredOutpoints(allUtxos);

--- a/src/Services/NBXplorerService.cs
+++ b/src/Services/NBXplorerService.cs
@@ -162,16 +162,26 @@ public class NBXplorerService : INBXplorerService
                 new("strategy", strategy.ToString()),
                 new("limit", limit.ToString()),
                 new("amount", amount.ToString()),
+                // Lets the backend drop dust by value, so callers do not have to spend one query
+                // parameter per dust outpoint saying the same thing
+                new("minimumValue", Constants.MINIMUM_UTXO_VALUE_SATS.ToString()),
             };
             if (strategy == CoinSelectionStrategy.ClosestToTargetFirst)
             {
                 keyValuePairs.Add(new("closestTo", closestTo.ToString()));
             }
 
-            ignoreOutpoints?.ForEach(outpoint => keyValuePairs.Add(new("ignoreOutpoint", outpoint)));
-
             var url = QueryHelpers.AddQueryString(requestUri, keyValuePairs);
-            var response = await _httpClient.GetAsync(url, cancellation);
+
+            // The ignored outpoints travel in the body. As one repeated ignoreOutpoint query
+            // parameter each they cost ~83 bytes apiece, so about ninety of them overflowed
+            // Kestrel's 8KB MaxRequestLineSize and NBXplorer answered 414 — which the callers
+            // swallow into a degraded selection. The body limit is 30MB, roughly 3,662x the
+            // room, so the list no longer has a practical ceiling.
+            // NOTE: this requires an NBXplorer serving POST /selectutxos (Elenpay/NBXplorer#18).
+            // Against an older build every call answers 405 and coin selection degrades.
+            var response = await _httpClient.PostAsync(url,
+                JsonContent.Create(new { ignoreOutpoints }), cancellation);
 
             if (response.IsSuccessStatusCode)
             {

--- a/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/CoinSelectionServiceTests.cs
@@ -114,7 +114,7 @@ public class CoinSelectionServiceTests
     }
 
     [Fact]
-    public async Task GetAvailableUTXOsAsync_WithCustomBackend_IgnoresLockedFrozenAndDustServerSide()
+    public async Task GetAvailableUTXOsAsync_WithCustomBackend_IgnoresLockedAndFrozenServerSide()
     {
         var previousCustomBackend = Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND;
         Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = true;
@@ -182,13 +182,165 @@ public class CoinSelectionServiceTests
             availableUTXOs.Should().ContainSingle();
             availableUTXOs[0].Outpoint.Should().Be(availableUtxo.Outpoint);
 
-            // Locked, frozen and dust UTXOs must all be ignored server-side so the backend does
-            // not count them towards the requested amount and return a short selection
+            // Locked and frozen UTXOs must be ignored server-side so the backend does not count
+            // them towards the requested amount and return a short selection
             ignoredOutpoints.Should().NotBeNull();
-            ignoredOutpoints.Should().Contain(dustUtxo.Outpoint.ToString());
             ignoredOutpoints.Should().Contain($"{lockedUtxo.Outpoint.Hash}-{lockedUtxo.Outpoint.N}");
             ignoredOutpoints.Should().Contain(frozenUtxo.Outpoint.ToString());
             ignoredOutpoints.Should().NotContain(availableUtxo.Outpoint.ToString());
+
+            // Dust is dropped by the backend on value, via the minimumValue parameter. Listing it
+            // here as well would spend one query parameter per dust UTXO to say the same thing,
+            // and that is what used to push the request line past 8KB and earn a 414
+            ignoredOutpoints.Should().NotContain(dustUtxo.Outpoint.ToString());
+        }
+        finally
+        {
+            Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = previousCustomBackend;
+        }
+    }
+
+    [Fact]
+    public async Task GetAvailableUTXOsAsync_WithCustomBackend_SkipsOutpointsOutsideTheWallet()
+    {
+        var previousCustomBackend = Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND;
+        Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = true;
+        try
+        {
+            // Arrange
+            var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+            var availableUtxo = CreateUtxo(1, 40_000);
+            var otherWalletLockedUtxo = CreateUtxo(2, 20_000);
+            var otherWalletFrozenUtxo = CreateUtxo(3, 30_000);
+
+            // Neither lookup is scoped to a wallet, so both return rows belonging to other wallets
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository
+                .Setup(x => x.GetLockedUTXOs(null, null))
+                .ReturnsAsync(new List<FMUTXO>()
+                {
+                    new()
+                    {
+                        TxId = otherWalletLockedUtxo.Outpoint.Hash.ToString(),
+                        OutputIndex = otherWalletLockedUtxo.Outpoint.N,
+                        SatsAmount = 20_000
+                    }
+                });
+
+            var utxoTagRepository = new Mock<IUTXOTagRepository>();
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsFrozenTag, "true"))
+                .ReturnsAsync(new List<UTXOTag>() { new() { Outpoint = otherWalletFrozenUtxo.Outpoint.ToString() } });
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsManuallyFrozenTag, It.IsAny<string>()))
+                .ReturnsAsync(new List<UTXOTag>());
+
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService
+                .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { availableUtxo } }
+                });
+            List<string>? ignoredOutpoints = null;
+            nbXplorerService
+                .Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .Callback<DerivationStrategyBase, CoinSelectionStrategy, int, long, long, List<string>?,
+                    CancellationToken>((_, _, _, _, _, ignore, _) => ignoredOutpoints = ignore)
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { availableUtxo } }
+                });
+
+            var mapper = new Mock<IMapper>();
+            var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object,
+                nbXplorerService.Object, null, null, utxoTagRepository.Object);
+
+            // Act
+            var availableUTXOs = await coinSelectionService.GetAvailableUTXOsAsync(
+                derivationStrategy, CoinSelectionStrategy.SmallestFirst, 0, 40_000, 0);
+
+            // Assert
+            availableUTXOs.Should().ContainSingle();
+
+            // The backend can only ever return UTXOs from the queried wallet, so telling it to skip
+            // another wallet's outpoints changes nothing and only lengthens the request line
+            ignoredOutpoints.Should().BeEmpty();
+        }
+        finally
+        {
+            Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = previousCustomBackend;
+        }
+    }
+
+    [Fact]
+    public async Task GetAvailableUTXOsAsync_WithCustomBackend_DeduplicatesIgnoredOutpoints()
+    {
+        var previousCustomBackend = Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND;
+        Constants.NBXPLORER_ENABLE_CUSTOM_BACKEND = true;
+        try
+        {
+            // Arrange: one UTXO that is both locked and frozen
+            var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+            var lockedAndFrozenUtxo = CreateUtxo(1, 20_000);
+            var availableUtxo = CreateUtxo(2, 40_000);
+
+            var fmutxoRepository = new Mock<IFMUTXORepository>();
+            fmutxoRepository
+                .Setup(x => x.GetLockedUTXOs(null, null))
+                .ReturnsAsync(new List<FMUTXO>()
+                {
+                    new()
+                    {
+                        TxId = lockedAndFrozenUtxo.Outpoint.Hash.ToString(),
+                        OutputIndex = lockedAndFrozenUtxo.Outpoint.N,
+                        SatsAmount = 20_000
+                    }
+                });
+
+            var utxoTagRepository = new Mock<IUTXOTagRepository>();
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsFrozenTag, "true"))
+                .ReturnsAsync(new List<UTXOTag>() { new() { Outpoint = lockedAndFrozenUtxo.Outpoint.ToString() } });
+            utxoTagRepository
+                .Setup(x => x.GetByKeyValue(Constants.IsManuallyFrozenTag, It.IsAny<string>()))
+                .ReturnsAsync(new List<UTXOTag>());
+
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService
+                .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange()
+                    {
+                        UTXOs = new List<UTXO>() { lockedAndFrozenUtxo, availableUtxo }
+                    }
+                });
+            List<string>? ignoredOutpoints = null;
+            nbXplorerService
+                .Setup(x => x.GetUTXOsByLimitAsync(It.IsAny<DerivationStrategyBase>(),
+                    It.IsAny<CoinSelectionStrategy>(), It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>(),
+                    It.IsAny<List<string>>(), default))
+                .Callback<DerivationStrategyBase, CoinSelectionStrategy, int, long, long, List<string>?,
+                    CancellationToken>((_, _, _, _, _, ignore, _) => ignoredOutpoints = ignore)
+                .ReturnsAsync(new UTXOChanges()
+                {
+                    Confirmed = new UTXOChange() { UTXOs = new List<UTXO>() { availableUtxo } }
+                });
+
+            var mapper = new Mock<IMapper>();
+            var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object,
+                nbXplorerService.Object, null, null, utxoTagRepository.Object);
+
+            // Act
+            await coinSelectionService.GetAvailableUTXOsAsync(
+                derivationStrategy, CoinSelectionStrategy.SmallestFirst, 0, 40_000, 0);
+
+            // Assert: sending it twice would say nothing extra and cost another query parameter
+            ignoredOutpoints.Should().ContainSingle()
+                .Which.Should().Be(lockedAndFrozenUtxo.Outpoint.ToString());
         }
         finally
         {

--- a/test/NodeGuard.Tests/Services/NBXplorerServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/NBXplorerServiceTests.cs
@@ -1,0 +1,154 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+using System.Net;
+using FluentAssertions;
+using NodeGuard.Data.Models;
+using NodeGuard.Helpers;
+using NodeGuard.TestHelpers;
+using Microsoft.Extensions.Logging;
+using Moq.Protected;
+using NBitcoin;
+
+namespace NodeGuard.Services;
+
+public class NBXplorerServiceTests
+{
+    private readonly ILogger<NBXplorerService> _logger = new Mock<ILogger<NBXplorerService>>().Object;
+    private readonly InternalWallet _internalWallet = CreateWallet.CreateInternalWallet();
+
+    /// <summary>
+    /// Captures what the service put on the wire. NBXPLORER_URI is unset under test, which leaves
+    /// the request URI relative, so the client needs a base address to resolve it against.
+    /// </summary>
+    private sealed class RequestRecorder
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Body { get; private set; }
+
+        public HttpClient CreateClient()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) =>
+                {
+                    Request = request;
+                    // Read it here: HttpClient disposes the content once the send completes
+                    Body = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+                })
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                });
+
+            return new HttpClient(handler.Object) { BaseAddress = new Uri("http://localhost:32838") };
+        }
+    }
+
+    private static List<string> CreateOutpoints(int count)
+    {
+        return Enumerable.Range(1, count)
+            .Select(i => new OutPoint(new uint256((uint)i), 0).ToString())
+            .ToList();
+    }
+
+    private static int CountIgnoreOutpointParams(Uri uri)
+    {
+        return uri.Query.Split('&').Count(part => part.TrimStart('?').StartsWith("ignoreOutpoint="));
+    }
+
+    // Both a handful of outpoints and a list far past the old ~90-outpoint request-line ceiling:
+    // the transport does not vary with size, so neither can 414.
+    [Theory]
+    [InlineData(5)]
+    [InlineData(100)]
+    public async Task GetUTXOsByLimitAsync_SendsPostWithTheOutpointsInTheBody(int outpointCount)
+    {
+        // Arrange
+        var recorder = new RequestRecorder();
+        var service = new NBXplorerService(recorder.CreateClient(), _logger);
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+        var ignoreOutpoints = CreateOutpoints(outpointCount);
+
+        // Act
+        await service.GetUTXOsByLimitAsync(derivationStrategy, CoinSelectionStrategy.SmallestFirst, 50, 40_000, 0,
+            ignoreOutpoints);
+
+        // Assert: nothing about the exclusion list touches the request line, so Kestrel's 8KB cap
+        // is out of the picture regardless of how many outpoints there are
+        recorder.Request.Should().NotBeNull();
+        recorder.Request!.Method.Should().Be(HttpMethod.Post);
+        recorder.Request.RequestUri!.Query.Should().NotContain("ignoreOutpoint");
+        CountIgnoreOutpointParams(recorder.Request.RequestUri!).Should().Be(0);
+
+        // Pin the wire format: NBXplorer binds this to SelectUTXOsRequest.IgnoreOutpoints, and the
+        // fork's CoinSelectionControllerTests posts exactly this shape
+        recorder.Body.Should().NotBeNull();
+        recorder.Body.Should().StartWith("{\"ignoreOutpoints\":[");
+        foreach (var outpoint in ignoreOutpoints)
+        {
+            recorder.Body.Should().Contain($"\"{outpoint}\"");
+        }
+    }
+
+    [Fact]
+    public async Task GetUTXOsByLimitAsync_AlwaysSendsMinimumValueSoDustNeedsNoOutpoints()
+    {
+        // Arrange
+        var recorder = new RequestRecorder();
+        var service = new NBXplorerService(recorder.CreateClient(), _logger);
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+
+        // Act
+        await service.GetUTXOsByLimitAsync(derivationStrategy, CoinSelectionStrategy.SmallestFirst, 50, 40_000, 0,
+            new List<string>());
+
+        // Assert: one scalar parameter replaces what used to be one parameter per dust UTXO
+        recorder.Request!.RequestUri!.Query.Should()
+            .Contain($"minimumValue={Constants.MINIMUM_UTXO_VALUE_SATS}");
+    }
+
+    [Fact]
+    public async Task GetUTXOsByLimitAsync_WhenBackendFails_ThrowsWithTheStatusCode()
+    {
+        // Arrange
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestUriTooLong)
+            {
+                Content = new StringContent(string.Empty)
+            });
+        var httpClient = new HttpClient(handler.Object) { BaseAddress = new Uri("http://localhost:32838") };
+        var service = new NBXplorerService(httpClient, _logger);
+        var derivationStrategy = CreateWallet.SingleSig(_internalWallet).GetDerivationStrategy();
+
+        // Act
+        var act = async () => await service.GetUTXOsByLimitAsync(derivationStrategy,
+            CoinSelectionStrategy.SmallestFirst, 50, 40_000, 0, new List<string>());
+
+        // Assert
+        (await act.Should().ThrowAsync<HttpRequestException>())
+            .WithMessage("*414*");
+    }
+}

--- a/test/NodeGuard.Tests/TestHelpers/TestEnvironment.cs
+++ b/test/NodeGuard.Tests/TestHelpers/TestEnvironment.cs
@@ -1,0 +1,48 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+using System.Runtime.CompilerServices;
+
+namespace NodeGuard.TestHelpers;
+
+internal static class TestEnvironment
+{
+    /// <summary>
+    /// Fills in the environment variables that Constants reads in its static constructor.
+    /// </summary>
+    /// <remarks>
+    /// Constants tolerates them being missing under test, but the values it exposes are readonly
+    /// and initialized on first touch, so a test cannot set one after the fact. A module
+    /// initializer runs before any code in this assembly, which makes the value deterministic no
+    /// matter which test happens to touch Constants first. Anything already set by the environment
+    /// wins, so a CI run can still point these elsewhere.
+    /// </remarks>
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        SetIfMissing("NBXPLORER_URI", "http://localhost:32838");
+    }
+
+    private static void SetIfMissing(string name, string value)
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(name)))
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+}


### PR DESCRIPTION
Refine the coin-selection process by ensuring the ignore list only includes locked and frozen UTXOs belonging to the queried wallet. 

This change prevents unnecessary outpoints from other wallets from affecting the request size, which previously led to HTTP 414 errors. Additionally, optimize the handling of dust UTXOs by allowing the backend to filter them by value, reducing the number of query parameters needed.

 Implement tests to cover the new functionality and ensure compatibility with existing systems.