### PR TITLE
Create two channel fee states when the channel is shared between two managed nodes

### DIFF
--- a/src/Data/ApplicationDbContext.cs
+++ b/src/Data/ApplicationDbContext.cs
@@ -109,23 +109,28 @@ namespace NodeGuard.Data
                 .HasForeignKey(r => r.SourceChannelId)
                 .OnDelete(DeleteBehavior.Restrict);
 
-            // Routing engine: 1:1 read models keyed on ChannelId.
+            // Routing engine read models are keyed per (channel, managed node), not per channel:
+            // a channel between two managed nodes has one row per side, since local balance, flow
+            // history and fee policy are all per-node views of the same channel.
             modelBuilder.Entity<ChannelRoutingState>()
                 .HasOne(x => x.Channel)
-                .WithOne()
-                .HasForeignKey<ChannelRoutingState>(x => x.ChannelId)
+                .WithMany()
+                .HasForeignKey(x => x.ChannelId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            // Only one ChannelRoutingState per channel.
-            modelBuilder.Entity<ChannelRoutingState>().HasIndex(x => x.ChannelId).IsUnique();
+            // One ChannelRoutingState per channel per managed node.
+            modelBuilder.Entity<ChannelRoutingState>()
+                .HasIndex(x => new { x.ChannelId, x.ManagedNodePubKey }).IsUnique();
 
             modelBuilder.Entity<ChannelFeeState>()
                 .HasOne(x => x.Channel)
-                .WithOne()
-                .HasForeignKey<ChannelFeeState>(x => x.ChannelId)
+                .WithMany()
+                .HasForeignKey(x => x.ChannelId)
                 .OnDelete(DeleteBehavior.Cascade);
-            // Only one ChannelFeeState per channel.
-            modelBuilder.Entity<ChannelFeeState>().HasIndex(x => x.ChannelId).IsUnique();
+
+            // One ChannelFeeState per channel per managed node.
+            modelBuilder.Entity<ChannelFeeState>()
+                .HasIndex(x => new { x.ChannelId, x.ManagedNodePubKey }).IsUnique();
 
             // These default ON: existing rows must be backfilled true (the C# initializer
             // only affects new in-code instances, not the DB column default / migration backfill).

--- a/src/Data/Models/ChannelFeeState.cs
+++ b/src/Data/Models/ChannelFeeState.cs
@@ -20,14 +20,24 @@
 namespace NodeGuard.Data.Models;
 
 /// <summary>
-/// Per-channel fee-engine state (1:1 with <see cref="Channel"/>). Holds last-applied
-/// policy and control state that must survive restarts.
+/// Fee-engine state for one channel <b>as seen by one managed node</b> — keyed by
+/// (<see cref="ChannelId"/>, <see cref="ManagedNodePubKey"/>). Holds last-applied policy and
+/// control state that must survive restarts.
+/// <para>
+/// Each side of a channel sets its own outbound policy, so a channel between two managed nodes
+/// carries one row per side (mirrors <see cref="ChannelRoutingState"/>).
+/// </para>
 /// </summary>
 public class ChannelFeeState : Entity
 {
-    /// <summary>FK to <see cref="Channel"/> (unique — one fee state per channel).</summary>
+    /// <summary>FK to <see cref="Channel"/> (unique together with <see cref="ManagedNodePubKey"/>).</summary>
     public int ChannelId { get; set; }
     public Channel Channel { get; set; } = null!;
+
+    /// <summary>
+    /// 66-hex pubkey of the managed node whose outbound/inbound policy this row tracks.
+    /// </summary>
+    public string ManagedNodePubKey { get; set; } = null!;
 
     public DateTimeOffset? LastFeeUpdateAt { get; set; }
     public long? LastAppliedOutboundBaseFeeMsat { get; set; }

--- a/src/Data/Models/ChannelRoutingState.cs
+++ b/src/Data/Models/ChannelRoutingState.cs
@@ -39,21 +39,31 @@ public enum PeerFlowCategory
 }
 
 /// <summary>
-/// Per-channel routing-engine read model (1:1 with <see cref="Channel"/>). Written by
+/// Routing-engine read model for one channel <b>as seen by one managed node</b> — keyed by
+/// (<see cref="ChannelId"/>, <see cref="ManagedNodePubKey"/>). Written by
 /// TargetRatioReevaluationJob; read by the fee engine and rebalancer. This is the single
 /// canonical place target ratio / category / smoothed balance live — actuators must not
 /// re-derive them.
+/// <para>
+/// A channel between two managed nodes has <b>one row per side</b>. Local balance, forwarding
+/// history and fee policy are all per-node views of the same channel, so each node needs its own
+/// signal: with a single shared row, whichever node did not own it was blind to its own depleted
+/// channels and could never classify them as rebalance destinations.
+/// </para>
 /// </summary>
 public class ChannelRoutingState : Entity
 {
-    /// <summary>FK to <see cref="Channel"/> (unique — one routing state per channel).</summary>
+    /// <summary>FK to <see cref="Channel"/> (unique together with <see cref="ManagedNodePubKey"/>).</summary>
     public int ChannelId { get; set; }
     public Channel Channel { get; set; } = null!;
 
     /// <summary>LND short-channel-id snapshot, refreshed every evaluation (alias -&gt; confirmed scid).</summary>
     public ulong ChanIdLnd { get; set; }
 
-    /// <summary>66-hex pubkey of the managed node that owns routing state for this channel.</summary>
+    /// <summary>
+    /// 66-hex pubkey of the managed node this state belongs to — the side whose local balance,
+    /// flow history and fee policy the row describes.
+    /// </summary>
     public string ManagedNodePubKey { get; set; } = null!;
 
     /// <summary>Dynamic target local-balance ratio, clamped to [0.10, 0.90]. Defaults to 0.5.</summary>

--- a/src/Data/Repositories/ChannelFeeStateRepository.cs
+++ b/src/Data/Repositories/ChannelFeeStateRepository.cs
@@ -32,36 +32,30 @@ public class ChannelFeeStateRepository : IChannelFeeStateRepository
         _dbContextFactory = dbContextFactory;
     }
 
-    public async Task<ChannelFeeState?> GetByChannelId(int channelId)
+    public async Task<ChannelFeeState?> GetByChannelIdAndNode(int channelId, string managedNodePubKey)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         return await context.ChannelFeeStates
-            .FirstOrDefaultAsync(x => x.ChannelId == channelId);
+            .FirstOrDefaultAsync(x => x.ChannelId == channelId && x.ManagedNodePubKey == managedNodePubKey);
     }
 
     public async Task<List<ChannelFeeState>> GetByManagedNodePubKey(string managedNodePubKey)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
-        // ChannelFeeState carries no node pubkey; the owning node lives on ChannelRoutingState
-        // (1:1 with the same Channel), so filter through it.
-        var channelIds = context.ChannelRoutingStates
-            .Where(s => s.ManagedNodePubKey == managedNodePubKey)
-            .Select(s => s.ChannelId);
-
         return await context.ChannelFeeStates
-            .Include(x => x.Channel)
-            .Where(x => channelIds.Contains(x.ChannelId))
+            .Where(x => x.ManagedNodePubKey == managedNodePubKey)
             .ToListAsync();
     }
 
-    public async Task UpsertByChannelId(ChannelFeeState state)
+    public async Task UpsertByChannelAndNode(ChannelFeeState state)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         var existing = await context.ChannelFeeStates
-            .FirstOrDefaultAsync(x => x.ChannelId == state.ChannelId);
+            .FirstOrDefaultAsync(x => x.ChannelId == state.ChannelId
+                                      && x.ManagedNodePubKey == state.ManagedNodePubKey);
 
         if (existing == null)
         {
@@ -90,14 +84,15 @@ public class ChannelFeeStateRepository : IChannelFeeStateRepository
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         var existing = await context.ChannelFeeStates
-            .FirstOrDefaultAsync(x => x.ChannelId == channelId);
+            .Where(x => x.ChannelId == channelId)
+            .ToListAsync();
 
-        if (existing == null)
+        if (existing.Count == 0)
         {
             return false;
         }
 
-        context.ChannelFeeStates.Remove(existing);
+        context.ChannelFeeStates.RemoveRange(existing);
         await context.SaveChangesAsync();
         return true;
     }
@@ -106,12 +101,8 @@ public class ChannelFeeStateRepository : IChannelFeeStateRepository
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
-        var channelIds = context.ChannelRoutingStates
-            .Where(s => s.ManagedNodePubKey == managedNodePubKey)
-            .Select(s => s.ChannelId);
-
         var states = await context.ChannelFeeStates
-            .Where(x => channelIds.Contains(x.ChannelId))
+            .Where(x => x.ManagedNodePubKey == managedNodePubKey)
             .ToListAsync();
 
         if (states.Count == 0)

--- a/src/Data/Repositories/ChannelRoutingStateRepository.cs
+++ b/src/Data/Repositories/ChannelRoutingStateRepository.cs
@@ -32,12 +32,12 @@ public class ChannelRoutingStateRepository : IChannelRoutingStateRepository
         _dbContextFactory = dbContextFactory;
     }
 
-    public async Task<ChannelRoutingState?> GetByChannelId(int channelId)
+    public async Task<ChannelRoutingState?> GetByChannelIdAndNode(int channelId, string managedNodePubKey)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         return await context.ChannelRoutingStates
-            .FirstOrDefaultAsync(x => x.ChannelId == channelId);
+            .FirstOrDefaultAsync(x => x.ChannelId == channelId && x.ManagedNodePubKey == managedNodePubKey);
     }
 
     public async Task<List<ChannelRoutingState>> GetByManagedNodePubKey(string managedNodePubKey)
@@ -49,12 +49,13 @@ public class ChannelRoutingStateRepository : IChannelRoutingStateRepository
             .ToListAsync();
     }
 
-    public async Task UpsertByChannelId(ChannelRoutingState state)
+    public async Task UpsertByChannelAndNode(ChannelRoutingState state)
     {
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         var existing = await context.ChannelRoutingStates
-            .FirstOrDefaultAsync(x => x.ChannelId == state.ChannelId);
+            .FirstOrDefaultAsync(x => x.ChannelId == state.ChannelId
+                                      && x.ManagedNodePubKey == state.ManagedNodePubKey);
 
         if (existing == null)
         {
@@ -67,7 +68,6 @@ public class ChannelRoutingStateRepository : IChannelRoutingStateRepository
         else
         {
             existing.ChanIdLnd = state.ChanIdLnd;
-            existing.ManagedNodePubKey = state.ManagedNodePubKey;
             existing.TargetLocalRatio = state.TargetLocalRatio;
             existing.PeerFlowCategory = state.PeerFlowCategory;
             existing.PendingCategory = state.PendingCategory;

--- a/src/Data/Repositories/Interfaces/IChannelFeeStateRepository.cs
+++ b/src/Data/Repositories/Interfaces/IChannelFeeStateRepository.cs
@@ -23,24 +23,25 @@ namespace NodeGuard.Data.Repositories.Interfaces;
 
 public interface IChannelFeeStateRepository
 {
-    Task<ChannelFeeState?> GetByChannelId(int channelId);
+    Task<ChannelFeeState?> GetByChannelIdAndNode(int channelId, string managedNodePubKey);
 
     /// <summary>
-    /// All fee-state rows for channels owned by the given managed node.
+    /// All fee-state rows belonging to the given managed node.
     /// Used by the fee engine to batch per-node state.
     /// </summary>
     Task<List<ChannelFeeState>> GetByManagedNodePubKey(string managedNodePubKey);
 
-    Task UpsertByChannelId(ChannelFeeState state);
+    Task UpsertByChannelAndNode(ChannelFeeState state);
 
     /// <summary>
-    /// Deletes the fee-state row for a single channel, if present.
+    /// Deletes the fee-state rows for a single channel — every managed side of it, since
+    /// <see cref="Channel.IsDynamicFeeEnabled"/> is a channel-level opt-out.
     /// </summary>
-    /// <returns><c>true</c> if a row was deleted; <c>false</c> if none existed.</returns>
+    /// <returns><c>true</c> if any row was deleted; <c>false</c> if none existed.</returns>
     Task<bool> DeleteByChannelId(int channelId);
 
     /// <summary>
-    /// Deletes the fee-state rows for every channel owned by the given managed node.
+    /// Deletes the fee-state rows belonging to the given managed node.
     /// </summary>
     /// <returns><c>true</c> if any rows were deleted; <c>false</c> if none existed.</returns>
     Task<bool> DeleteByManagedNodePubKey(string managedNodePubKey);

--- a/src/Data/Repositories/Interfaces/IChannelRoutingStateRepository.cs
+++ b/src/Data/Repositories/Interfaces/IChannelRoutingStateRepository.cs
@@ -23,14 +23,9 @@ namespace NodeGuard.Data.Repositories.Interfaces;
 
 public interface IChannelRoutingStateRepository
 {
-    Task<ChannelRoutingState?> GetByChannelId(int channelId);
+    Task<ChannelRoutingState?> GetByChannelIdAndNode(int channelId, string managedNodePubKey);
 
     Task<List<ChannelRoutingState>> GetByManagedNodePubKey(string managedNodePubKey);
 
-    /// <summary>
-    /// Insert-or-update keyed on <see cref="ChannelRoutingState.ChannelId"/>. Load-then-update
-    /// is sufficient because TargetRatioReevaluationJob is the sole writer under
-    /// [DisallowConcurrentExecution].
-    /// </summary>
-    Task UpsertByChannelId(ChannelRoutingState state);
+    Task UpsertByChannelAndNode(ChannelRoutingState state);
 }

--- a/src/Jobs/ChannelFeeOptimizerJob.cs
+++ b/src/Jobs/ChannelFeeOptimizerJob.cs
@@ -211,7 +211,7 @@ public class ChannelFeeOptimizerJob : IJob
         {
             _logger.LogInformation("Channel {ChanId} on {NodeName}: {Action} ({Reason})",
                 candidate.LndChannel.ChanId, node.Name, decision.Action, decision.Reason);
-            await _feeStateRepository.UpsertByChannelId(feeState);
+            await _feeStateRepository.UpsertByChannelAndNode(feeState);
             return;
         }
 
@@ -222,7 +222,7 @@ public class ChannelFeeOptimizerJob : IJob
         {
             _logger.LogWarning("Skipping channel {ChanId} on {NodeName}: current fee policy unavailable",
                 candidate.LndChannel.ChanId, node.Name);
-            await _feeStateRepository.UpsertByChannelId(feeState);
+            await _feeStateRepository.UpsertByChannelAndNode(feeState);
             return;
         }
 
@@ -241,7 +241,7 @@ public class ChannelFeeOptimizerJob : IJob
             feeState.LastAppliedInboundPpm = decision.InboundPpm;
             feeState.LastFeeUpdateAt = now;
 
-            await _feeStateRepository.UpsertByChannelId(feeState);
+            await _feeStateRepository.UpsertByChannelAndNode(feeState);
             return;
         }
 
@@ -269,7 +269,7 @@ public class ChannelFeeOptimizerJob : IJob
             _logger.LogInformation("{NodeName} chan {ChanId}: set outbound {Outbound}ppm inbound {Inbound}ppm ({Reason})",
                 node.Name, candidate.LndChannel.ChanId, decision.OutboundPpm, decision.InboundPpm, decision.Reason);
 
-            await _feeStateRepository.UpsertByChannelId(feeState);
+            await _feeStateRepository.UpsertByChannelAndNode(feeState);
         }
         catch (Exception ex)
         {

--- a/src/Jobs/ChannelFeeOptimizerJob.cs
+++ b/src/Jobs/ChannelFeeOptimizerJob.cs
@@ -193,7 +193,10 @@ public class ChannelFeeOptimizerJob : IJob
     private async Task OptimizeChannel(Node node, Candidate candidate, FeeOptimizerTunables tunables, DateTimeOffset now)
     {
         var routingState = candidate.RoutingState;
-        var feeState = candidate.FeeState ?? new ChannelFeeState { ChannelId = candidate.DbChannel.Id };
+        var feeState = candidate.FeeState ?? new ChannelFeeState {
+            ChannelId = candidate.DbChannel.Id,
+            ManagedNodePubKey = node.PubKey,
+        };
 
         var decision = FeeOptimizerService.ComputeNextPolicy(
             routingState.EmaLocalRatio,

--- a/src/Jobs/TargetRatioReevaluationJob.cs
+++ b/src/Jobs/TargetRatioReevaluationJob.cs
@@ -169,7 +169,7 @@ public class TargetRatioReevaluationJob : IJob
                             / Math.Max(1, lndChannel.LocalBalance + lndChannel.RemoteBalance);
 
         // Seed EmaLocalRatio with the first observation on insert — no 0.5 cold-start bias.
-        var state = await _routingStateRepository.GetByChannelId(dbChannel.Id)
+        var state = await _routingStateRepository.GetByChannelIdAndNode(dbChannel.Id, managedNode.PubKey)
                     ?? new ChannelRoutingState
                     {
                         ChannelId = dbChannel.Id,
@@ -229,6 +229,6 @@ public class TargetRatioReevaluationJob : IJob
         state.LastKnownUptime = lndChannel.Uptime;
         state.LastEvaluatedAt = now;
 
-        await _routingStateRepository.UpsertByChannelId(state);
+        await _routingStateRepository.UpsertByChannelAndNode(state);
     }
 }

--- a/src/Jobs/TargetRatioReevaluationJob.cs
+++ b/src/Jobs/TargetRatioReevaluationJob.cs
@@ -83,7 +83,7 @@ public class TargetRatioReevaluationJob : IJob
             {
                 try
                 {
-                    await ReevaluateNode(managedNode, managedNodes, openChannelsByChanId);
+                    await ReevaluateNode(managedNode, openChannelsByChanId);
                 }
                 catch (Exception ex)
                 {
@@ -103,7 +103,6 @@ public class TargetRatioReevaluationJob : IJob
 
     private async Task ReevaluateNode(
         Node managedNode,
-        IReadOnlyCollection<Node> managedNodes,
         IReadOnlyDictionary<ulong, Channel> openChannelsByChanId)
     {
         var chainTip = await _lightningService.GetBlockHeight(managedNode);
@@ -125,16 +124,14 @@ public class TargetRatioReevaluationJob : IJob
         var now = DateTimeOffset.UtcNow;
         var windowStart = now - TimeSpan.FromDays(Constants.ROUTING_ENGINE_FLOW_WINDOW_DAYS);
 
+        // Every channel the node holds gets state, including channels shared with another managed
+        // node: routing state is per (channel, managed node), and each side's local balance, flow
+        // history and fee policy are its own. Deduping these to the initiator left the other side
+        // blind to its own depleted channels, so they never became rebalance destinations.
         foreach (var lndChannel in listResp.Channels)
         {
             try
             {
-                // Canonical ownership rule — a channel between two managed nodes is owned by one side.
-                if (!ChannelOwnershipHelper.IsOwnedByManagedNode(lndChannel, managedNodes))
-                {
-                    continue;
-                }
-
                 // Act only on a channel we have a confirmed, open DB row for (O(1) lookup by scid).
                 if (!openChannelsByChanId.TryGetValue(lndChannel.ChanId, out var dbChannel))
                 {

--- a/src/Migrations/20260821095604_RoutingStatePerManagedNode.Designer.cs
+++ b/src/Migrations/20260821095604_RoutingStatePerManagedNode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819155831_RoutingStatePerManagedNode")]
+    partial class RoutingStatePerManagedNode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -408,11 +411,6 @@ namespace NodeGuard.Migrations
 
                     b.Property<long>("FundingTxOutputIndex")
                         .HasColumnType("bigint");
-
-                    b.Property<bool>("IsAutoRebalanceEnabled")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(false);
 
                     b.Property<bool>("IsAutomatedLiquidityEnabled")
                         .HasColumnType("boolean");

--- a/src/Migrations/20260821095604_RoutingStatePerManagedNode.cs
+++ b/src/Migrations/20260821095604_RoutingStatePerManagedNode.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <summary>
+    /// Re-keys the routing-engine read models from "one row per channel" to "one row per channel
+    /// per managed node".
+    /// <para>
+    /// A channel between two managed nodes used to get a single row, assigned to the initiator
+    /// side. The other side was then invisible to the routing engine: it could not see its own
+    /// depleted channels, so they never classified as rebalance destinations and its outbound fee
+    /// policy was never managed. Both sides now carry their own state.
+    /// </para>
+    /// </summary>
+    public partial class RoutingStatePerManagedNode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ChannelRoutingStates_ChannelId",
+                table: "ChannelRoutingStates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChannelFeeStates_ChannelId",
+                table: "ChannelFeeStates");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ManagedNodePubKey",
+                table: "ChannelFeeStates",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            // ChannelFeeState had no owning node of its own — it was resolved by joining through
+            // ChannelRoutingState, which was 1:1 with the channel. Carry that owner across so the
+            // fee control loop keeps its operating point instead of cold-starting everywhere.
+            migrationBuilder.Sql(@"
+                UPDATE ""ChannelFeeStates"" fs
+                SET ""ManagedNodePubKey"" = rs.""ManagedNodePubKey""
+                FROM ""ChannelRoutingStates"" rs
+                WHERE rs.""ChannelId"" = fs.""ChannelId"";");
+
+            // Any fee state we could not attribute to a node is unreachable by the engine — drop it
+            // so the channel cold-starts from its category baseline on the next cycle.
+            migrationBuilder.Sql(@"DELETE FROM ""ChannelFeeStates"" WHERE ""ManagedNodePubKey"" = '';");
+
+            // The empty-string default existed only to backfill; new rows must always name a node.
+            migrationBuilder.Sql(@"ALTER TABLE ""ChannelFeeStates"" ALTER COLUMN ""ManagedNodePubKey"" DROP DEFAULT;");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelRoutingStates_ChannelId_ManagedNodePubKey",
+                table: "ChannelRoutingStates",
+                columns: new[] { "ChannelId", "ManagedNodePubKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelFeeStates_ChannelId_ManagedNodePubKey",
+                table: "ChannelFeeStates",
+                columns: new[] { "ChannelId", "ManagedNodePubKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ChannelRoutingStates_ChannelId_ManagedNodePubKey",
+                table: "ChannelRoutingStates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChannelFeeStates_ChannelId_ManagedNodePubKey",
+                table: "ChannelFeeStates");
+
+            // Going back to one row per channel: keep the oldest side, drop the rest, or the
+            // unique index below cannot be recreated.
+            migrationBuilder.Sql(@"
+                DELETE FROM ""ChannelRoutingStates"" a
+                USING ""ChannelRoutingStates"" b
+                WHERE a.""ChannelId"" = b.""ChannelId"" AND a.""Id"" > b.""Id"";");
+
+            migrationBuilder.Sql(@"
+                DELETE FROM ""ChannelFeeStates"" a
+                USING ""ChannelFeeStates"" b
+                WHERE a.""ChannelId"" = b.""ChannelId"" AND a.""Id"" > b.""Id"";");
+
+            migrationBuilder.DropColumn(
+                name: "ManagedNodePubKey",
+                table: "ChannelFeeStates");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelRoutingStates_ChannelId",
+                table: "ChannelRoutingStates",
+                column: "ChannelId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelFeeStates_ChannelId",
+                table: "ChannelFeeStates",
+                column: "ChannelId",
+                unique: true);
+        }
+    }
+}

--- a/test/NodeGuard.Tests/Data/Repositories/ChannelFeeStateRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/ChannelFeeStateRepositoryTests.cs
@@ -45,12 +45,28 @@ public class ChannelFeeStateRepositoryTests
         var (factory, _) = SetupDb();
         var sut = new ChannelFeeStateRepository(factory.Object);
 
-        await sut.UpsertByChannelId(new ChannelFeeState { ChannelId = 7, LastAppliedOutboundPpm = 1234 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 1234 });
 
         var deleted = await sut.DeleteByChannelId(7);
 
         deleted.Should().BeTrue();
-        (await sut.GetByChannelId(7)).Should().BeNull();
+        (await sut.GetByChannelIdAndNode(7, "02a")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteByChannelId_RemovesEverySideOfTheChannel()
+    {
+        var (factory, _) = SetupDb();
+        var sut = new ChannelFeeStateRepository(factory.Object);
+
+        // IsDynamicFeeEnabled is channel-level, so opting out drops both managed sides' state.
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 10 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02b", LastAppliedOutboundPpm = 20 });
+
+        (await sut.DeleteByChannelId(7)).Should().BeTrue();
+
+        (await sut.GetByChannelIdAndNode(7, "02a")).Should().BeNull();
+        (await sut.GetByChannelIdAndNode(7, "02b")).Should().BeNull();
     }
 
     [Fact]
@@ -63,32 +79,66 @@ public class ChannelFeeStateRepositoryTests
     }
 
     [Fact]
-    public async Task DeleteByManagedNodePubKey_RemovesOnlyThatNodesFeeStates_ResolvedViaRoutingState()
+    public async Task UpsertByChannelAndNode_KeepsOneRowPerManagedSideOfTheSameChannel()
     {
         var (factory, options) = SetupDb();
         var sut = new ChannelFeeStateRepository(factory.Object);
 
-        // Fee states for three channels.
-        await sut.UpsertByChannelId(new ChannelFeeState { ChannelId = 1, LastAppliedOutboundPpm = 10 });
-        await sut.UpsertByChannelId(new ChannelFeeState { ChannelId = 2, LastAppliedOutboundPpm = 20 });
-        await sut.UpsertByChannelId(new ChannelFeeState { ChannelId = 3, LastAppliedOutboundPpm = 30 });
+        // Each side of a channel sets its own outbound policy, so each keeps its own fee state.
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 100 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02b", LastAppliedOutboundPpm = 900 });
 
-        // Ownership lives on ChannelRoutingState: channels 1 & 2 belong to node A, channel 3 to node B.
-        await using (var seed = new ApplicationDbContext(options))
-        {
-            seed.ChannelRoutingStates.AddRange(
-                new ChannelRoutingState { ChannelId = 1, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow },
-                new ChannelRoutingState { ChannelId = 2, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow },
-                new ChannelRoutingState { ChannelId = 3, ManagedNodePubKey = "02b", LastEvaluatedAt = DateTimeOffset.UtcNow });
-            await seed.SaveChangesAsync();
-        }
+        await using var verify = new ApplicationDbContext(options);
+        (await verify.ChannelFeeStates.CountAsync(x => x.ChannelId == 7)).Should().Be(2);
+
+        // Updating one side leaves the other untouched.
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 7, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 150 });
+
+        (await sut.GetByChannelIdAndNode(7, "02a"))!.LastAppliedOutboundPpm.Should().Be(150);
+        (await sut.GetByChannelIdAndNode(7, "02b"))!.LastAppliedOutboundPpm.Should().Be(900);
+    }
+
+    [Fact]
+    public async Task GetByManagedNodePubKey_ReturnsOnlyThatNodesRows()
+    {
+        var (factory, _) = SetupDb();
+        var sut = new ChannelFeeStateRepository(factory.Object);
+
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 1, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 10 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 2, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 20 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 2, ManagedNodePubKey = "02b", LastAppliedOutboundPpm = 30 });
+
+        var forA = await sut.GetByManagedNodePubKey("02a");
+
+        forA.Should().HaveCount(2);
+        forA.Select(x => x.ChannelId).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task DeleteByManagedNodePubKey_RemovesOnlyThatNodesFeeStates()
+    {
+        var (factory, _) = SetupDb();
+        var sut = new ChannelFeeStateRepository(factory.Object);
+
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 1, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 10 });
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 2, ManagedNodePubKey = "02a", LastAppliedOutboundPpm = 20 });
+        // Same channel, other managed side — must survive.
+        await sut.UpsertByChannelAndNode(new ChannelFeeState { ChannelId = 2, ManagedNodePubKey = "02b", LastAppliedOutboundPpm = 30 });
 
         var deleted = await sut.DeleteByManagedNodePubKey("02a");
 
         deleted.Should().BeTrue();
-        (await sut.GetByChannelId(1)).Should().BeNull();
-        (await sut.GetByChannelId(2)).Should().BeNull();
-        // Node B's channel is untouched.
-        (await sut.GetByChannelId(3)).Should().NotBeNull();
+        (await sut.GetByChannelIdAndNode(1, "02a")).Should().BeNull();
+        (await sut.GetByChannelIdAndNode(2, "02a")).Should().BeNull();
+        (await sut.GetByChannelIdAndNode(2, "02b")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteByManagedNodePubKey_ReturnsFalse_WhenAbsent()
+    {
+        var (factory, _) = SetupDb();
+        var sut = new ChannelFeeStateRepository(factory.Object);
+
+        (await sut.DeleteByManagedNodePubKey("02a")).Should().BeFalse();
     }
 }

--- a/test/NodeGuard.Tests/Data/Repositories/ChannelRoutingStateRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/ChannelRoutingStateRepositoryTests.cs
@@ -40,13 +40,13 @@ public class ChannelRoutingStateRepositoryTests
     }
 
     [Fact]
-    public async Task UpsertByChannelId_InsertsThenUpdatesInPlace_PreservingSmoothedFields()
+    public async Task UpsertByChannelAndNode_InsertsThenUpdatesInPlace_PreservingSmoothedFields()
     {
         var (factory, options) = SetupDb();
         var sut = new ChannelRoutingStateRepository(factory.Object);
 
         // First call inserts.
-        await sut.UpsertByChannelId(new ChannelRoutingState
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState
         {
             ChannelId = 42,
             ManagedNodePubKey = "02node",
@@ -56,13 +56,13 @@ public class ChannelRoutingStateRepositoryTests
             LastEvaluatedAt = DateTimeOffset.UtcNow,
         });
 
-        var afterInsert = await sut.GetByChannelId(42);
+        var afterInsert = await sut.GetByChannelIdAndNode(42, "02node");
         afterInsert.Should().NotBeNull();
         afterInsert!.EmaLocalRatio.Should().Be(0.70);
         afterInsert.PeerFlowCategory.Should().Be(PeerFlowCategory.Sink);
 
-        // Second call with the same ChannelId updates in place.
-        await sut.UpsertByChannelId(new ChannelRoutingState
+        // Second call with the same (ChannelId, node) updates in place.
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState
         {
             ChannelId = 42,
             ManagedNodePubKey = "02node",
@@ -72,7 +72,7 @@ public class ChannelRoutingStateRepositoryTests
             LastEvaluatedAt = DateTimeOffset.UtcNow,
         });
 
-        var afterUpdate = await sut.GetByChannelId(42);
+        var afterUpdate = await sut.GetByChannelIdAndNode(42, "02node");
         afterUpdate!.EmaLocalRatio.Should().Be(0.75);
         afterUpdate.TargetLocalRatio.Should().Be(0.62);
         afterUpdate.PeerFlowCategory.Should().Be(PeerFlowCategory.Bidirectional);
@@ -88,12 +88,58 @@ public class ChannelRoutingStateRepositoryTests
         var (factory, _) = SetupDb();
         var sut = new ChannelRoutingStateRepository(factory.Object);
 
-        await sut.UpsertByChannelId(new ChannelRoutingState { ChannelId = 1, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow });
-        await sut.UpsertByChannelId(new ChannelRoutingState { ChannelId = 2, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow });
-        await sut.UpsertByChannelId(new ChannelRoutingState { ChannelId = 3, ManagedNodePubKey = "02b", LastEvaluatedAt = DateTimeOffset.UtcNow });
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState { ChannelId = 1, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow });
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState { ChannelId = 2, ManagedNodePubKey = "02a", LastEvaluatedAt = DateTimeOffset.UtcNow });
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState { ChannelId = 3, ManagedNodePubKey = "02b", LastEvaluatedAt = DateTimeOffset.UtcNow });
 
         var forA = await sut.GetByManagedNodePubKey("02a");
         forA.Should().HaveCount(2);
         forA.Select(x => x.ChannelId).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task UpsertByChannelAndNode_KeepsOneRowPerManagedSideOfTheSameChannel()
+    {
+        var (factory, options) = SetupDb();
+        var sut = new ChannelRoutingStateRepository(factory.Object);
+
+        // Both ends of channel 7 are managed by NodeGuard; each keeps its own view of it.
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState
+        {
+            ChannelId = 7, ManagedNodePubKey = "02a", EmaLocalRatio = 0.95, LastEvaluatedAt = DateTimeOffset.UtcNow,
+        });
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState
+        {
+            ChannelId = 7, ManagedNodePubKey = "02b", EmaLocalRatio = 0.05, LastEvaluatedAt = DateTimeOffset.UtcNow,
+        });
+
+        await using var verify = new ApplicationDbContext(options);
+        (await verify.ChannelRoutingStates.CountAsync(x => x.ChannelId == 7)).Should().Be(2);
+
+        (await sut.GetByChannelIdAndNode(7, "02a"))!.EmaLocalRatio.Should().Be(0.95);
+        (await sut.GetByChannelIdAndNode(7, "02b"))!.EmaLocalRatio.Should().Be(0.05);
+
+        // Updating one side leaves the other untouched.
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState
+        {
+            ChannelId = 7, ManagedNodePubKey = "02a", EmaLocalRatio = 0.80, LastEvaluatedAt = DateTimeOffset.UtcNow,
+        });
+
+        (await sut.GetByChannelIdAndNode(7, "02a"))!.EmaLocalRatio.Should().Be(0.80);
+        (await sut.GetByChannelIdAndNode(7, "02b"))!.EmaLocalRatio.Should().Be(0.05);
+    }
+
+    [Fact]
+    public async Task GetByManagedNodePubKey_ReturnsThisNodesSideOfASharedChannel()
+    {
+        var (factory, _) = SetupDb();
+        var sut = new ChannelRoutingStateRepository(factory.Object);
+
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState { ChannelId = 7, ManagedNodePubKey = "02a", EmaLocalRatio = 0.95, LastEvaluatedAt = DateTimeOffset.UtcNow });
+        await sut.UpsertByChannelAndNode(new ChannelRoutingState { ChannelId = 7, ManagedNodePubKey = "02b", EmaLocalRatio = 0.05, LastEvaluatedAt = DateTimeOffset.UtcNow });
+
+        var forB = await sut.GetByManagedNodePubKey("02b");
+        forB.Should().ContainSingle();
+        forB[0].EmaLocalRatio.Should().Be(0.05);
     }
 }

--- a/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
@@ -213,7 +213,7 @@ public class ChannelFeeOptimizerJobTests
             // and the computed values are recorded so the operator can see what WOULD have been applied.
             _lightningService.Verify(x => x.GetChannelFeePolicy(ChanId, It.IsAny<Node>()), Times.Once);
             VerifyNoFeeWrite();
-            _feeStateRepository.Verify(x => x.UpsertByChannelId(
+            _feeStateRepository.Verify(x => x.UpsertByChannelAndNode(
                 It.Is<ChannelFeeState>(s => s.LastAppliedOutboundPpm == 2550u && s.LastFeeUpdateAt != null)), Times.Once);
         }
         finally
@@ -260,7 +260,7 @@ public class ChannelFeeOptimizerJobTests
 
             _lightningService.Verify(x => x.GetChannelFeePolicy(It.IsAny<ulong>(), It.IsAny<Node>()), Times.Never);
             VerifyNoFeeWrite();
-            _feeStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelFeeState>()), Times.Never);
+            _feeStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelFeeState>()), Times.Never);
         }
         finally
         {
@@ -320,7 +320,7 @@ public class ChannelFeeOptimizerJobTests
             // NoOp channels never cost an LND round-trip, but the observed ratio/target are still persisted.
             _lightningService.Verify(x => x.GetChannelFeePolicy(It.IsAny<ulong>(), It.IsAny<Node>()), Times.Never);
             VerifyNoFeeWrite();
-            _feeStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelFeeState>()), Times.Once);
+            _feeStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelFeeState>()), Times.Once);
         }
         finally
         {
@@ -350,7 +350,7 @@ public class ChannelFeeOptimizerJobTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<uint>(),
                 It.IsAny<uint>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<bool>()), Times.Once);
             // On write failure the fee state is NOT persisted (LastApplied stays null → next cycle re-seeds).
-            _feeStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelFeeState>()), Times.Never);
+            _feeStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelFeeState>()), Times.Never);
         }
         finally
         {

--- a/test/NodeGuard.Tests/Jobs/TargetRatioReevaluationJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/TargetRatioReevaluationJobTests.cs
@@ -35,6 +35,7 @@ namespace NodeGuard.Jobs;
 /// is used so these prove the JOB feeds it correctly: age gate, ownership/eligibility filter, the
 /// push/pull → net-flow sign convention, first-insert EMA seeding, failure handling, and the kill switch.
 /// </summary>
+[Collection("RoutingEngine")]
 public class TargetRatioReevaluationJobTests
 {
     private const string NodePubKey = "alicePubKey";
@@ -107,7 +108,7 @@ public class TargetRatioReevaluationJobTests
             .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
             .ReturnsAsync(listResp);
 
-        _routingStateRepository.Setup(x => x.GetByChannelId(ChannelDbId)).ReturnsAsync((ChannelRoutingState?)null);
+        _routingStateRepository.Setup(x => x.GetByChannelIdAndNode(ChannelDbId, NodePubKey)).ReturnsAsync((ChannelRoutingState?)null);
         _forwardingHtlcEventRepository
             .Setup(x => x.GetOutgoingAmountMsat(NodePubKey, ChanId, It.IsAny<DateTimeOffset>()))
             .ReturnsAsync(push);
@@ -120,10 +121,10 @@ public class TargetRatioReevaluationJobTests
 
     private ChannelRoutingState? _captured;
 
-    /// <summary>Captures the state handed to UpsertByChannelId so a test can assert the persisted result.</summary>
+    /// <summary>Captures the state handed to UpsertByChannelAndNode so a test can assert the persisted result.</summary>
     private void CaptureUpsert() =>
         _routingStateRepository
-            .Setup(x => x.UpsertByChannelId(It.IsAny<ChannelRoutingState>()))
+            .Setup(x => x.UpsertByChannelAndNode(It.IsAny<ChannelRoutingState>()))
             .Callback<ChannelRoutingState>(s => _captured = s)
             .Returns(Task.CompletedTask);
 
@@ -278,7 +279,7 @@ public class TargetRatioReevaluationJobTests
     }
 
     [Fact]
-    public async Task Execute_PeerInitiatedChannelToManagedPeer_IsSkipped()
+    public async Task Execute_PeerInitiatedChannelToManagedPeer_StillGetsItsOwnState()
     {
         var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
         var prevMinAge = Constants.ROUTING_ENGINE_CATEGORIZATION_MIN_AGE_BLOCKS;
@@ -297,7 +298,9 @@ public class TargetRatioReevaluationJobTests
             var node = BuildNode();
             var peer = new Node { Id = 21, PubKey = PeerPubKey, Name = "bob", DynamicFeeManagementEnabled = true };
 
-            // Both nodes are managed; the channel is peer-initiated ⇒ the dedup rule assigns it to the peer.
+            // Both nodes are managed and the channel is peer-initiated. There is no dedup any more:
+            // this side keeps its own routing state, because its local balance and fee policy are
+            // its own. Without it the node is blind to this channel when it runs dry.
             _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node, peer });
             _lightningService.Setup(x => x.GetBlockHeight(It.IsAny<Node>())).ReturnsAsync((uint?)5000);
 
@@ -311,11 +314,17 @@ public class TargetRatioReevaluationJobTests
             _lightningClientService.Setup(x => x.ListChannels(It.Is<Node>(n => n.PubKey == NodePubKey), It.IsAny<Lnrpc.Lightning.LightningClient>())).ReturnsAsync(aliceList);
             _lightningClientService.Setup(x => x.ListChannels(It.Is<Node>(n => n.PubKey == PeerPubKey), It.IsAny<Lnrpc.Lightning.LightningClient>())).ReturnsAsync(new Lnrpc.ListChannelsResponse());
 
+            _routingStateRepository.Setup(x => x.GetByChannelIdAndNode(ChannelDbId, NodePubKey)).ReturnsAsync((ChannelRoutingState?)null);
+            CaptureUpsert();
+
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
 
-            _routingStateRepository.Verify(x => x.GetByChannelId(It.IsAny<int>()), Times.Never);
-            _routingStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelRoutingState>()), Times.Never);
-            _forwardingHtlcEventRepository.Verify(x => x.GetOutgoingAmountMsat(It.IsAny<string>(), It.IsAny<ulong>(), It.IsAny<DateTimeOffset>()), Times.Never);
+            _routingStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelRoutingState>()), Times.Once);
+            _captured.Should().NotBeNull();
+            _captured!.ChannelId.Should().Be(ChannelDbId);
+            // Stamped with this node, not the initiator peer.
+            _captured.ManagedNodePubKey.Should().Be(NodePubKey);
+            _captured.PeerInitiated.Should().BeTrue();
         }
         finally
         {
@@ -350,8 +359,8 @@ public class TargetRatioReevaluationJobTests
 
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
 
-            _routingStateRepository.Verify(x => x.GetByChannelId(It.IsAny<int>()), Times.Never);
-            _routingStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelRoutingState>()), Times.Never);
+            _routingStateRepository.Verify(x => x.GetByChannelIdAndNode(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+            _routingStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelRoutingState>()), Times.Never);
         }
         finally
         {
@@ -389,7 +398,7 @@ public class TargetRatioReevaluationJobTests
 
             await act.Should().NotThrowAsync();
             _lightningClientService.Verify(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()), Times.Never);
-            _routingStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelRoutingState>()), Times.Never);
+            _routingStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelRoutingState>()), Times.Never);
         }
         finally
         {
@@ -430,7 +439,7 @@ public class TargetRatioReevaluationJobTests
 
             await act.Should().NotThrowAsync();
             _forwardingHtlcEventRepository.Verify(x => x.GetOutgoingAmountMsat(It.IsAny<string>(), It.IsAny<ulong>(), It.IsAny<DateTimeOffset>()), Times.Never);
-            _routingStateRepository.Verify(x => x.UpsertByChannelId(It.IsAny<ChannelRoutingState>()), Times.Never);
+            _routingStateRepository.Verify(x => x.UpsertByChannelAndNode(It.IsAny<ChannelRoutingState>()), Times.Never);
         }
         finally
         {


### PR DESCRIPTION
This pull request updates the data model and repository logic for channel routing and fee state to support multiple managed nodes per channel. Instead of a single row per channel, the system now maintains separate state rows for each (channel, managed node) pair, reflecting the fact that each node has its own view and policy for a shared channel. The changes include schema updates, model and repository adjustments, and updates to background jobs to support the new structure.