### PR TITLE
Create Auto Rebalance Algorithm

### DIFF
--- a/src/Data/Models/Rebalance.cs
+++ b/src/Data/Models/Rebalance.cs
@@ -90,6 +90,12 @@ public class Rebalance : Entity
     [NotMapped]
     public Money FeePaid => new Money(FeePaidSats ?? 0, MoneyUnit.Satoshi);
 
+    /// <summary>
+    /// Worst-case fee a not-yet-settled rebalance can still consume: the whole amount at its fee cap.
+    /// </summary>
+    public static long WorstCaseFeeSats(long amountSats, double maxFeePct)
+        => (long)(amountSats * maxFeePct / 100.0);
+
     public int? SourceChannelId { get; set; }
     public Channel? SourceChannel { get; set; }
 

--- a/src/Data/Repositories/ChannelRepository.cs
+++ b/src/Data/Repositories/ChannelRepository.cs
@@ -105,15 +105,6 @@ namespace NodeGuard.Data.Repositories
                 .ToListAsync();
         }
 
-        public async Task<List<Channel>> GetChannelsByOpenAndDynamicFeeEnabled()
-        {
-            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
-
-            return await applicationDbContext.Channels
-                .Where(c => c.Status == Channel.ChannelStatus.Open && c.ChanId != 0 && c.IsDynamicFeeEnabled)
-                .ToListAsync();
-        }
-
         public async Task<(bool, string?)> AddAsync(Channel type)
         {
             await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();

--- a/src/Data/Repositories/Interfaces/IChannelRepository.cs
+++ b/src/Data/Repositories/Interfaces/IChannelRepository.cs
@@ -32,8 +32,6 @@ public interface IChannelRepository
 
     Task<List<Channel>> GetOpenChannels();
 
-    Task <List<Channel>> GetChannelsByOpenAndDynamicFeeEnabled();
-
     Task<(bool, string?)> AddAsync(Channel type);
 
     Task<(bool, string?)> AddRangeAsync(List<Channel> type);

--- a/src/Data/Repositories/RebalanceRepository.cs
+++ b/src/Data/Repositories/RebalanceRepository.cs
@@ -181,9 +181,8 @@ public class RebalanceRepository : IRebalanceRepository
         foreach (var r in rows)
         {
             var feePaid = r.FeePaidSats ?? 0;
-            // Conservative worst-case reservation for a still-in-flight rebalance: RequestedAmountSats ×
-            // (MaxFeePct/100).
-            var reserved = (long)(r.RequestedAmountSats * r.MaxFeePct / 100.0);
+            // Conservative worst-case reservation for a still-in-flight rebalance.
+            var reserved = Rebalance.WorstCaseFeeSats(r.RequestedAmountSats, r.MaxFeePct);
             total += r.Status == RebalanceStatus.Succeeded
                 ? feePaid
                 : reserved;

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -284,6 +284,12 @@ public class Constants
     /// </summary>
     public static int ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES = 5;
 
+    /// <summary>
+    /// Cadence of AutoRebalanceJob in prod, in minutes. Independent of
+    /// ROUTING_ENGINE_JOB_INTERVAL_MINUTES. In dev it is 1 minute.
+    /// </summary>
+    public static int ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES = 10;
+
     // Both fees use integral control: each cycle the applied value is nudged by gain·deviation·baseline
     // off its previous value, so a persistent deviation keeps driving the fee until the channel balances.
     public static double ROUTING_ENGINE_FEE_OUTBOUND_INTEGRAL_GAIN = 0.8;
@@ -356,7 +362,7 @@ public class Constants
 
     /// Fallback max concurrent (Pending/InFlight) rebalances when a node leaves
     /// MaxRebalancesInFlight unset.
-    public static int ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT = 1;
+    public static int ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT = 5;
 
     /// Fallback rebalance-budget refresh window (hours) when a node leaves
     /// RebalanceBudgetRefreshInterval unset.
@@ -635,6 +641,8 @@ public class Constants
         if (reJobInterval != null) ROUTING_ENGINE_JOB_INTERVAL_MINUTES = int.Parse(reJobInterval);
         var reActuatorOffset = Environment.GetEnvironmentVariable("ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES");
         if (reActuatorOffset != null) ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES = int.Parse(reActuatorOffset);
+        var reRebalanceInterval = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES");
+        if (reRebalanceInterval != null) ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES = int.Parse(reRebalanceInterval);
 
         // Routing Engine
         var feeOutboundIntegralGain = Environment.GetEnvironmentVariable("ROUTING_ENGINE_FEE_OUTBOUND_INTEGRAL_GAIN");

--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -273,10 +273,16 @@ public class Constants
     public static int ROUTING_ENGINE_CATEGORY_FLIP_HYSTERESIS_CYCLES = 3;
 
     /// <summary>
-    /// Cadence of TargetRatioReevaluationJob and ChannelFeeOptimizerJob in prod, in minutes. Default 30. In dev
+    /// Cadence of TargetRatioReevaluationJob and RoutingEngineActuatorJob in prod, in minutes. Default 30. In dev
     /// (IS_DEV_ENVIRONMENT) the job runs every 5 minutes regardless.
     /// </summary>
     public static int ROUTING_ENGINE_JOB_INTERVAL_MINUTES = 30;
+
+    /// <summary>
+    /// How long after TargetRatioReevaluationJob the RoutingEngineActuatorJob first fires,
+    /// in minutes (prod only).
+    /// </summary>
+    public static int ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES = 5;
 
     // Both fees use integral control: each cycle the applied value is nudged by gain·deviation·baseline
     // off its previous value, so a persistent deviation keeps driving the fee until the channel balances.
@@ -288,7 +294,7 @@ public class Constants
     public static double ROUTING_ENGINE_FEE_DEADBAND = 0.03;
 
     // The rebalancer's imbalance deadband is a separate, more aggressive threshold for triggering rebalances.
-    public static double ROUTING_ENGINE_REBALANCE_TRIGGER = 0.15;
+    public static double ROUTING_ENGINE_REBALANCE_DEADBAND = 0.15;
 
     // Max outbound ppm change applied in a single cycle (rate limiter / anti-jump).
     public static uint ROUTING_ENGINE_FEE_MAX_STEP_PPM = 50;
@@ -334,6 +340,27 @@ public class Constants
     /// untouched ones.
     /// </summary>
     public static double MAX_HTLC_CAPACITY_RATIO = 0.99;
+
+    // Routing Engine: automated rebalancer
+
+    /// Upper clamp on a single automated rebalance amount (sats)
+    public static long ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS = 10_000_000;
+
+    /// Max rebalances the routing-engine actuator initiates per node per run
+    public static int ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN = 5;
+
+    /// Fallback profitability margin when a node leaves MaxRebalanceCostToEarnRatio unset. The
+    /// gate caps rebalance cost at ratio × (capacity-weighted-avg outbound ppm of the refilled
+    /// peer). 0.5 = spend at most half the destination's earn rate.
+    public static double ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO = 0.5;
+
+    /// Fallback max concurrent (Pending/InFlight) rebalances when a node leaves
+    /// MaxRebalancesInFlight unset.
+    public static int ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT = 1;
+
+    /// Fallback rebalance-budget refresh window (hours) when a node leaves
+    /// RebalanceBudgetRefreshInterval unset.
+    public static int ROUTING_ENGINE_REBALANCE_DEFAULT_BUDGET_REFRESH_HOURS = 24;
 
     public const string IsFrozenTag = "frozen";
     public const string IsManuallyFrozenTag = "manually_frozen";
@@ -606,6 +633,8 @@ public class Constants
 
         var reJobInterval = Environment.GetEnvironmentVariable("ROUTING_ENGINE_JOB_INTERVAL_MINUTES");
         if (reJobInterval != null) ROUTING_ENGINE_JOB_INTERVAL_MINUTES = int.Parse(reJobInterval);
+        var reActuatorOffset = Environment.GetEnvironmentVariable("ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES");
+        if (reActuatorOffset != null) ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES = int.Parse(reActuatorOffset);
 
         // Routing Engine
         var feeOutboundIntegralGain = Environment.GetEnvironmentVariable("ROUTING_ENGINE_FEE_OUTBOUND_INTEGRAL_GAIN");
@@ -618,7 +647,7 @@ public class Constants
         if (feeDeadband != null) ROUTING_ENGINE_FEE_DEADBAND = double.Parse(feeDeadband, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
 
         var rebalanceDeadband = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_DEADBAND");
-        if (rebalanceDeadband != null) ROUTING_ENGINE_REBALANCE_TRIGGER = double.Parse(rebalanceDeadband, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+        if (rebalanceDeadband != null) ROUTING_ENGINE_REBALANCE_DEADBAND = double.Parse(rebalanceDeadband, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
 
         var feeMaxStep = Environment.GetEnvironmentVariable("ROUTING_ENGINE_FEE_MAX_STEP_PPM");
         if (feeMaxStep != null) ROUTING_ENGINE_FEE_MAX_STEP_PPM = uint.Parse(feeMaxStep);
@@ -665,6 +694,17 @@ public class Constants
             if (parsedRatio > 0 && parsedRatio <= 1) MAX_HTLC_CAPACITY_RATIO = parsedRatio;
             else throw new ArgumentOutOfRangeException(nameof(MAX_HTLC_CAPACITY_RATIO), parsedRatio, "MAX_HTLC_CAPACITY_RATIO must be in (0, 1]");
         }
+        
+        var reRebalanceMaxAmount = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS");
+        if (reRebalanceMaxAmount != null) ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS = long.Parse(reRebalanceMaxAmount);
+        var reRebalanceMaxInit = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN");
+        if (reRebalanceMaxInit != null) ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN = int.Parse(reRebalanceMaxInit);
+        var reRebalanceDefaultRatio = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO");
+        if (reRebalanceDefaultRatio != null) ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO = double.Parse(reRebalanceDefaultRatio, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+        var reRebalanceDefaultMaxInFlight = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT");
+        if (reRebalanceDefaultMaxInFlight != null) ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT = int.Parse(reRebalanceDefaultMaxInFlight);
+        var reRebalanceDefaultRefreshHours = Environment.GetEnvironmentVariable("ROUTING_ENGINE_REBALANCE_DEFAULT_BUDGET_REFRESH_HOURS");
+        if (reRebalanceDefaultRefreshHours != null) ROUTING_ENGINE_REBALANCE_DEFAULT_BUDGET_REFRESH_HOURS = int.Parse(reRebalanceDefaultRefreshHours);
 
         // DB Initialization
         ALICE_PUBKEY = Environment.GetEnvironmentVariable("ALICE_PUBKEY") ?? ALICE_PUBKEY;

--- a/src/Jobs/AutoRebalanceJob.cs
+++ b/src/Jobs/AutoRebalanceJob.cs
@@ -1,0 +1,330 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
+using NodeGuard.Services;
+using Quartz;
+using Channel = NodeGuard.Data.Models.Channel;
+
+namespace NodeGuard.Jobs;
+
+/// <summary>
+/// The routing engine's rebalance actuator. For every node with <see cref="Node.AutoRebalanceEnabled"/>
+/// it takes a snapshot, hands it to the pure <see cref="RebalanceInitiatorService"/> to plan
+/// too-local-source → too-remote-destination circular rebalances, and dispatches them via
+/// <see cref="IRebalanceService"/> — bounded by the node's fee budget, its in-flight cap, and the
+/// per-run initiation cap.
+/// <para>
+/// Runs on its own cadence (ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES), independent of
+/// <see cref="ChannelFeeOptimizerJob"/>.
+/// </summary>
+[DisallowConcurrentExecution]
+public class AutoRebalanceJob : IJob
+{
+    private readonly ILogger<AutoRebalanceJob> _logger;
+    private readonly INodeRepository _nodeRepository;
+    private readonly IChannelRepository _channelRepository;
+    private readonly IRebalanceRepository _rebalanceRepository;
+    private readonly IRebalanceService _rebalanceService;
+    private readonly IRoutingEngineSnapshotService _snapshotService;
+    private readonly ILightningService _lightningService;
+
+    public AutoRebalanceJob(
+        ILogger<AutoRebalanceJob> logger,
+        INodeRepository nodeRepository,
+        IChannelRepository channelRepository,
+        IRebalanceRepository rebalanceRepository,
+        IRebalanceService rebalanceService,
+        IRoutingEngineSnapshotService snapshotService,
+        ILightningService lightningService)
+    {
+        _logger = logger;
+        _nodeRepository = nodeRepository;
+        _channelRepository = channelRepository;
+        _rebalanceRepository = rebalanceRepository;
+        _rebalanceService = rebalanceService;
+        _snapshotService = snapshotService;
+        _lightningService = lightningService;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        // Global kill switch — checked before any work
+        if (!Constants.ROUTING_ENGINE_ENABLED)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Starting {JobName}...", nameof(AutoRebalanceJob));
+
+        try
+        {
+            var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(withDisabled: false);
+
+            var relevantNodes = managedNodes.Where(n => n.AutoRebalanceEnabled).ToList();
+            if (relevantNodes.Count == 0)
+            {
+                _logger.LogInformation("No managed nodes with the rebalancer enabled; skipping {JobName}",
+                    nameof(AutoRebalanceJob));
+                return;
+            }
+
+            // Shared per-run context, only needed when at least one node is under management
+            var openChannelsByChanId = (await _channelRepository.GetOpenChannels())
+                .ToDictionary(c => c.ChanId);
+            var inFlightSourceChannelIds = await _rebalanceRepository.GetPendingInFlightSourceChannelIds();
+
+            foreach (var node in relevantNodes)
+            {
+                try
+                {
+                    await RebalanceNode(node, openChannelsByChanId, inFlightSourceChannelIds);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error rebalancing node {NodeName} ({NodePubKey})",
+                        node.Name, node.PubKey);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {JobName}", nameof(AutoRebalanceJob));
+        }
+
+        _logger.LogInformation("{JobName} ended", nameof(AutoRebalanceJob));
+    }
+
+    private async Task RebalanceNode(
+        Node node,
+        IReadOnlyDictionary<ulong, Channel> openChannelsByChanId,
+        IReadOnlySet<int> inFlightSourceChannelIds)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // A budget must be configured before we spend anything. Checked before the LND round-trip
+        var budgetSats = node.RebalanceBudgetSats ?? 0;
+        if (budgetSats <= 0)
+        {
+            _logger.LogInformation("Node {NodeName}: no rebalance budget configured; skipping", node.Name);
+            return;
+        }
+
+        // Budget-period refresh
+        var refreshInterval = node.RebalanceBudgetRefreshInterval
+                              ?? TimeSpan.FromHours(Constants.ROUTING_ENGINE_REBALANCE_DEFAULT_BUDGET_REFRESH_HOURS);
+        if (!node.RebalanceBudgetStartDatetime.HasValue ||
+            now - node.RebalanceBudgetStartDatetime.Value >= refreshInterval)
+        {
+            _logger.LogInformation("Refreshing rebalance budget for node {NodeName}", node.Name);
+            node.RebalanceBudgetStartDatetime = now;
+            _nodeRepository.Update(node);
+        }
+
+        var periodStart = node.RebalanceBudgetStartDatetime ?? now;
+
+        // Remaining fee budget for this period. GetConsumedFeesSince already counts in-flight
+        // reservations, so a rebalance started earlier this period is charged immediately
+        var consumed = await _rebalanceRepository.GetConsumedFeesSince(node.Id, periodStart);
+        var remainingBudget = budgetSats - consumed;
+        if (remainingBudget <= 0)
+        {
+            _logger.LogInformation("Node {NodeName}: rebalance fee budget exhausted ({Consumed}/{Budget} sats)",
+                node.Name, consumed, budgetSats);
+            return;
+        }
+
+        // In-flight cap
+        var inFlight = await _rebalanceRepository.GetInFlightByNode(node.Id);
+        var maxInFlight = node.MaxRebalancesInFlight ?? Constants.ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT;
+        if (inFlight >= maxInFlight)
+        {
+            _logger.LogInformation("Node {NodeName}: max rebalances in flight reached ({InFlight}/{Max})",
+                node.Name, inFlight, maxInFlight);
+            return;
+        }
+
+        var owned = await _snapshotService.GetOwnedChannelsAsync(node, openChannelsByChanId, withFeeState: false);
+        if (owned == null)
+        {
+            _logger.LogWarning("Skipping node {NodeName}: ListChannels unavailable", node.Name);
+            return;
+        }
+
+        var signals = owned.Select(oc => new ChannelSignal(
+            oc.DbChannel.Id,
+            oc.Lnd.ChanId,
+            oc.Lnd.RemotePubkey,
+            oc.Lnd.Capacity,
+            oc.Lnd.LocalBalance,
+            oc.Lnd.RemoteBalance,
+            oc.RoutingState.EmaLocalRatio,
+            oc.RoutingState.TargetLocalRatio,
+            oc.Lnd.Active,
+            // A channel is a fresh source only if opted in and not already being drained
+            oc.DbChannel.IsAutoRebalanceEnabled && !inFlightSourceChannelIds.Contains(oc.DbChannel.Id)))
+            .ToList();
+
+        var tunables = BuildRebalanceTunables(node);
+        var classification = RebalanceInitiatorService.Classify(signals, tunables);
+
+        if (classification.Sources.Count == 0 && classification.Destinations.Count == 0)
+        {
+            _logger.LogInformation("Node {NodeName}: nothing to rebalance (no channel tripped the trigger)", node.Name);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Node {NodeName}: detected {Sources} source(s) and {Destinations} destination(s); " +
+            "fallback pool {FallbackSources} source(s), {FallbackDestinations} destination(s)",
+            node.Name, classification.Sources.Count, classification.Destinations.Count,
+            classification.FallbackSources.Count, classification.FallbackDestinations.Count);
+
+        var earnRates = await FetchEarnRatesAsync(node, owned);
+        if (earnRates == null)
+        {
+            _logger.LogWarning("Skipping node {NodeName}: FeeReport unavailable, so nothing can be profit-gated",
+                node.Name);
+            return;
+        }
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earnRates, tunables);
+        if (plans.Count == 0)
+        {
+            _logger.LogInformation("Node {NodeName}: no profitable rebalance plans this cycle", node.Name);
+            return;
+        }
+
+        var initiations = 0;
+        var planIndex = 0;
+        string? capStopReason = null;
+
+        for (; planIndex < plans.Count; planIndex++)
+        {
+            var plan = plans[planIndex];
+
+            if (initiations >= tunables.MaxInitiations)
+            {
+                capStopReason = $"per-run initiation cap reached ({initiations}/{tunables.MaxInitiations})";
+                break;
+            }
+
+            if (inFlight + initiations >= maxInFlight)
+            {
+                capStopReason =
+                    $"in-flight cap reached ({inFlight + initiations}/{maxInFlight}, {inFlight} already in flight " +
+                    "before this run; raise the node's MaxRebalancesInFlight to dispatch more per cycle)";
+                break;
+            }
+
+            var reservedFee = Rebalance.WorstCaseFeeSats(plan.AmountSats, plan.MaxFeePct);
+            if (reservedFee > remainingBudget)
+            {
+                _logger.LogInformation(
+                    "Node {NodeName}: skipping plan (reserved {Reserved} sats > remaining budget {Remaining} sats): {Reason}",
+                    node.Name, reservedFee, remainingBudget, plan.Reason);
+                continue;
+            }
+
+            if (node.RoutingEngineDryRun)
+            {
+                _logger.LogInformation("Dry-run: node {NodeName} would rebalance — {Reason}", node.Name, plan.Reason);
+                remainingBudget -= reservedFee;
+                initiations++;
+                continue;
+            }
+
+            try
+            {
+                var request = new RebalanceRequest(
+                    NodeId: node.Id,
+                    SourceChannelId: plan.SourceChannelId,
+                    TargetPubkey: plan.DestinationPeerPubKey,
+                    AmountSats: plan.AmountSats,
+                    MaxFeePct: plan.MaxFeePct,
+                    IsManual: false,
+                    // Keep retries within the profitable ceiling
+                    RetryMaxFeePct: plan.MaxFeePct);
+
+                // Fire-and-forget, and deliberately not tracked: RebalanceService logs and audits
+                // the whole lifecycle itself and MonitorRebalancesJob reconciles anything this process abandons
+                _ = _rebalanceService.RebalanceAsync(request, CancellationToken.None);
+
+                remainingBudget -= reservedFee;
+                initiations++;
+                _logger.LogInformation("Node {NodeName}: initiated rebalance — {Reason}", node.Name, plan.Reason);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Node {NodeName}: failed to initiate rebalance ({Reason})", node.Name, plan.Reason);
+            }
+        }
+
+        // A cap stops the loop outright, so every remaining plan is abandoned
+        if (capStopReason != null)
+        {
+            var dropped = plans.Count - planIndex;
+            _logger.LogInformation(
+                "Node {NodeName}: dropped {DroppedCount} of {PlannedCount} planned rebalance(s) — {CapStopReason}",
+                node.Name, dropped, plans.Count, capStopReason);
+
+            for (var i = planIndex; i < plans.Count; i++)
+            {
+                _logger.LogInformation("Node {NodeName}: dropped plan — {Reason}", node.Name, plans[i].Reason);
+            }
+        }
+
+        _logger.LogInformation(
+            "Node {NodeName}: initiated {Count} of {PlannedCount} planned rebalance(s), remaining budget {Remaining}/{Budget} sats",
+            node.Name, initiations, plans.Count, remainingBudget, budgetSats);
+    }
+
+    private static RebalanceInitiatorTunables BuildRebalanceTunables(Node node) => new(
+        RebalanceTrigger: Constants.ROUTING_ENGINE_REBALANCE_DEADBAND,
+        MinAmountSats: Constants.REBALANCE_MIN_AMOUNT_SATS,
+        MaxAmountSats: Constants.ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS,
+        CostToEarnRatio: node.MaxRebalanceCostToEarnRatio ?? Constants.ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO,
+        MaxInitiations: Constants.ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN);
+
+    /// <summary>
+    /// Maps our channel id → live local-outbound ppm for every channel in the snapshot, from a single
+    /// FeeReport.
+    /// </summary>
+    private async Task<Dictionary<int, long>?> FetchEarnRatesAsync(Node node, IReadOnlyList<OwnedChannel> owned)
+    {
+        var ppmByChanId = await _lightningService.GetLocalOutboundFeeRatesPpmAsync(node);
+        if (ppmByChanId == null) return null;
+
+        var earnRates = new Dictionary<int, long>();
+        foreach (var oc in owned)
+        {
+            if (ppmByChanId.TryGetValue(oc.Lnd.ChanId, out var ppm))
+            {
+                earnRates[oc.DbChannel.Id] = ppm;
+            }
+        }
+
+        _logger.LogDebug("Node {NodeName}: priced {Priced} of {Total} channel(s) from FeeReport",
+            node.Name, earnRates.Count, owned.Count);
+
+        return earnRates;
+    }
+}

--- a/src/Jobs/AutoRebalanceJob.cs
+++ b/src/Jobs/AutoRebalanceJob.cs
@@ -46,6 +46,7 @@ public class AutoRebalanceJob : IJob
     private readonly IRebalanceService _rebalanceService;
     private readonly IRoutingEngineSnapshotService _snapshotService;
     private readonly ILightningService _lightningService;
+    private readonly IAuditService _auditService;
 
     public AutoRebalanceJob(
         ILogger<AutoRebalanceJob> logger,
@@ -54,7 +55,8 @@ public class AutoRebalanceJob : IJob
         IRebalanceRepository rebalanceRepository,
         IRebalanceService rebalanceService,
         IRoutingEngineSnapshotService snapshotService,
-        ILightningService lightningService)
+        ILightningService lightningService,
+        IAuditService auditService)
     {
         _logger = logger;
         _nodeRepository = nodeRepository;
@@ -63,6 +65,7 @@ public class AutoRebalanceJob : IJob
         _rebalanceService = rebalanceService;
         _snapshotService = snapshotService;
         _lightningService = lightningService;
+        _auditService = auditService;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -173,7 +176,6 @@ public class AutoRebalanceJob : IJob
             oc.DbChannel.Id,
             oc.Lnd.ChanId,
             oc.Lnd.RemotePubkey,
-            oc.Lnd.Capacity,
             oc.Lnd.LocalBalance,
             oc.Lnd.RemoteBalance,
             oc.RoutingState.EmaLocalRatio,
@@ -183,7 +185,7 @@ public class AutoRebalanceJob : IJob
             oc.DbChannel.IsAutoRebalanceEnabled && !inFlightSourceChannelIds.Contains(oc.DbChannel.Id)))
             .ToList();
 
-        var tunables = BuildRebalanceTunables(node);
+        var tunables = RebalanceInitiatorTunables.FromConstants(node);
         var classification = RebalanceInitiatorService.Classify(signals, tunables);
 
         if (classification.Sources.Count == 0 && classification.Destinations.Count == 0)
@@ -198,7 +200,7 @@ public class AutoRebalanceJob : IJob
             node.Name, classification.Sources.Count, classification.Destinations.Count,
             classification.FallbackSources.Count, classification.FallbackDestinations.Count);
 
-        var earnRates = await FetchEarnRatesAsync(node, owned);
+        var earnRates = await _lightningService.GetLocalOutboundFeeRatesPpmAsync(node);
         if (earnRates == null)
         {
             _logger.LogWarning("Skipping node {NodeName}: FeeReport unavailable, so nothing can be profit-gated",
@@ -214,24 +216,25 @@ public class AutoRebalanceJob : IJob
         }
 
         var initiations = 0;
-        var planIndex = 0;
-        string? capStopReason = null;
 
-        for (; planIndex < plans.Count; planIndex++)
+        for (var i = 0; i < plans.Count; i++)
         {
-            var plan = plans[planIndex];
+            var plan = plans[i];
 
-            if (initiations >= tunables.MaxInitiations)
-            {
-                capStopReason = $"per-run initiation cap reached ({initiations}/{tunables.MaxInitiations})";
-                break;
-            }
-
+            // The cap stops the loop outright, so every remaining plan is abandoned
             if (inFlight + initiations >= maxInFlight)
             {
-                capStopReason =
-                    $"in-flight cap reached ({inFlight + initiations}/{maxInFlight}, {inFlight} already in flight " +
-                    "before this run; raise the node's MaxRebalancesInFlight to dispatch more per cycle)";
+                _logger.LogInformation(
+                    "Node {NodeName}: dropped {DroppedCount} of {PlannedCount} planned rebalance(s) — " +
+                    "in-flight cap reached ({Reached}/{Max}, {Before} already in flight before this run; " +
+                    "raise the node's MaxRebalancesInFlight to dispatch more per cycle)",
+                    node.Name, plans.Count - i, plans.Count, inFlight + initiations, maxInFlight, inFlight);
+
+                for (var dropped = i; dropped < plans.Count; dropped++)
+                {
+                    _logger.LogInformation("Node {NodeName}: dropped plan — {Reason}", node.Name, plans[dropped].Reason);
+                }
+
                 break;
             }
 
@@ -264,9 +267,30 @@ public class AutoRebalanceJob : IJob
                     // Keep retries within the profitable ceiling
                     RetryMaxFeePct: plan.MaxFeePct);
 
-                // Fire-and-forget, and deliberately not tracked: RebalanceService logs and audits
-                // the whole lifecycle itself and MonitorRebalancesJob reconciles anything this process abandons
-                _ = _rebalanceService.RebalanceAsync(request, CancellationToken.None);
+                await _rebalanceService.RebalanceAsync(request, CancellationToken.None);
+
+                // Audit the performed rebalance
+                await _auditService.LogSystemAsync(
+                    AuditActionType.RebalanceInitiated,
+                    AuditEventType.Attempt,
+                    AuditObjectType.Rebalance,
+                    plan.SourceChannelId.ToString(),
+                    new
+                    {
+                        NodeName = node.Name,
+                        NodeId = node.Id,
+                        NodePubKey = node.PubKey,
+                        SourceChannelId = plan.SourceChannelId,
+                        TargetPubkey = plan.DestinationPeerPubKey,
+                        AmountSats = plan.AmountSats,
+                        MaxFeePct = plan.MaxFeePct,
+                        ReservedFeeSats = reservedFee,
+                        BudgetRemainingSats = remainingBudget - reservedFee,
+                        BudgetTotalSats = budgetSats,
+                        InFlightCount = inFlight + initiations + 1,
+                        MaxInFlightCount = maxInFlight,
+                        Reason = plan.Reason
+                    });
 
                 remainingBudget -= reservedFee;
                 initiations++;
@@ -278,53 +302,8 @@ public class AutoRebalanceJob : IJob
             }
         }
 
-        // A cap stops the loop outright, so every remaining plan is abandoned
-        if (capStopReason != null)
-        {
-            var dropped = plans.Count - planIndex;
-            _logger.LogInformation(
-                "Node {NodeName}: dropped {DroppedCount} of {PlannedCount} planned rebalance(s) — {CapStopReason}",
-                node.Name, dropped, plans.Count, capStopReason);
-
-            for (var i = planIndex; i < plans.Count; i++)
-            {
-                _logger.LogInformation("Node {NodeName}: dropped plan — {Reason}", node.Name, plans[i].Reason);
-            }
-        }
-
         _logger.LogInformation(
             "Node {NodeName}: initiated {Count} of {PlannedCount} planned rebalance(s), remaining budget {Remaining}/{Budget} sats",
             node.Name, initiations, plans.Count, remainingBudget, budgetSats);
-    }
-
-    private static RebalanceInitiatorTunables BuildRebalanceTunables(Node node) => new(
-        RebalanceTrigger: Constants.ROUTING_ENGINE_REBALANCE_DEADBAND,
-        MinAmountSats: Constants.REBALANCE_MIN_AMOUNT_SATS,
-        MaxAmountSats: Constants.ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS,
-        CostToEarnRatio: node.MaxRebalanceCostToEarnRatio ?? Constants.ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO,
-        MaxInitiations: Constants.ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN);
-
-    /// <summary>
-    /// Maps our channel id → live local-outbound ppm for every channel in the snapshot, from a single
-    /// FeeReport.
-    /// </summary>
-    private async Task<Dictionary<int, long>?> FetchEarnRatesAsync(Node node, IReadOnlyList<OwnedChannel> owned)
-    {
-        var ppmByChanId = await _lightningService.GetLocalOutboundFeeRatesPpmAsync(node);
-        if (ppmByChanId == null) return null;
-
-        var earnRates = new Dictionary<int, long>();
-        foreach (var oc in owned)
-        {
-            if (ppmByChanId.TryGetValue(oc.Lnd.ChanId, out var ppm))
-            {
-                earnRates[oc.DbChannel.Id] = ppm;
-            }
-        }
-
-        _logger.LogDebug("Node {NodeName}: priced {Priced} of {Total} channel(s) from FeeReport",
-            node.Name, earnRates.Count, owned.Count);
-
-        return earnRates;
     }
 }

--- a/src/Jobs/ChannelFeeOptimizerJob.cs
+++ b/src/Jobs/ChannelFeeOptimizerJob.cs
@@ -27,11 +27,10 @@ using Channel = NodeGuard.Data.Models.Channel;
 namespace NodeGuard.Jobs;
 
 /// <summary>
-/// Dynamic fee actuator. For every eligible, owned channel
-/// on a node with dynamic fee management enabled it reads the signal
+/// The routing engine's fee actuator. For every eligible channel on a node with
+/// <see cref="Node.DynamicFeeManagementEnabled"/> it reads the signal
 /// (<see cref="ChannelRoutingState"/>), runs the pure <see cref="FeeOptimizerService"/> control
-/// law, and applies the resulting outbound/inbound ppm via LND — enforcing the fee-vs-rebalance
-/// authority split.
+/// law, and applies the resulting outbound/inbound ppm via LND.
 /// Everything is gated by the global ROUTING_ENGINE_ENABLED kill switch.
 /// </summary>
 [DisallowConcurrentExecution]
@@ -40,30 +39,27 @@ public class ChannelFeeOptimizerJob : IJob
     private readonly ILogger<ChannelFeeOptimizerJob> _logger;
     private readonly INodeRepository _nodeRepository;
     private readonly IChannelRepository _channelRepository;
-    private readonly IChannelRoutingStateRepository _routingStateRepository;
     private readonly IChannelFeeStateRepository _feeStateRepository;
     private readonly IRebalanceRepository _rebalanceRepository;
+    private readonly IRoutingEngineSnapshotService _snapshotService;
     private readonly ILightningService _lightningService;
-    private readonly ILightningClientService _lightningClientService;
 
     public ChannelFeeOptimizerJob(
         ILogger<ChannelFeeOptimizerJob> logger,
         INodeRepository nodeRepository,
         IChannelRepository channelRepository,
-        IChannelRoutingStateRepository routingStateRepository,
         IChannelFeeStateRepository feeStateRepository,
         IRebalanceRepository rebalanceRepository,
-        ILightningService lightningService,
-        ILightningClientService lightningClientService)
+        IRoutingEngineSnapshotService snapshotService,
+        ILightningService lightningService)
     {
         _logger = logger;
         _nodeRepository = nodeRepository;
         _channelRepository = channelRepository;
-        _routingStateRepository = routingStateRepository;
         _feeStateRepository = feeStateRepository;
         _rebalanceRepository = rebalanceRepository;
+        _snapshotService = snapshotService;
         _lightningService = lightningService;
-        _lightningClientService = lightningClientService;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -81,31 +77,33 @@ public class ChannelFeeOptimizerJob : IJob
             var tunables = FeeOptimizerTunables.FromConstants();
             var managedNodes = await _nodeRepository.GetAllManagedByNodeGuard(withDisabled: false);
 
-            var anyEnabled = managedNodes.Any(n => n.DynamicFeeManagementEnabled);
-            if (!anyEnabled)
+            var relevantNodes = managedNodes.Where(n => n.DynamicFeeManagementEnabled).ToList();
+            if (relevantNodes.Count == 0)
             {
                 _logger.LogInformation("No managed nodes with dynamic fee management enabled; skipping {JobName}",
                     nameof(ChannelFeeOptimizerJob));
                 return;
             }
 
-            // Shared per-run context, only needed when at least one node is under management.
-            var channelsByChanId = (await _channelRepository.GetChannelsByOpenAndDynamicFeeEnabled())
-                .ToDictionary(c => c.ChanId);
             var inFlightSourceChannelIds = await _rebalanceRepository.GetPendingInFlightSourceChannelIds();
 
-            foreach (var managedNode in managedNodes)
+            // Get all the open channels that are eligible for fee optimization in one DB call, then filter per node.
+            var openChannelsByChanId = (await _channelRepository.GetOpenChannels())
+                .Where(c => c.IsDynamicFeeEnabled)
+                .Where(c => c.SatsAmount >= Constants.ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS)
+                .Where(c => !inFlightSourceChannelIds.Contains(c.Id))
+                .ToDictionary(c => c.ChanId);
+
+            foreach (var node in relevantNodes)
             {
                 try
                 {
-                    if (!managedNode.DynamicFeeManagementEnabled) continue;
-
-                    await OptimizeNode(managedNode, managedNodes, channelsByChanId, inFlightSourceChannelIds, tunables);
+                    await OptimizeNode(node, openChannelsByChanId, inFlightSourceChannelIds, tunables);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error optimizing fees for node {NodeName} ({NodePubKey})",
-                        managedNode.Name, managedNode.PubKey);
+                        node.Name, node.PubKey);
                 }
             }
         }
@@ -118,85 +116,44 @@ public class ChannelFeeOptimizerJob : IJob
         _logger.LogInformation("{JobName} ended", nameof(ChannelFeeOptimizerJob));
     }
 
-    private sealed class Candidate
-    {
-        public required Lnrpc.Channel LndChannel { get; init; }
-        public required Channel DbChannel { get; init; }
-        public required ChannelRoutingState RoutingState { get; init; }
-        public required ChannelFeeState? FeeState { get; init; }
-    }
-
     private async Task OptimizeNode(
         Node node,
-        IReadOnlyCollection<Node> managedNodes,
-        IReadOnlyDictionary<ulong, Channel> channelsByChanId,
+        IReadOnlyDictionary<ulong, Channel> openChannelsByChanId,
         IReadOnlySet<int> inFlightSourceChannelIds,
         FeeOptimizerTunables tunables)
     {
-        var listResp = await _lightningClientService.ListChannels(node);
-        if (listResp == null)
+        var owned = await _snapshotService.GetOwnedChannelsAsync(node, openChannelsByChanId, withFeeState: true);
+        if (owned == null)
         {
-            _logger.LogWarning("Skipping fee optimization for node {NodeName}: ListChannels unavailable", node.Name);
+            _logger.LogWarning("Skipping node {NodeName}: ListChannels unavailable", node.Name);
             return;
         }
 
-        var routingStates = (await _routingStateRepository.GetByManagedNodePubKey(node.PubKey))
-            .ToDictionary(s => s.ChannelId);
-        var feeStates = (await _feeStateRepository.GetByManagedNodePubKey(node.PubKey))
-            .ToDictionary(s => s.ChannelId);
-
-        var now = DateTimeOffset.UtcNow;
-
-        // Eligibility filter.
-        var candidates = new List<Candidate>();
-        foreach (var lndChannel in listResp.Channels)
+        foreach (var oc in owned)
         {
-            if (!ChannelOwnershipHelper.IsOwnedByManagedNode(lndChannel, managedNodes)) continue;
-            if (!channelsByChanId.TryGetValue(lndChannel.ChanId, out var dbChannel)) continue;
-            if (lndChannel.Capacity < Constants.ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS) continue;
-            if (!routingStates.TryGetValue(dbChannel.Id, out var routingState)) continue; // no signal yet
-
-            feeStates.TryGetValue(dbChannel.Id, out var feeState);
-
-            candidates.Add(new Candidate
-            {
-                LndChannel = lndChannel,
-                DbChannel = dbChannel,
-                RoutingState = routingState,
-                FeeState = feeState,
-            });
-        }
-
-        foreach (var candidate in candidates)
-        {
-            // Authority split: never touch a channel the rebalancer is actively moving.
-            if (inFlightSourceChannelIds.Contains(candidate.DbChannel.Id))
-            {
-                _logger.LogDebug("Skipping channel {ChanId} on {NodeName}: in-flight rebalance owns it",
-                    candidate.LndChannel.ChanId, node.Name);
-                continue;
-            }
-
             try
             {
-                await OptimizeChannel(node, candidate, tunables, now);
+                await OptimizeChannel(node, oc, tunables);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error optimizing fees for channel {ChanId} on node {NodeName}",
-                    candidate.LndChannel.ChanId, node.Name);
+                    oc.Lnd.ChanId, node.Name);
             }
         }
     }
 
     /// <summary>Runs the control law for one channel and applies the resulting fee update when needed.</summary>
-    private async Task OptimizeChannel(Node node, Candidate candidate, FeeOptimizerTunables tunables, DateTimeOffset now)
+    private async Task OptimizeChannel(Node node, OwnedChannel candidate, FeeOptimizerTunables tunables)
     {
         var routingState = candidate.RoutingState;
-        var feeState = candidate.FeeState ?? new ChannelFeeState {
+        var feeState = candidate.FeeState ?? new ChannelFeeState
+        {
             ChannelId = candidate.DbChannel.Id,
             ManagedNodePubKey = node.PubKey,
         };
+
+        var now = DateTimeOffset.UtcNow;
 
         var decision = FeeOptimizerService.ComputeNextPolicy(
             routingState.EmaLocalRatio,
@@ -213,18 +170,18 @@ public class ChannelFeeOptimizerJob : IJob
         if (decision.Action != FeeAction.Update)
         {
             _logger.LogInformation("Channel {ChanId} on {NodeName}: {Action} ({Reason})",
-                candidate.LndChannel.ChanId, node.Name, decision.Action, decision.Reason);
+                candidate.Lnd.ChanId, node.Name, decision.Action, decision.Reason);
             await _feeStateRepository.UpsertByChannelAndNode(feeState);
             return;
         }
 
         // The live policy is needed only on the write path for the untouched base fee/timelock.
         // NoOp channels never cost an LND round-trip.
-        var (managedPolicy, _) = await _lightningService.GetChannelFeePolicy(candidate.LndChannel.ChanId, node);
+        var (managedPolicy, _) = await _lightningService.GetChannelFeePolicy(candidate.Lnd.ChanId, node);
         if (managedPolicy == null)
         {
             _logger.LogWarning("Skipping channel {ChanId} on {NodeName}: current fee policy unavailable",
-                candidate.LndChannel.ChanId, node.Name);
+                candidate.Lnd.ChanId, node.Name);
             await _feeStateRepository.UpsertByChannelAndNode(feeState);
             return;
         }
@@ -237,7 +194,7 @@ public class ChannelFeeOptimizerJob : IJob
         if (node.RoutingEngineDryRun)
         {
             _logger.LogInformation("Dry-run: would set channel {ChanId} ({NodeName}-{PeerAlias}) to outbound {Outbound}ppm inbound {Inbound}ppm ({Reason})",
-                candidate.LndChannel.ChanId, node.Name, candidate.LndChannel.PeerAlias, decision.OutboundPpm, decision.InboundPpm, decision.Reason);
+                candidate.Lnd.ChanId, node.Name, candidate.Lnd.PeerAlias, decision.OutboundPpm, decision.InboundPpm, decision.Reason);
             feeState.LastAppliedOutboundBaseFeeMsat = baseFeeMsat;
             feeState.LastAppliedOutboundPpm = decision.OutboundPpm;
             feeState.LastAppliedInboundBaseMsat = inboundBaseMsat;
@@ -270,7 +227,7 @@ public class ChannelFeeOptimizerJob : IJob
             feeState.LastFeeUpdateAt = now;
 
             _logger.LogInformation("{NodeName} chan {ChanId}: set outbound {Outbound}ppm inbound {Inbound}ppm ({Reason})",
-                node.Name, candidate.LndChannel.ChanId, decision.OutboundPpm, decision.InboundPpm, decision.Reason);
+                node.Name, candidate.Lnd.ChanId, decision.OutboundPpm, decision.InboundPpm, decision.Reason);
 
             await _feeStateRepository.UpsertByChannelAndNode(feeState);
         }
@@ -278,7 +235,7 @@ public class ChannelFeeOptimizerJob : IJob
         {
             // Log and skip this channel for this cycle; the next cycle retries.
             _logger.LogError(ex, "Failed to set fee policy for channel {ChanId} on {NodeName}",
-                candidate.LndChannel.ChanId, node.Name);
+                candidate.Lnd.ChanId, node.Name);
         }
     }
 }

--- a/src/Jobs/NodeChannelSubscribeJob.cs
+++ b/src/Jobs/NodeChannelSubscribeJob.cs
@@ -103,7 +103,8 @@ public class NodeChannelSuscribeJob : IJob
                     CreationDatetime = DateTimeOffset.Now,
                     UpdateDatetime = DateTimeOffset.Now,
                     IsPrivate = channelOpened.Private,
-                    IsDynamicFeeEnabled = node.DynamicFeeManagementEnabled
+                    IsDynamicFeeEnabled = node.DynamicFeeManagementEnabled,
+                    IsAutoRebalanceEnabled = node.AutoRebalanceEnabled
                 };
 
                 var remoteNode = await _nodeRepository.GetOrCreateByPubKey(channelOpened.RemotePubkey, _lightningService);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -274,23 +274,19 @@ namespace NodeGuard
                         });
                 });
 
-                // Both routing (dynamic-fee) jobs share a cadence: ROUTING_ENGINE_JOB_INTERVAL_SECONDS wins
-                // when set (the fee-engine e2e uses a few seconds so it converges fast); otherwise
-                // ROUTING_ENGINE_JOB_INTERVAL_MINUTES (default 30). Except when the environment is 
-                // DEV, then overridden to 5 minutes (faster convergence for devs).
                 var routingJobIntervalSeconds =
                     int.TryParse(Environment.GetEnvironmentVariable("ROUTING_ENGINE_JOB_INTERVAL_SECONDS"), out var rjs)
                         ? rjs
                         : (int?)null;
 
-                void ScheduleRoutingJob(SimpleScheduleBuilder sb)
+                void ScheduleRoutingJob(SimpleScheduleBuilder sb, int minutes)
                 {
                     if (routingJobIntervalSeconds is int seconds)
                         sb.WithIntervalInSeconds(seconds).RepeatForever();
                     else if (Constants.IS_DEV_ENVIRONMENT)
-                        sb.WithIntervalInMinutes(5).RepeatForever();
+                        sb.WithIntervalInMinutes(1).RepeatForever();
                     else
-                        sb.WithIntervalInMinutes(Constants.ROUTING_ENGINE_JOB_INTERVAL_MINUTES).RepeatForever();
+                        sb.WithIntervalInMinutes(minutes).RepeatForever();
                 }
 
                 //Target Ratio Reevaluation Job
@@ -304,7 +300,7 @@ namespace NodeGuard
                 {
                     opts.ForJob(nameof(TargetRatioReevaluationJob))
                         .WithIdentity($"{nameof(TargetRatioReevaluationJob)}Trigger")
-                        .StartNow().WithSimpleSchedule(ScheduleRoutingJob);
+                        .StartNow().WithSimpleSchedule(sb => ScheduleRoutingJob(sb, Constants.ROUTING_ENGINE_JOB_INTERVAL_MINUTES));
                 });
 
                 //Channel Fee Optimizer Job (routing-engine fee actuator)
@@ -317,20 +313,15 @@ namespace NodeGuard
                 q.AddTrigger(opts =>
                 {
                     opts.ForJob(nameof(ChannelFeeOptimizerJob))
-                        .WithIdentity($"{nameof(ChannelFeeOptimizerJob)}Trigger");
+                        .WithIdentity($"{nameof(ChannelFeeOptimizerJob)}Trigger")
+                        .WithSimpleSchedule(sb => ScheduleRoutingJob(sb, Constants.ROUTING_ENGINE_JOB_INTERVAL_MINUTES));
 
                     if (Constants.IS_DEV_ENVIRONMENT)
-                    {
-                        opts.StartNow()
-                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(1).RepeatForever());
-                    }
+                        opts.StartNow();
+                    // Start a few minutes after TargetRatioReevaluationJob (which uses StartNow) so the
+                    // fee control law always acts on freshly-written routing state.
                     else
-                    {
-                        // Start a few minutes after TargetRatioReevaluationJob (which uses StartNow) so the
-                        // fee control law always acts on freshly-written routing state.
-                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute))
-                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(Constants.ROUTING_ENGINE_JOB_INTERVAL_MINUTES).RepeatForever());
-                    }
+                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute));
                 });
 
                 //Auto Rebalance Job (routing-engine rebalance actuator, own cadence)
@@ -343,21 +334,15 @@ namespace NodeGuard
                 q.AddTrigger(opts =>
                 {
                     opts.ForJob(nameof(AutoRebalanceJob))
-                        .WithIdentity($"{nameof(AutoRebalanceJob)}Trigger");
+                        .WithIdentity($"{nameof(AutoRebalanceJob)}Trigger")
+                        .WithSimpleSchedule(sb => ScheduleRoutingJob(sb, Constants.ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES));
 
                     if (Constants.IS_DEV_ENVIRONMENT)
-                    {
-                        opts.StartNow()
-                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(1).RepeatForever());
-                    }
+                        opts.StartNow();
+                    // Start a few minutes after TargetRatioReevaluationJob (which uses StartNow) so the
+                    // fee control law always acts on freshly-written routing state.
                     else
-                    {
-                        // Same post-signal offset as the fee job, but its own cadence thereafter. Running
-                        // first means the Pending rows it writes are already visible to the fee job, which
-                        // is what keeps the fee-vs-rebalance authority split intact.
-                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute))
-                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(Constants.ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES).RepeatForever());
-                    }
+                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute));
                 });
 
                 //Monitor Withdrawals Job

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -149,6 +149,7 @@ namespace NodeGuard
             builder.Services.AddTransient<INBXplorerService, NBXplorerService>();
             builder.Services.AddTransient<ISwapsService, SwapsService>();
             builder.Services.AddTransient<IRebalanceService, RebalanceService>();
+            builder.Services.AddTransient<IRoutingEngineSnapshotService, RoutingEngineSnapshotService>();
             builder.Services.AddScoped<IAuditService, AuditService>();
 
             //DbContext
@@ -306,7 +307,7 @@ namespace NodeGuard
                         .StartNow().WithSimpleSchedule(ScheduleRoutingJob);
                 });
 
-                //Channel Fee Optimizer Job
+                //Channel Fee Optimizer Job (routing-engine fee actuator)
                 q.AddJob<ChannelFeeOptimizerJob>(opts =>
                 {
                     opts.DisallowConcurrentExecution();
@@ -316,8 +317,47 @@ namespace NodeGuard
                 q.AddTrigger(opts =>
                 {
                     opts.ForJob(nameof(ChannelFeeOptimizerJob))
-                        .WithIdentity($"{nameof(ChannelFeeOptimizerJob)}Trigger")
-                        .StartNow().WithSimpleSchedule(ScheduleRoutingJob);
+                        .WithIdentity($"{nameof(ChannelFeeOptimizerJob)}Trigger");
+
+                    if (Constants.IS_DEV_ENVIRONMENT)
+                    {
+                        opts.StartNow()
+                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(1).RepeatForever());
+                    }
+                    else
+                    {
+                        // Start a few minutes after TargetRatioReevaluationJob (which uses StartNow) so the
+                        // fee control law always acts on freshly-written routing state.
+                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute))
+                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(Constants.ROUTING_ENGINE_JOB_INTERVAL_MINUTES).RepeatForever());
+                    }
+                });
+
+                //Auto Rebalance Job (routing-engine rebalance actuator, own cadence)
+                q.AddJob<AutoRebalanceJob>(opts =>
+                {
+                    opts.DisallowConcurrentExecution();
+                    opts.WithIdentity(nameof(AutoRebalanceJob));
+                });
+
+                q.AddTrigger(opts =>
+                {
+                    opts.ForJob(nameof(AutoRebalanceJob))
+                        .WithIdentity($"{nameof(AutoRebalanceJob)}Trigger");
+
+                    if (Constants.IS_DEV_ENVIRONMENT)
+                    {
+                        opts.StartNow()
+                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(1).RepeatForever());
+                    }
+                    else
+                    {
+                        // Same post-signal offset as the fee job, but its own cadence thereafter. Running
+                        // first means the Pending rows it writes are already visible to the fee job, which
+                        // is what keeps the fee-vs-rebalance authority split intact.
+                        opts.StartAt(DateBuilder.FutureDate(Constants.ROUTING_ENGINE_ACTUATOR_OFFSET_MINUTES, IntervalUnit.Minute))
+                            .WithSimpleSchedule(scheduleBuilder => scheduleBuilder.WithIntervalInMinutes(Constants.ROUTING_ENGINE_REBALANCE_JOB_INTERVAL_MINUTES).RepeatForever());
+                    }
                 });
 
                 //Monitor Withdrawals Job

--- a/src/Services/LightningClientService.cs
+++ b/src/Services/LightningClientService.cs
@@ -38,6 +38,7 @@ public interface ILightningClientService
     public Task<ListChannelsResponse?> ListChannels(Node node, Lightning.LightningClient? client = null);
     public Task<ChannelBalanceResponse?> ChannelBalanceAsync(Node node, Lightning.LightningClient? client = null);
     public Task<ChannelEdge?> GetChanInfo(Node node, ulong chanId, Lightning.LightningClient? client = null);
+    public Task<FeeReportResponse?> FeeReport(Node node, Lightning.LightningClient? client = null);
     public Task<AddInvoiceResponse?> AddInvoice(Node node, Invoice invoice, Lightning.LightningClient? client = null);
     public Task<QueryRoutesResponse?> QueryRoutes(Node node, QueryRoutesRequest request, Lightning.LightningClient? client = null);
     public AsyncServerStreamingCall<CloseStatusUpdate>? CloseChannel(Node node, Channel channel, bool forceClose = false, Lightning.LightningClient? client = null);
@@ -219,6 +220,23 @@ public class LightningClientService : ILightningClientService
         catch (Exception e)
         {
             _logger.LogError(e, "Error while getting channel info for node {NodeId} and channel {ChannelId}", node.Id, chanId);
+            return null;
+        }
+    }
+    
+    public async Task<FeeReportResponse?> FeeReport(Node node, Lightning.LightningClient? client = null)
+    {
+        try
+        {
+            client ??= GetLightningClient(node.Endpoint);
+            return await client.FeeReportAsync(new FeeReportRequest(), new Metadata
+            {
+                { "macaroon", node.ChannelAdminMacaroon }
+            });
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting the fee report for node {NodeId}", node.Id);
             return null;
         }
     }

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -826,7 +826,8 @@ namespace NodeGuard.Services
                 DestinationNodeId = destinationNodeId,
                 CreatedByNodeGuard = true,
                 IsPrivate = currentChannel.Private,
-                IsDynamicFeeEnabled = source.DynamicFeeManagementEnabled
+                IsDynamicFeeEnabled = source.DynamicFeeManagementEnabled,
+                IsAutoRebalanceEnabled = source.AutoRebalanceEnabled
             };
 
             return channel;

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -213,6 +213,13 @@ namespace NodeGuard.Services
         Task<long?> GetLocalOutboundFeeRatePpmAsync(Node node, ulong chanId);
 
         /// <summary>
+        /// Local-outbound fee rate (ppm) for every channel on the node, keyed by LND chan_id.
+        /// Returns null when FeeReport is unavailable, which callers should treat as "skip this node
+        /// this cycle" rather than as "every channel earns nothing".
+        /// </summary>
+        Task<Dictionary<ulong, long>?> GetLocalOutboundFeeRatesPpmAsync(Node node);
+
+        /// <summary>
         /// Sets the channel fee policy for a given channel identified by its chanPoint
         /// </summary>
         /// <param name="chanPoint"></param>
@@ -1783,6 +1790,26 @@ namespace NodeGuard.Services
 
             // FeeRateMilliMsat is "milli-msat per msat" which numerically equals ppm.
             return policy?.FeeRateMilliMsat;
+        }
+
+        public async Task<Dictionary<ulong, long>?> GetLocalOutboundFeeRatesPpmAsync(Node node)
+        {
+            var report = await _lightningClientService.FeeReport(node);
+            if (report == null) return null;
+
+            // FeePerMil is "per million" of the amount forwarded, i.e. the same ppm figure as
+            // RoutingPolicy.FeeRateMilliMsat — but reported for our own side, so unlike GetChanInfo
+            // there is no Node1Pub/Node2Pub comparison to get right.
+            //
+            // Indexer rather than ToDictionary: a duplicate chan_id from LND would throw and take
+            // out the whole node's cycle, and last-wins is harmless for a fee rate.
+            var byChanId = new Dictionary<ulong, long>(report.ChannelFees.Count);
+            foreach (var fee in report.ChannelFees)
+            {
+                byChanId[fee.ChanId] = fee.FeePerMil;
+            }
+
+            return byChanId;
         }
 
         public async Task<long?> GetLocalOutboundFeeRatePpmByPeerAsync(Node node, string peerPubkey)

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -205,6 +205,14 @@ namespace NodeGuard.Services
         (Node node, string peerPubkey);
 
         /// <summary>
+        /// Returns the local-outbound fee rate (ppm) of a specific channel — the per-channel
+        /// variant of <see cref="GetLocalOutboundFeeRatePpmByPeerAsync"/>. Used by the
+        /// auto-rebalancer to pick the cheapest source to drain and to weight a destination
+        /// peer's earn rate for the profitability gate.
+        /// </summary>
+        Task<long?> GetLocalOutboundFeeRatePpmAsync(Node node, ulong chanId);
+
+        /// <summary>
         /// Sets the channel fee policy for a given channel identified by its chanPoint
         /// </summary>
         /// <param name="chanPoint"></param>

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -1558,7 +1558,7 @@ namespace NodeGuard.Services
                     if (channel == null) continue;
                     // If the source node is not the channel initiator, but the remote node is also managed by NodeGuard
                     // We skip and wait for the other node to report the channel
-                    if (nodes.Any((n) => !channel.Initiator && n.PubKey == channel.RemotePubkey)) continue;
+                    if (!ChannelOwnershipHelper.IsOwnedByManagedNode(channel, nodes)) continue;
 
                     var htlcsLocal = channel.PendingHtlcs.Where(x => x.Incoming == true).Sum(x => x.Amount);
                     var htlcsRemote = channel.PendingHtlcs.Where(x => x.Incoming == false).Sum(x => x.Amount);

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -201,14 +201,12 @@ namespace NodeGuard.Services
         /// a specific channel. If the peer has multiple channels with us, the first one
         /// returned by ListChannels is used as a representative.
         /// </summary>
-        Task<long?> GetLocalOutboundFeeRatePpmByPeerAsync
-        (Node node, string peerPubkey);
+        Task<long?> GetLocalOutboundFeeRatePpmByPeerAsync(Node node, string peerPubkey);
 
         /// <summary>
-        /// Returns the local-outbound fee rate (ppm) of a specific channel — the per-channel
-        /// variant of <see cref="GetLocalOutboundFeeRatePpmByPeerAsync"/>. Used by the
-        /// auto-rebalancer to pick the cheapest source to drain and to weight a destination
-        /// peer's earn rate for the profitability gate.
+        /// Returns the local-outbound fee rate (ppm) of a specific channel, read from the gossip
+        /// graph via GetChanInfo. Backs <see cref="GetLocalOutboundFeeRatePpmByPeerAsync"/>, its only
+        /// caller.
         /// </summary>
         Task<long?> GetLocalOutboundFeeRatePpmAsync(Node node, ulong chanId);
 

--- a/src/Services/RebalanceInitiatorService.cs
+++ b/src/Services/RebalanceInitiatorService.cs
@@ -17,18 +17,18 @@
  *
  */
 
+using NodeGuard.Helpers;
+
 namespace NodeGuard.Services;
 
 /// <summary>
 /// One of our channels, with the live balances and the smoothed routing-engine signal the
-/// rebalancer needs. Built by <see cref="Jobs.AutoRebalanceJob"/> from ListChannels +
-/// ChannelRoutingState; the decision logic itself never touches LND or the DB.
+/// rebalancer needs.
 /// </summary>
 public record ChannelSignal(
     int ChannelId,
     ulong ChanIdLnd,
     string PeerPubKey,
-    long CapacitySats,
     long LocalSats,
     long RemoteSats,
     double EmaLocalRatio,
@@ -38,51 +38,28 @@ public record ChannelSignal(
 
 /// <summary>
 /// A channel we can drain (send OUT of via <c>outgoing_chan_id</c>) — precise, per channel.
-/// <para>
-/// <see cref="ExcessSats"/> is how much this channel may contribute, not simply how much it holds.
-/// For a channel that tripped the trigger it is the excess over its own target. For a fallback
-/// source (see <see cref="RebalanceClassification.FallbackSources"/>) it is the room down to the
-/// low edge of its deadband, so lending liquidity can never turn it into next cycle's destination.
-/// </para>
 /// </summary>
 public record SourceChannel(
     int ChannelId,
     ulong ChanIdLnd,
     string PeerPubKey,
-    long ExcessSats,
-    long LocalSats);
+    long ExcessSats);
 
 /// <summary>One of our channels with a destination peer — carries the earn-rate weight (balance base).</summary>
-public record PeerMemberChannel(int ChannelId, ulong ChanIdLnd, long BalanceBaseSats);
+public record PeerMemberChannel(ulong ChanIdLnd, long BalanceBaseSats);
 
 /// <summary>
 /// A peer we want to refill, aggregated across all our channels with it. LND's
 /// <c>last_hop_pubkey</c> only constrains the peer, not the exact incoming channel, so the
 /// destination side is modelled at peer granularity.
-/// <para>
-/// <see cref="DeficitSats"/> is how much this peer may absorb. For a peer that tripped the trigger
-/// it is the shortfall against its own target. For a fallback destination (see
-/// <see cref="RebalanceClassification.FallbackDestinations"/>) it is the room up to the high edge
-/// of its deadband, so being refilled can never turn it into next cycle's source.
-/// </para>
 /// </summary>
 public record DestinationPeer(
     string PeerPubKey,
-    double AggregateEmaRatio,
-    double AggregateTargetRatio,
     long DeficitSats,
-    long RemoteSats,
     IReadOnlyList<PeerMemberChannel> Members);
 
 /// <summary>
 /// Output of <see cref="RebalanceInitiatorService.Classify"/>.
-/// <para>
-/// <see cref="Sources"/> and <see cref="Destinations"/> are the imbalances the engine actually
-/// detected. The two fallback pools are everything else that is merely *able* to take part, and
-/// exist so a detected imbalance is still acted on when nothing on the opposite side tripped the
-/// trigger — a lone too-local source still gets drained somewhere, a lone depleted peer still gets
-/// refilled from somewhere.
-/// </para>
 /// </summary>
 public record RebalanceClassification(
     IReadOnlyList<SourceChannel> Sources,
@@ -91,12 +68,11 @@ public record RebalanceClassification(
     IReadOnlyList<DestinationPeer> FallbackDestinations);
 
 /// <summary>
-/// A concrete rebalance the job should dispatch: drain <see cref="SourceChanIdLnd"/>, refill via
+/// A concrete rebalance the job should dispatch: drain <see cref="SourceChannelId"/>, refill via
 /// last-hop <see cref="DestinationPeerPubKey"/>, sized and profit-gated.
 /// </summary>
 public record RebalancePlan(
     int SourceChannelId,
-    ulong SourceChanIdLnd,
     string DestinationPeerPubKey,
     long AmountSats,
     double MaxFeePct,
@@ -104,16 +80,28 @@ public record RebalancePlan(
     string Reason);
 
 /// <summary>
-/// Control tunables for <see cref="RebalanceInitiatorService"/>. Passed in explicitly so the
-/// decision logic stays pure and unit-testable; the job builds these from the node config +
-/// ROUTING_ENGINE_REBALANCE_* constants.
+/// Control tunables for <see cref="RebalanceInitiatorService"/>.
 /// </summary>
 public record RebalanceInitiatorTunables(
     double RebalanceTrigger,
     long MinAmountSats,
     long MaxAmountSats,
     double CostToEarnRatio,
-    int MaxInitiations);
+    int MaxInitiations)
+{
+    /// <summary>
+    /// Production wiring: global ROUTING_ENGINE_REBALANCE_* defaults, with the cost-to-earn ratio
+    /// overridden per node. Lives on the record — as <see cref="FeeOptimizerTunables.FromConstants"/>
+    /// does — so the pure module owns its own configuration and the job never names a constant.
+    /// </summary>
+    public static RebalanceInitiatorTunables FromConstants(Data.Models.Node node) => new(
+        RebalanceTrigger: Constants.ROUTING_ENGINE_REBALANCE_DEADBAND,
+        MinAmountSats: Constants.REBALANCE_MIN_AMOUNT_SATS,
+        MaxAmountSats: Constants.ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS,
+        CostToEarnRatio: node.MaxRebalanceCostToEarnRatio
+                         ?? Constants.ROUTING_ENGINE_REBALANCE_DEFAULT_COST_TO_EARN_RATIO,
+        MaxInitiations: Constants.ROUTING_ENGINE_REBALANCE_MAX_INITIATIONS_PER_RUN);
+}
 
 /// <summary>
 /// Pure decision logic for the automated rebalancer — no I/O, no clock, no DB, so it is a static
@@ -143,24 +131,21 @@ public static class RebalanceInitiatorService
             var baseSats = c.LocalSats + c.RemoteSats;
             if (baseSats <= 0) continue;
 
-            var targetLocal = (long)Math.Round(c.TargetLocalRatio * baseSats, MidpointRounding.AwayFromZero);
-            var excess = c.LocalSats - targetLocal;
+            var excess = c.LocalSats - SatsAt(c.TargetLocalRatio, baseSats);
 
             // Too-local by the smoothed signal
             if (c.EmaLocalRatio - c.TargetLocalRatio > t.RebalanceTrigger && excess > 0)
             {
-                sources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, excess, c.LocalSats));
+                sources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, excess));
                 continue;
             }
 
             // Searching for fallback sources. Avoiding creating a next cycle rebalance by
             // lending liquidity down to the low edge of the deadband only
-            var floorRatio = Math.Max(0, c.TargetLocalRatio - t.RebalanceTrigger);
-            var floorLocal = (long)Math.Round(floorRatio * baseSats, MidpointRounding.AwayFromZero);
-            var lendable = c.LocalSats - floorLocal;
-            if (lendable > 0)
+            var lendable = c.LocalSats - SatsAt(Math.Max(0, c.TargetLocalRatio - t.RebalanceTrigger), baseSats);
+            if (lendable > 0 && lendable > t.MinAmountSats)
             {
-                fallbackSources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, lendable, c.LocalSats));
+                fallbackSources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, lendable));
             }
         }
 
@@ -170,7 +155,6 @@ public static class RebalanceInitiatorService
         foreach (var group in channels.Where(c => c.Active).GroupBy(c => c.PeerPubKey))
         {
             long peerLocal = 0;
-            long peerRemote = 0;
             long peerBase = 0;
             double weightedEma = 0;
             double weightedTarget = 0;
@@ -182,11 +166,10 @@ public static class RebalanceInitiatorService
                 if (baseSats <= 0) continue;
 
                 peerLocal += c.LocalSats;
-                peerRemote += c.RemoteSats;
                 peerBase += baseSats;
                 weightedEma += c.EmaLocalRatio * baseSats;
                 weightedTarget += c.TargetLocalRatio * baseSats;
-                members.Add(new PeerMemberChannel(c.ChannelId, c.ChanIdLnd, baseSats));
+                members.Add(new PeerMemberChannel(c.ChanIdLnd, baseSats));
             }
 
             if (peerBase <= 0) continue;
@@ -201,19 +184,16 @@ public static class RebalanceInitiatorService
             // Too-remote in aggregate (smoothed): the peer holds too little of our local
             if (aggEma - aggTarget < -t.RebalanceTrigger && deficit > 0)
             {
-                destinations.Add(new DestinationPeer(group.Key, aggEma, aggTarget, deficit, peerRemote, members));
+                destinations.Add(new DestinationPeer(group.Key, deficit, members));
                 continue;
             }
 
             // Searching for fallback destinations. Avoiding creating a next cycle rebalance by
             // lending liquidity up to the high edge of the deadband only
-            var ceilingRatio = Math.Min(1.0, aggTarget + t.RebalanceTrigger);
-            var ceilingLocal = (long)Math.Round(ceilingRatio * peerBase, MidpointRounding.AwayFromZero);
-            var absorbable = ceilingLocal - peerLocal;
-            if (absorbable > 0)
+            var absorbable = SatsAt(Math.Min(1.0, aggTarget + t.RebalanceTrigger), peerBase) - peerLocal;
+            if (absorbable > 0 && absorbable > t.MinAmountSats)
             {
-                fallbackDestinations.Add(
-                    new DestinationPeer(group.Key, aggEma, aggTarget, absorbable, peerRemote, members));
+                fallbackDestinations.Add(new DestinationPeer(group.Key, absorbable, members));
             }
         }
 
@@ -230,27 +210,32 @@ public static class RebalanceInitiatorService
     /// </summary>
     public static IReadOnlyList<RebalancePlan> BuildPlans(
         RebalanceClassification classification,
-        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId,
+        IReadOnlyDictionary<ulong, long> earnPpmByChanIdLnd,
         RebalanceInitiatorTunables t)
     {
         var plans = new List<RebalancePlan>();
         var usedSourceIds = new HashSet<int>();
 
-        // Only counterparties big enough to be worth a hop
         var sources = classification.Sources
-            .Where(s => s.ExcessSats >= t.MinAmountSats)
+            .OrderByDescending(s => s.ExcessSats)
             .ToList();
         var fallbackSources = classification.FallbackSources
-            .Where(s => s.ExcessSats >= t.MinAmountSats)
+            .OrderByDescending(s => s.ExcessSats)
+            .ToList();
+        var destinations = classification.Destinations
+            .OrderByDescending(d => d.DeficitSats)
+            .ToList();
+        var fallbackDestinations = classification.FallbackDestinations
+            .OrderByDescending(d => d.DeficitSats)
             .ToList();
 
         // Pass 1: refill every detected destination
-        foreach (var dest in classification.Destinations)
+        foreach (var dest in destinations)
         {
             if (plans.Count >= t.MaxInitiations) return plans;
 
             // No known earn rate ⇒ nothing to profit-gate against ⇒ leave the peer alone.
-            var destEarnPpm = WeightedAverageEarnPpm(dest.Members, outboundEarnPpmByChannelId);
+            var destEarnPpm = WeightedAverageEarnPpm(dest.Members, earnPpmByChanIdLnd);
             if (destEarnPpm == null) continue;
 
             // A channel that tripped the trigger first; failing that, borrow from the fallback pool
@@ -260,7 +245,7 @@ public static class RebalanceInitiatorService
             source ??= FirstFreeSource(fallbackSources, dest, usedSourceIds);
             if (source == null) continue;
 
-            var plan = TryBuildPlan(source, dest, destEarnPpm.Value, outboundEarnPpmByChannelId, t, isFallback);
+            var plan = TryBuildPlan(source, dest, destEarnPpm.Value, earnPpmByChanIdLnd, t, isFallback);
             if (plan == null) continue;
 
             usedSourceIds.Add(source.ChannelId);
@@ -268,8 +253,8 @@ public static class RebalanceInitiatorService
         }
 
         // Pass 2: drain every detected source pass 1 left unused
-        var gatedFallbackDestinations = classification.FallbackDestinations
-            .Select(d => (Dest: d, EarnPpm: WeightedAverageEarnPpm(d.Members, outboundEarnPpmByChannelId)))
+        var gatedFallbackDestinations = fallbackDestinations
+            .Select(d => (Dest: d, EarnPpm: WeightedAverageEarnPpm(d.Members, earnPpmByChanIdLnd)))
             .Where(x => x.EarnPpm.HasValue)
             .ToList();
 
@@ -285,7 +270,7 @@ public static class RebalanceInitiatorService
                 if (dest.PeerPubKey == source.PeerPubKey) continue;
                 if (refilledFallbackPeers.Contains(dest.PeerPubKey)) continue;
 
-                var plan = TryBuildPlan(source, dest, destEarnPpm!.Value, outboundEarnPpmByChannelId, t,
+                var plan = TryBuildPlan(source, dest, destEarnPpm!.Value, earnPpmByChanIdLnd, t,
                     isFallbackPairing: true);
                 if (plan == null) continue;
 
@@ -301,6 +286,12 @@ public static class RebalanceInitiatorService
         return plans;
     }
 
+    /// <summary>
+    /// Sats corresponding to <paramref name="ratio"/> of <paramref name="baseSats"/>.
+    /// </summary>
+    private static long SatsAt(double ratio, long baseSats)
+        => (long)Math.Round(ratio * baseSats, MidpointRounding.AwayFromZero);
+
     private static SourceChannel? FirstFreeSource(
         IReadOnlyList<SourceChannel> pool,
         DestinationPeer dest,
@@ -315,7 +306,7 @@ public static class RebalanceInitiatorService
         SourceChannel source,
         DestinationPeer dest,
         long destEarnPpm,
-        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId,
+        IReadOnlyDictionary<ulong, long> earnPpmByChanIdLnd,
         RebalanceInitiatorTunables t,
         bool isFallbackPairing)
     {
@@ -326,14 +317,12 @@ public static class RebalanceInitiatorService
 
         // What the source can give, bounded by what the destination can take
         var raw = Math.Min(source.ExcessSats, dest.DeficitSats);
-        if (raw < t.MinAmountSats) return null;
         var amount = Math.Min(raw, t.MaxAmountSats);
 
-        var sourceEarn = outboundEarnPpmByChannelId.TryGetValue(source.ChannelId, out var se) ? se : (long?)null;
+        var sourceEarn = earnPpmByChanIdLnd.TryGetValue(source.ChanIdLnd, out var se) ? se : (long?)null;
         var kind = isFallbackPairing ? "fallback " : string.Empty;
         return new RebalancePlan(
             source.ChannelId,
-            source.ChanIdLnd,
             dest.PeerPubKey,
             amount,
             maxFeePct,
@@ -348,13 +337,13 @@ public static class RebalanceInitiatorService
     /// </summary>
     private static long? WeightedAverageEarnPpm(
         IReadOnlyList<PeerMemberChannel> members,
-        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId)
+        IReadOnlyDictionary<ulong, long> earnPpmByChanIdLnd)
     {
         double weightedSum = 0;
         long totalWeight = 0;
         foreach (var m in members)
         {
-            if (!outboundEarnPpmByChannelId.TryGetValue(m.ChannelId, out var ppm)) continue;
+            if (!earnPpmByChanIdLnd.TryGetValue(m.ChanIdLnd, out var ppm)) continue;
             weightedSum += (double)ppm * m.BalanceBaseSats;
             totalWeight += m.BalanceBaseSats;
         }

--- a/src/Services/RebalanceInitiatorService.cs
+++ b/src/Services/RebalanceInitiatorService.cs
@@ -1,0 +1,365 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+namespace NodeGuard.Services;
+
+/// <summary>
+/// One of our channels, with the live balances and the smoothed routing-engine signal the
+/// rebalancer needs. Built by <see cref="Jobs.AutoRebalanceJob"/> from ListChannels +
+/// ChannelRoutingState; the decision logic itself never touches LND or the DB.
+/// </summary>
+public record ChannelSignal(
+    int ChannelId,
+    ulong ChanIdLnd,
+    string PeerPubKey,
+    long CapacitySats,
+    long LocalSats,
+    long RemoteSats,
+    double EmaLocalRatio,
+    double TargetLocalRatio,
+    bool Active,
+    bool SourceOptIn);
+
+/// <summary>
+/// A channel we can drain (send OUT of via <c>outgoing_chan_id</c>) — precise, per channel.
+/// <para>
+/// <see cref="ExcessSats"/> is how much this channel may contribute, not simply how much it holds.
+/// For a channel that tripped the trigger it is the excess over its own target. For a fallback
+/// source (see <see cref="RebalanceClassification.FallbackSources"/>) it is the room down to the
+/// low edge of its deadband, so lending liquidity can never turn it into next cycle's destination.
+/// </para>
+/// </summary>
+public record SourceChannel(
+    int ChannelId,
+    ulong ChanIdLnd,
+    string PeerPubKey,
+    long ExcessSats,
+    long LocalSats);
+
+/// <summary>One of our channels with a destination peer — carries the earn-rate weight (balance base).</summary>
+public record PeerMemberChannel(int ChannelId, ulong ChanIdLnd, long BalanceBaseSats);
+
+/// <summary>
+/// A peer we want to refill, aggregated across all our channels with it. LND's
+/// <c>last_hop_pubkey</c> only constrains the peer, not the exact incoming channel, so the
+/// destination side is modelled at peer granularity.
+/// <para>
+/// <see cref="DeficitSats"/> is how much this peer may absorb. For a peer that tripped the trigger
+/// it is the shortfall against its own target. For a fallback destination (see
+/// <see cref="RebalanceClassification.FallbackDestinations"/>) it is the room up to the high edge
+/// of its deadband, so being refilled can never turn it into next cycle's source.
+/// </para>
+/// </summary>
+public record DestinationPeer(
+    string PeerPubKey,
+    double AggregateEmaRatio,
+    double AggregateTargetRatio,
+    long DeficitSats,
+    long RemoteSats,
+    IReadOnlyList<PeerMemberChannel> Members);
+
+/// <summary>
+/// Output of <see cref="RebalanceInitiatorService.Classify"/>.
+/// <para>
+/// <see cref="Sources"/> and <see cref="Destinations"/> are the imbalances the engine actually
+/// detected. The two fallback pools are everything else that is merely *able* to take part, and
+/// exist so a detected imbalance is still acted on when nothing on the opposite side tripped the
+/// trigger — a lone too-local source still gets drained somewhere, a lone depleted peer still gets
+/// refilled from somewhere.
+/// </para>
+/// </summary>
+public record RebalanceClassification(
+    IReadOnlyList<SourceChannel> Sources,
+    IReadOnlyList<DestinationPeer> Destinations,
+    IReadOnlyList<SourceChannel> FallbackSources,
+    IReadOnlyList<DestinationPeer> FallbackDestinations);
+
+/// <summary>
+/// A concrete rebalance the job should dispatch: drain <see cref="SourceChanIdLnd"/>, refill via
+/// last-hop <see cref="DestinationPeerPubKey"/>, sized and profit-gated.
+/// </summary>
+public record RebalancePlan(
+    int SourceChannelId,
+    ulong SourceChanIdLnd,
+    string DestinationPeerPubKey,
+    long AmountSats,
+    double MaxFeePct,
+    bool IsFallbackPairing,
+    string Reason);
+
+/// <summary>
+/// Control tunables for <see cref="RebalanceInitiatorService"/>. Passed in explicitly so the
+/// decision logic stays pure and unit-testable; the job builds these from the node config +
+/// ROUTING_ENGINE_REBALANCE_* constants.
+/// </summary>
+public record RebalanceInitiatorTunables(
+    double RebalanceTrigger,
+    long MinAmountSats,
+    long MaxAmountSats,
+    double CostToEarnRatio,
+    int MaxInitiations);
+
+/// <summary>
+/// Pure decision logic for the automated rebalancer — no I/O, no clock, no DB, so it is a static
+/// function library (mirrors <see cref="FeeOptimizerService"/>).
+/// <para>
+/// A circular rebalance drains liquidity OUT of a too-local channel (precise: <c>outgoing_chan_id</c>)
+/// and refills a too-remote one (fuzzy: <c>last_hop_pubkey</c> pins only the peer, not the channel).
+/// </summary>
+public static class RebalanceInitiatorService
+{
+    /// <summary>
+    /// Splits <paramref name="channels"/> into drainable sources and refillable destination peers,
+    /// using the smoothed EMA ratio for the direction decision and live balances for sizing. Whatever
+    /// trips neither trigger lands in the fallback pools instead of being discarded.
+    /// </summary>
+    public static RebalanceClassification Classify(
+        IReadOnlyList<ChannelSignal> channels,
+        RebalanceInitiatorTunables t)
+    {
+        // Sources calculation
+        var sources = new List<SourceChannel>();
+        var fallbackSources = new List<SourceChannel>();
+        foreach (var c in channels)
+        {
+            if (!c.Active || !c.SourceOptIn) continue;
+
+            var baseSats = c.LocalSats + c.RemoteSats;
+            if (baseSats <= 0) continue;
+
+            var targetLocal = (long)Math.Round(c.TargetLocalRatio * baseSats, MidpointRounding.AwayFromZero);
+            var excess = c.LocalSats - targetLocal;
+
+            // Too-local by the smoothed signal
+            if (c.EmaLocalRatio - c.TargetLocalRatio > t.RebalanceTrigger && excess > 0)
+            {
+                sources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, excess, c.LocalSats));
+                continue;
+            }
+
+            // Searching for fallback sources. Avoiding creating a next cycle rebalance by
+            // lending liquidity down to the low edge of the deadband only
+            var floorRatio = Math.Max(0, c.TargetLocalRatio - t.RebalanceTrigger);
+            var floorLocal = (long)Math.Round(floorRatio * baseSats, MidpointRounding.AwayFromZero);
+            var lendable = c.LocalSats - floorLocal;
+            if (lendable > 0)
+            {
+                fallbackSources.Add(new SourceChannel(c.ChannelId, c.ChanIdLnd, c.PeerPubKey, lendable, c.LocalSats));
+            }
+        }
+
+        // Destinations calculation
+        var destinations = new List<DestinationPeer>();
+        var fallbackDestinations = new List<DestinationPeer>();
+        foreach (var group in channels.Where(c => c.Active).GroupBy(c => c.PeerPubKey))
+        {
+            long peerLocal = 0;
+            long peerRemote = 0;
+            long peerBase = 0;
+            double weightedEma = 0;
+            double weightedTarget = 0;
+            var members = new List<PeerMemberChannel>();
+
+            foreach (var c in group)
+            {
+                var baseSats = c.LocalSats + c.RemoteSats;
+                if (baseSats <= 0) continue;
+
+                peerLocal += c.LocalSats;
+                peerRemote += c.RemoteSats;
+                peerBase += baseSats;
+                weightedEma += c.EmaLocalRatio * baseSats;
+                weightedTarget += c.TargetLocalRatio * baseSats;
+                members.Add(new PeerMemberChannel(c.ChannelId, c.ChanIdLnd, baseSats));
+            }
+
+            if (peerBase <= 0) continue;
+
+            var aggEma = weightedEma / peerBase;
+            var aggTarget = weightedTarget / peerBase;
+
+            // Sats of local needed to bring the peer aggregate back to target
+            var targetLocalSats = (long)Math.Round(weightedTarget, MidpointRounding.AwayFromZero);
+            var deficit = targetLocalSats - peerLocal;
+
+            // Too-remote in aggregate (smoothed): the peer holds too little of our local
+            if (aggEma - aggTarget < -t.RebalanceTrigger && deficit > 0)
+            {
+                destinations.Add(new DestinationPeer(group.Key, aggEma, aggTarget, deficit, peerRemote, members));
+                continue;
+            }
+
+            // Searching for fallback destinations. Avoiding creating a next cycle rebalance by
+            // lending liquidity up to the high edge of the deadband only
+            var ceilingRatio = Math.Min(1.0, aggTarget + t.RebalanceTrigger);
+            var ceilingLocal = (long)Math.Round(ceilingRatio * peerBase, MidpointRounding.AwayFromZero);
+            var absorbable = ceilingLocal - peerLocal;
+            if (absorbable > 0)
+            {
+                fallbackDestinations.Add(
+                    new DestinationPeer(group.Key, aggEma, aggTarget, absorbable, peerRemote, members));
+            }
+        }
+
+        return new RebalanceClassification(sources, destinations, fallbackSources, fallbackDestinations);
+    }
+
+    /// <summary>
+    /// Turns the classification into sized, profit-gated <see cref="RebalancePlan"/>s.
+    /// <para>
+    /// Pass 1 refills every detected destination from the first source still available,
+    /// otherwise the fallback pool. Pass 2 then drains any detected source pass 1 didn't
+    /// consume into the first fallback destination that fits.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<RebalancePlan> BuildPlans(
+        RebalanceClassification classification,
+        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId,
+        RebalanceInitiatorTunables t)
+    {
+        var plans = new List<RebalancePlan>();
+        var usedSourceIds = new HashSet<int>();
+
+        // Only counterparties big enough to be worth a hop
+        var sources = classification.Sources
+            .Where(s => s.ExcessSats >= t.MinAmountSats)
+            .ToList();
+        var fallbackSources = classification.FallbackSources
+            .Where(s => s.ExcessSats >= t.MinAmountSats)
+            .ToList();
+
+        // Pass 1: refill every detected destination
+        foreach (var dest in classification.Destinations)
+        {
+            if (plans.Count >= t.MaxInitiations) return plans;
+
+            // No known earn rate ⇒ nothing to profit-gate against ⇒ leave the peer alone.
+            var destEarnPpm = WeightedAverageEarnPpm(dest.Members, outboundEarnPpmByChannelId);
+            if (destEarnPpm == null) continue;
+
+            // A channel that tripped the trigger first; failing that, borrow from the fallback pool
+            // so the detected shortfall still gets funded.
+            var source = FirstFreeSource(sources, dest, usedSourceIds);
+            var isFallback = source == null;
+            source ??= FirstFreeSource(fallbackSources, dest, usedSourceIds);
+            if (source == null) continue;
+
+            var plan = TryBuildPlan(source, dest, destEarnPpm.Value, outboundEarnPpmByChannelId, t, isFallback);
+            if (plan == null) continue;
+
+            usedSourceIds.Add(source.ChannelId);
+            plans.Add(plan);
+        }
+
+        // Pass 2: drain every detected source pass 1 left unused
+        var gatedFallbackDestinations = classification.FallbackDestinations
+            .Select(d => (Dest: d, EarnPpm: WeightedAverageEarnPpm(d.Members, outboundEarnPpmByChannelId)))
+            .Where(x => x.EarnPpm.HasValue)
+            .ToList();
+
+        var refilledFallbackPeers = new HashSet<string>();
+
+        foreach (var source in sources)
+        {
+            if (plans.Count >= t.MaxInitiations) return plans;
+            if (usedSourceIds.Contains(source.ChannelId)) continue;
+
+            foreach (var (dest, destEarnPpm) in gatedFallbackDestinations)
+            {
+                if (dest.PeerPubKey == source.PeerPubKey) continue;
+                if (refilledFallbackPeers.Contains(dest.PeerPubKey)) continue;
+
+                var plan = TryBuildPlan(source, dest, destEarnPpm!.Value, outboundEarnPpmByChannelId, t,
+                    isFallbackPairing: true);
+                if (plan == null) continue;
+
+                // Both marked only now, so a pairing the profit gate or the min-amount floor
+                // rejected leaves the source and the peer available to everything downstream.
+                usedSourceIds.Add(source.ChannelId);
+                refilledFallbackPeers.Add(dest.PeerPubKey);
+                plans.Add(plan);
+                break;
+            }
+        }
+
+        return plans;
+    }
+
+    private static SourceChannel? FirstFreeSource(
+        IReadOnlyList<SourceChannel> pool,
+        DestinationPeer dest,
+        HashSet<int> usedSourceIds)
+        => pool.FirstOrDefault(s => !usedSourceIds.Contains(s.ChannelId) && s.PeerPubKey != dest.PeerPubKey);
+
+    /// <summary>
+    /// Sizes and profit-gates one source→destination pairing. Returns null when the pairing can't
+    /// pay for itself or is too small to be worth a hop.
+    /// </summary>
+    private static RebalancePlan? TryBuildPlan(
+        SourceChannel source,
+        DestinationPeer dest,
+        long destEarnPpm,
+        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId,
+        RebalanceInitiatorTunables t,
+        bool isFallbackPairing)
+    {
+        // Profit gate: cost is capped at ratio × the earn rate of the destination we actually chose
+        var maxCostPpm = (long)Math.Round(t.CostToEarnRatio * destEarnPpm, MidpointRounding.AwayFromZero);
+        if (maxCostPpm < 1) return null;
+        var maxFeePct = maxCostPpm / 10_000.0;
+
+        // What the source can give, bounded by what the destination can take
+        var raw = Math.Min(source.ExcessSats, dest.DeficitSats);
+        if (raw < t.MinAmountSats) return null;
+        var amount = Math.Min(raw, t.MaxAmountSats);
+
+        var sourceEarn = outboundEarnPpmByChannelId.TryGetValue(source.ChannelId, out var se) ? se : (long?)null;
+        var kind = isFallbackPairing ? "fallback " : string.Empty;
+        return new RebalancePlan(
+            source.ChannelId,
+            source.ChanIdLnd,
+            dest.PeerPubKey,
+            amount,
+            maxFeePct,
+            isFallbackPairing,
+            $"{kind}drain chan {source.ChanIdLnd} (earn {sourceEarn?.ToString() ?? "?"}ppm) → refill peer {dest.PeerPubKey} " +
+            $"(earn {destEarnPpm}ppm, capacity {dest.DeficitSats} sats); amount {amount} sats, maxCost {maxCostPpm}ppm ({maxFeePct:0.####}%)");
+    }
+
+    /// <summary>
+    /// Balance-weighted average of the peer's channels' outbound ppm (weight = balance base),
+    /// over the members whose earn rate is known. Null when none are known.
+    /// </summary>
+    private static long? WeightedAverageEarnPpm(
+        IReadOnlyList<PeerMemberChannel> members,
+        IReadOnlyDictionary<int, long> outboundEarnPpmByChannelId)
+    {
+        double weightedSum = 0;
+        long totalWeight = 0;
+        foreach (var m in members)
+        {
+            if (!outboundEarnPpmByChannelId.TryGetValue(m.ChannelId, out var ppm)) continue;
+            weightedSum += (double)ppm * m.BalanceBaseSats;
+            totalWeight += m.BalanceBaseSats;
+        }
+
+        if (totalWeight <= 0) return null;
+        return (long)Math.Round(weightedSum / totalWeight, MidpointRounding.AwayFromZero);
+    }
+}

--- a/src/Services/RebalanceService.cs
+++ b/src/Services/RebalanceService.cs
@@ -114,7 +114,7 @@ public class RebalanceService : IRebalanceService
                 "Target pubkey is required.",
                 nameof(request.TargetPubkey));
 
-        var node = await _nodeRepository.GetById(request.NodeId);
+        var node = await _nodeRepository.GetById(request.NodeId, includeRelatedData: false);
         if (node == null)
             throw new ArgumentException($"Node {request.NodeId} not found", nameof(request.NodeId));
 
@@ -129,7 +129,7 @@ public class RebalanceService : IRebalanceService
             ? sourceChannel.DestinationNodeId
             : sourceChannel.SourceNodeId;
 
-        var counterpartyPeer = await _nodeRepository.GetById(counterpartyPeerId);
+        var counterpartyPeer = await _nodeRepository.GetById(counterpartyPeerId, includeRelatedData: false);
         if (counterpartyPeer == null)
             throw new InvalidOperationException(
                 $"Counterparty peer node {counterpartyPeerId} not found for source channel {request.SourceChannelId}");
@@ -202,7 +202,7 @@ public class RebalanceService : IRebalanceService
         if (rebalance == null)
             throw new InvalidOperationException($"Rebalance {rebalanceId} not found");
 
-        var node = rebalance.Node ?? await _nodeRepository.GetById(rebalance.NodeId);
+        var node = rebalance.Node ?? await _nodeRepository.GetById(rebalance.NodeId, includeRelatedData: false);
         if (node == null)
             throw new InvalidOperationException($"Node {rebalance.NodeId} not found for rebalance {rebalanceId}");
 

--- a/src/Services/RoutingEngineSnapshotService.cs
+++ b/src/Services/RoutingEngineSnapshotService.cs
@@ -1,0 +1,111 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using Channel = NodeGuard.Data.Models.Channel;
+
+namespace NodeGuard.Services;
+
+/// <summary>
+/// One of a node's channels with everything the routing-engine jobs act on, assembled from a
+/// single <c>ListChannels</c> plus the per-(channel, managed node) routing and fee state.
+/// </summary>
+public sealed class OwnedChannel
+{
+    public required Lnrpc.Channel Lnd { get; init; }
+    public required Channel DbChannel { get; init; }
+    public required ChannelRoutingState RoutingState { get; init; }
+    public required ChannelFeeState? FeeState { get; init; }
+}
+
+/// <summary>
+/// Builds the per-node channel view both routing-engine actuator jobs
+/// (<see cref="Jobs.ChannelFeeOptimizerJob"/> and <see cref="Jobs.AutoRebalanceJob"/>) start from.
+/// The two jobs run on independent cadences, so each takes its own snapshot.
+/// </summary>
+public interface IRoutingEngineSnapshotService
+{
+    /// <summary>
+    /// The node's actuatable channels: open, known to NodeGuard, and carrying a routing-state
+    /// signal for this managed node. Returns null when LND is unreachable — callers should treat
+    /// that as "skip this node this cycle" rather than as an empty result. Per-job eligibility
+    /// (min size / IsDynamicFeeEnabled for fees, opt-in / trigger for rebalancing) is the caller's.
+    /// </summary>
+    Task<IReadOnlyList<OwnedChannel>?> GetOwnedChannelsAsync(
+        Node node,
+        IReadOnlyDictionary<ulong, Channel> openChannelsByChanId,
+        bool withFeeState);
+}
+
+public class RoutingEngineSnapshotService : IRoutingEngineSnapshotService
+{
+    private readonly IChannelRoutingStateRepository _routingStateRepository;
+    private readonly IChannelFeeStateRepository _feeStateRepository;
+    private readonly ILightningClientService _lightningClientService;
+
+    public RoutingEngineSnapshotService(
+        IChannelRoutingStateRepository routingStateRepository,
+        IChannelFeeStateRepository feeStateRepository,
+        ILightningClientService lightningClientService)
+    {
+        _routingStateRepository = routingStateRepository;
+        _feeStateRepository = feeStateRepository;
+        _lightningClientService = lightningClientService;
+    }
+
+    public async Task<IReadOnlyList<OwnedChannel>?> GetOwnedChannelsAsync(
+        Node node,
+        IReadOnlyDictionary<ulong, Channel> openChannelsByChanId,
+        bool withFeeState)
+    {
+        // One LND round-trip per node per job run.
+        var listResp = await _lightningClientService.ListChannels(node);
+        if (listResp == null) return null;
+
+        var routingStates = (await _routingStateRepository.GetByManagedNodePubKey(node.PubKey))
+            .ToDictionary(s => s.ChannelId);
+
+        // Only the fee job reads these; the rebalancer never does.
+        var feeStates = withFeeState
+            ? (await _feeStateRepository.GetByManagedNodePubKey(node.PubKey)).ToDictionary(s => s.ChannelId)
+            : new Dictionary<int, ChannelFeeState>();
+
+        var owned = new List<OwnedChannel>();
+        foreach (var lndChannel in listResp.Channels)
+        {
+            // No ownership dedup: routing/fee state is per (channel, managed node), so when both
+            // ends are managed each side actuates its own view — its own local balance for the
+            // rebalancer, its own outbound policy for the fee job.
+            if (!openChannelsByChanId.TryGetValue(lndChannel.ChanId, out var dbChannel)) continue;
+            if (!routingStates.TryGetValue(dbChannel.Id, out var routingState)) continue; // no signal yet
+
+            feeStates.TryGetValue(dbChannel.Id, out var feeState);
+            owned.Add(new OwnedChannel
+            {
+                Lnd = lndChannel,
+                DbChannel = dbChannel,
+                RoutingState = routingState,
+                FeeState = feeState,
+            });
+        }
+
+        return owned;
+    }
+}

--- a/test/NodeGuard.Tests/Jobs/AutoRebalanceJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/AutoRebalanceJobTests.cs
@@ -1,0 +1,446 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using Microsoft.Extensions.Logging;
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
+using NodeGuard.Services;
+using NodeGuard.Tests.Helpers;
+using Quartz;
+using Channel = NodeGuard.Data.Models.Channel;
+
+namespace NodeGuard.Jobs;
+
+
+[Collection("RoutingEngine")]
+public class AutoRebalanceJobTests
+{
+    private const string NodePubKey = "managedPubKey";
+
+    private readonly Mock<ILogger<AutoRebalanceJob>> _logger = new();
+
+    private readonly Mock<INodeRepository> _nodeRepository = new();
+    private readonly Mock<IChannelRepository> _channelRepository = new();
+    private readonly Mock<IChannelRoutingStateRepository> _routingStateRepository = new();
+    private readonly Mock<IChannelFeeStateRepository> _feeStateRepository = new();
+    private readonly Mock<IRebalanceRepository> _rebalanceRepository = new();
+    private readonly Mock<IRebalanceService> _rebalanceService = new();
+    private readonly Mock<ILightningService> _lightningService = new();
+    private readonly Mock<ILightningClientService> _lightningClientService = new();
+
+    // The real snapshot service over the mocked repos/LND, so these tests still cover the
+    // open-channel + routing-state filtering that feeds the job.
+    private IRoutingEngineSnapshotService BuildSnapshotService() =>
+        new RoutingEngineSnapshotService(
+            _routingStateRepository.Object,
+            _feeStateRepository.Object,
+            _lightningClientService.Object);
+
+    private AutoRebalanceJob BuildJob() =>
+        new(
+            _logger.Object,
+            _nodeRepository.Object,
+            _channelRepository.Object,
+            _rebalanceRepository.Object,
+            _rebalanceService.Object,
+            BuildSnapshotService(),
+            _lightningService.Object);
+
+    private static async Task WithEngine(bool enabled, Func<Task> body)
+    {
+        var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
+        Constants.ROUTING_ENGINE_ENABLED = enabled;
+        try
+        {
+            await body();
+        }
+        finally
+        {
+            Constants.ROUTING_ENGINE_ENABLED = prevEnabled;
+        }
+    }
+
+
+    /// <summary>
+    /// A drainable source (too-local 0.75 vs 0.50, cheap 50 ppm) and a depleted destination on a
+    /// different peer (0.10 vs 0.50, dear 2500 ppm), on a node with budget to spend.
+    /// <paramref name="sourceOptedIn"/> drives the per-channel rebalance opt-in;
+    /// <paramref name="sourceLiquidityFlag"/> drives the unrelated swap-liquidity flag.
+    /// </summary>
+    private void ArrangeRebalancePair(bool sourceOptedIn, bool sourceLiquidityFlag = false)
+    {
+        var node = new Node
+        {
+            Id = 20,
+            PubKey = NodePubKey,
+            Name = "alice",
+            AutoRebalanceEnabled = true,
+            RebalanceBudgetSats = 1_000_000,
+            MaxRebalancesInFlight = 5,
+            MaxRebalanceCostToEarnRatio = 0.5,
+        };
+        _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node });
+
+        var sourceDb = new Channel
+        {
+            Id = 101, ChanId = 1001, Status = Channel.ChannelStatus.Open,
+            IsDynamicFeeEnabled = true,
+            IsAutoRebalanceEnabled = sourceOptedIn,
+            IsAutomatedLiquidityEnabled = sourceLiquidityFlag,
+            FundingTx = "txS", FundingTxOutputIndex = 0,
+        };
+        var destDb = new Channel
+        {
+            Id = 102, ChanId = 1002, Status = Channel.ChannelStatus.Open,
+            IsDynamicFeeEnabled = true, IsAutoRebalanceEnabled = false,
+            FundingTx = "txD", FundingTxOutputIndex = 0,
+        };
+        _channelRepository.Setup(x => x.GetOpenChannels()).ReturnsAsync(new List<Channel> { sourceDb, destDb });
+
+        _routingStateRepository.Setup(x => x.GetByManagedNodePubKey(NodePubKey)).ReturnsAsync(new List<ChannelRoutingState>
+        {
+            new() { ChannelId = 101, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1001, EmaLocalRatio = 0.75, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Source },
+            new() { ChannelId = 102, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1002, EmaLocalRatio = 0.10, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Sink },
+        });
+        _feeStateRepository.Setup(x => x.GetByManagedNodePubKey(NodePubKey)).ReturnsAsync(new List<ChannelFeeState>());
+
+        _rebalanceRepository.Setup(x => x.GetPendingInFlightSourceChannelIds()).ReturnsAsync(new HashSet<int>());
+        _rebalanceRepository.Setup(x => x.GetConsumedFeesSince(node.Id, It.IsAny<DateTimeOffset>())).ReturnsAsync(0L);
+        _rebalanceRepository.Setup(x => x.GetInFlightByNode(node.Id)).ReturnsAsync(0);
+
+        var listResp = new Lnrpc.ListChannelsResponse
+        {
+            Channels =
+            {
+                new Lnrpc.Channel { ChanId = 1001, Capacity = 20_000_000, LocalBalance = 15_000_000, RemoteBalance = 5_000_000, Active = true, Initiator = true, RemotePubkey = "peerS" },
+                new Lnrpc.Channel { ChanId = 1002, Capacity = 20_000_000, LocalBalance = 2_000_000, RemoteBalance = 18_000_000, Active = true, Initiator = true, RemotePubkey = "peerD" },
+            },
+        };
+        _lightningClientService
+            .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
+            .ReturnsAsync(listResp);
+
+        _lightningService.Setup(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()))
+            .ReturnsAsync(new Dictionary<ulong, long> { [1001] = 50, [1002] = 2500 });
+
+        _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Rebalance());
+    }
+
+
+    [Fact]
+    public async Task Execute_DispatchesThePlannedRebalance()
+    {
+        ArrangeRebalancePair(sourceOptedIn: true);
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        // Source 101 -> dest peer "peerD", sized to the excess, gate 0.5 x 2500ppm.
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.Is<RebalanceRequest>(r => r.SourceChannelId == 101 && r.TargetPubkey == "peerD"
+                && r.AmountSats == 5_000_000 && !r.IsManual
+                && r.MaxFeePct.HasValue && Math.Abs(r.MaxFeePct.Value - 0.125) < 1e-9),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotWaitForTheRebalanceToSettle()
+    {
+        ArrangeRebalancePair(sourceOptedIn: true);
+
+        // A payment that never resolves. Dispatch is fire-and-forget, so the run has to finish
+        // anyway; if it were awaited this would block until the test timed out.
+        var neverSettles = new TaskCompletionSource<Rebalance>();
+        _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(neverSettles.Task);
+
+        await WithEngine(enabled: true, async () =>
+        {
+            var run = BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+            var first = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(run, first); // the run must not block on the payment
+            await run;
+        });
+
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.False(neverSettles.Task.IsCompleted); // the payment is still outstanding
+    }
+
+    [Fact]
+    public async Task Execute_KillSwitchOff_DoesNothing()
+    {
+        ArrangeRebalancePair(sourceOptedIn: true);
+
+        await WithEngine(enabled: false, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        _nodeRepository.Verify(x => x.GetAllManagedByNodeGuard(It.IsAny<bool>()), Times.Never);
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_SwapLiquidityFlagAloneDoesNotOptAChannelIn()
+    {
+        // The rebalancer used to borrow IsAutomatedLiquidityEnabled, which means "opted into
+        // swap-based liquidity rules". They are separate opt-ins now: a channel carrying only the
+        // swap flag must not be drained.
+        ArrangeRebalancePair(sourceOptedIn: false, sourceLiquidityFlag: true);
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Two drainable sources and two depleted destination peers, so the planner produces two plans,
+    /// on a node pinned to one in-flight rebalance so the second plan is dropped. Pairing is
+    /// first-fit in classification order, so chan 1001 pairs with peerD1 and chan 1003 with peerD2.
+    /// </summary>
+    private void ArrangeTwoRebalancePairs()
+    {
+        var node = new Node
+        {
+            Id = 20,
+            PubKey = NodePubKey,
+            Name = "alice",
+            // Fee pass off: this test is only about rebalance dispatch accounting.
+            DynamicFeeManagementEnabled = false,
+            AutoRebalanceEnabled = true,
+            RebalanceBudgetSats = 1_000_000,
+            MaxRebalanceCostToEarnRatio = 0.5,
+            // Pinned, not inherited: this test asserts the drop path, so the cap has to be 1 here
+            // regardless of what ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT is set to.
+            MaxRebalancesInFlight = 1,
+        };
+        _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node });
+
+        Channel Db(int id, ulong chanId, bool optIn) => new()
+        {
+            Id = id, ChanId = chanId, Status = Channel.ChannelStatus.Open,
+            IsAutoRebalanceEnabled = optIn,
+            FundingTx = $"tx{id}", FundingTxOutputIndex = 0,
+        };
+
+        _channelRepository.Setup(x => x.GetOpenChannels()).ReturnsAsync(new List<Channel>
+        {
+            Db(101, 1001, optIn: true),  // source 1
+            Db(102, 1002, optIn: false), // destination 1
+            Db(103, 1003, optIn: true),  // source 2
+            Db(104, 1004, optIn: false), // destination 2
+        });
+
+        _routingStateRepository.Setup(x => x.GetByManagedNodePubKey(NodePubKey)).ReturnsAsync(new List<ChannelRoutingState>
+        {
+            new() { ChannelId = 101, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1001, EmaLocalRatio = 0.75, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Source },
+            new() { ChannelId = 102, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1002, EmaLocalRatio = 0.10, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Sink },
+            new() { ChannelId = 103, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1003, EmaLocalRatio = 0.75, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Source },
+            new() { ChannelId = 104, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1004, EmaLocalRatio = 0.10, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Sink },
+        });
+        _feeStateRepository.Setup(x => x.GetByManagedNodePubKey(NodePubKey)).ReturnsAsync(new List<ChannelFeeState>());
+
+        _rebalanceRepository.Setup(x => x.GetPendingInFlightSourceChannelIds()).ReturnsAsync(new HashSet<int>());
+        _rebalanceRepository.Setup(x => x.GetConsumedFeesSince(node.Id, It.IsAny<DateTimeOffset>())).ReturnsAsync(0L);
+        _rebalanceRepository.Setup(x => x.GetInFlightByNode(node.Id)).ReturnsAsync(0);
+
+        Lnrpc.Channel Lnd(ulong chanId, long local, long remote, string peer) => new()
+        {
+            ChanId = chanId, Capacity = 20_000_000, LocalBalance = local, RemoteBalance = remote,
+            Active = true, Initiator = true, RemotePubkey = peer,
+        };
+
+        _lightningClientService
+            .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
+            .ReturnsAsync(new Lnrpc.ListChannelsResponse
+            {
+                Channels =
+                {
+                    Lnd(1001, 15_000_000, 5_000_000, "peerS1"),
+                    Lnd(1002, 2_000_000, 18_000_000, "peerD1"),
+                    Lnd(1003, 15_000_000, 5_000_000, "peerS2"),
+                    Lnd(1004, 2_000_000, 18_000_000, "peerD2"),
+                },
+            });
+
+        _lightningService.Setup(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()))
+            .ReturnsAsync(new Dictionary<ulong, long>
+            {
+                [1001] = 50, [1002] = 2500, [1003] = 60, [1004] = 2400,
+            });
+
+        _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Rebalance());
+    }
+
+    [Fact]
+    public async Task Execute_LogsPlansDroppedByTheInFlightCap()
+    {
+        ArrangeTwoRebalancePairs();
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        // The cap is 1, so only the first plan is dispatched...
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.Is<RebalanceRequest>(r => r.SourceChannelId == 101 && r.TargetPubkey == "peerD1"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // ...and the plan the cap ate is reported rather than silently discarded.
+        _logger.Verify(x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("dropped 1 of 2 planned rebalance(s)")
+                                          && v.ToString()!.Contains("in-flight cap reached (1/1")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+
+        // The dropped plan's own details, so an operator can see what was left on the table.
+        _logger.Verify(x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("dropped plan")
+                                          && v.ToString()!.Contains("drain chan 1003")
+                                          && v.ToString()!.Contains("refill peer peerD2")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_PricesEveryChannelInOneRoundTrip()
+    {
+        // Each GetChanInfo is an LND round-trip, so only channels whose rate drives a decision are
+        // priced. Chan 1003 is a fallback source (live local 0.70 but ema 0.60, so it never tripped
+        // the +0.15 trigger) and fallback sources are chosen by balance, never by cost.
+        var node = new Node
+        {
+            Id = 20,
+            PubKey = NodePubKey,
+            Name = "alice",
+            AutoRebalanceEnabled = true,
+            RebalanceBudgetSats = 1_000_000,
+            MaxRebalancesInFlight = 5,
+            MaxRebalanceCostToEarnRatio = 0.5,
+        };
+        _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node });
+
+        Channel Db(int id, ulong chanId, bool optIn) => new()
+        {
+            Id = id, ChanId = chanId, Status = Channel.ChannelStatus.Open,
+            IsAutoRebalanceEnabled = optIn, FundingTx = $"tx{id}", FundingTxOutputIndex = 0,
+        };
+        _channelRepository.Setup(x => x.GetOpenChannels()).ReturnsAsync(new List<Channel>
+        {
+            Db(101, 1001, optIn: true),   // detected source
+            Db(102, 1002, optIn: false),  // detected destination
+            Db(103, 1003, optIn: true),   // fallback source only
+        });
+
+        _routingStateRepository.Setup(x => x.GetByManagedNodePubKey(NodePubKey)).ReturnsAsync(new List<ChannelRoutingState>
+        {
+            new() { ChannelId = 101, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1001, EmaLocalRatio = 0.75, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Source },
+            new() { ChannelId = 102, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1002, EmaLocalRatio = 0.10, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Sink },
+            new() { ChannelId = 103, ManagedNodePubKey = NodePubKey, ChanIdLnd = 1003, EmaLocalRatio = 0.60, TargetLocalRatio = 0.50, PeerFlowCategory = PeerFlowCategory.Bidirectional },
+        });
+
+        _rebalanceRepository.Setup(x => x.GetPendingInFlightSourceChannelIds()).ReturnsAsync(new HashSet<int>());
+        _rebalanceRepository.Setup(x => x.GetConsumedFeesSince(node.Id, It.IsAny<DateTimeOffset>())).ReturnsAsync(0L);
+        _rebalanceRepository.Setup(x => x.GetInFlightByNode(node.Id)).ReturnsAsync(0);
+
+        _lightningClientService
+            .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
+            .ReturnsAsync(new Lnrpc.ListChannelsResponse
+            {
+                Channels =
+                {
+                    new Lnrpc.Channel { ChanId = 1001, Capacity = 20_000_000, LocalBalance = 15_000_000, RemoteBalance = 5_000_000, Active = true, RemotePubkey = "peerS" },
+                    new Lnrpc.Channel { ChanId = 1002, Capacity = 20_000_000, LocalBalance = 2_000_000, RemoteBalance = 18_000_000, Active = true, RemotePubkey = "peerD" },
+                    new Lnrpc.Channel { ChanId = 1003, Capacity = 20_000_000, LocalBalance = 14_000_000, RemoteBalance = 6_000_000, Active = true, RemotePubkey = "peerF" },
+                },
+            });
+
+        _lightningService.Setup(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()))
+            .ReturnsAsync(new Dictionary<ulong, long> { [1001] = 2000, [1002] = 2000, [1003] = 2000 });
+        _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Rebalance());
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        // Three channels across a detected source, a detected destination and a fallback source —
+        // all priced by ONE round-trip. The old per-channel path cost a GetChanInfo each and had to
+        // reason about which subset the planner would consult; FeeReport removes that decision.
+        _lightningService.Verify(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()), Times.Once);
+        _lightningService.Verify(x => x.GetLocalOutboundFeeRatePpmAsync(
+            It.IsAny<Node>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_FeeReportUnavailable_SkipsTheNodeWithoutDispatching()
+    {
+        ArrangeRebalancePair(sourceOptedIn: true);
+        // Null, not an empty map: no rate for any channel means nothing can be profit-gated, and
+        // treating that as "everything earns zero" would silently drop every plan as unprofitable.
+        _lightningService.Setup(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()))
+            .ReturnsAsync((Dictionary<ulong, long>?)null);
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        _rebalanceService.Verify(x => x.RebalanceAsync(
+            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Skipped deliberately, not by blowing up: without the warning this test would also pass
+        // if BuildPlans threw on a null map and the per-node catch swallowed it.
+        _logger.Verify(x => x.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("FeeReport unavailable")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+        _logger.Verify(x => x.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Never);
+    }
+}

--- a/test/NodeGuard.Tests/Jobs/AutoRebalanceJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/AutoRebalanceJobTests.cs
@@ -23,6 +23,7 @@ using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.Helpers;
 using NodeGuard.Services;
 using NodeGuard.Tests.Helpers;
+using NodeGuard.Tests.Jobs;
 using Quartz;
 using Channel = NodeGuard.Data.Models.Channel;
 
@@ -44,6 +45,7 @@ public class AutoRebalanceJobTests
     private readonly Mock<IRebalanceService> _rebalanceService = new();
     private readonly Mock<ILightningService> _lightningService = new();
     private readonly Mock<ILightningClientService> _lightningClientService = new();
+    private readonly Mock<IAuditService> _auditService = new();
 
     // The real snapshot service over the mocked repos/LND, so these tests still cover the
     // open-channel + routing-state filtering that feeds the job.
@@ -53,6 +55,26 @@ public class AutoRebalanceJobTests
             _feeStateRepository.Object,
             _lightningClientService.Object);
 
+    /// <summary>A NodeGuard channel row the rebalancer will consider, opted in or not.</summary>
+    private static Channel Db(int id, ulong chanId, bool optIn) => new()
+    {
+        Id = id, ChanId = chanId, Status = Channel.ChannelStatus.Open,
+        IsAutoRebalanceEnabled = optIn,
+        FundingTx = $"tx{id}", FundingTxOutputIndex = 0,
+    };
+
+    /// <summary>The matching LND channel, with the balances that drive sizing.</summary>
+    private static Lnrpc.Channel Lnd(ulong chanId, long local, long remote, string peer) => new()
+    {
+        ChanId = chanId, Capacity = 20_000_000, LocalBalance = local, RemoteBalance = remote,
+        Active = true, Initiator = true, RemotePubkey = peer,
+    };
+
+    /// <summary>
+    /// A scope factory whose scope hands back <see cref="_rebalanceService"/>, mirroring how the job
+    /// resolves a fresh IRebalanceService per dispatch so the payment doesn't run on the job's own
+    /// (soon-disposed) scope.
+    /// </summary>
     private AutoRebalanceJob BuildJob() =>
         new(
             _logger.Object,
@@ -61,21 +83,9 @@ public class AutoRebalanceJobTests
             _rebalanceRepository.Object,
             _rebalanceService.Object,
             BuildSnapshotService(),
-            _lightningService.Object);
+            _lightningService.Object,
+            _auditService.Object);
 
-    private static async Task WithEngine(bool enabled, Func<Task> body)
-    {
-        var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
-        Constants.ROUTING_ENGINE_ENABLED = enabled;
-        try
-        {
-            await body();
-        }
-        finally
-        {
-            Constants.ROUTING_ENGINE_ENABLED = prevEnabled;
-        }
-    }
 
 
     /// <summary>
@@ -150,7 +160,7 @@ public class AutoRebalanceJobTests
     {
         ArrangeRebalancePair(sourceOptedIn: true);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -164,27 +174,34 @@ public class AutoRebalanceJobTests
     }
 
     [Fact]
-    public async Task Execute_DoesNotWaitForTheRebalanceToSettle()
+    public async Task Execute_AwaitsEachPayment_BeforeDispatchingTheNext()
     {
-        ArrangeRebalancePair(sourceOptedIn: true);
+        ArrangeTwoRebalancePairs(maxRebalancesInFlight: 5);
 
-        // A payment that never resolves. Dispatch is fire-and-forget, so the run has to finish
-        // anyway; if it were awaited this would block until the test timed out.
-        var neverSettles = new TaskCompletionSource<Rebalance>();
+        // Two payments we control. Everything else the job awaits is mocked with completed tasks, so
+        // Execute runs straight through and hands the task back only once it is parked on the first
+        // payment — which is what makes the assertions below deterministic rather than timing-based.
+        var first = new TaskCompletionSource<Rebalance>();
+        var second = new TaskCompletionSource<Rebalance>();
+        var started = 0;
         _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
-            .Returns(neverSettles.Task);
+            .Returns(() => Interlocked.Increment(ref started) == 1 ? first.Task : second.Task);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             var run = BuildJob().Execute(Mock.Of<IJobExecutionContext>());
-            var first = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
-            Assert.Same(run, first); // the run must not block on the payment
-            await run;
-        });
 
-        _rebalanceService.Verify(x => x.RebalanceAsync(
-            It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-        Assert.False(neverSettles.Task.IsCompleted); // the payment is still outstanding
+            // Detached dispatch would have finished the run; concurrent dispatch would have started
+            // both payments. Being parked after exactly one is what "awaits each" means.
+            Assert.False(run.IsCompleted);
+            Assert.Equal(1, started);
+
+            first.SetResult(new Rebalance());
+            second.SetResult(new Rebalance());
+
+            await run;
+            Assert.Equal(2, started);
+        });
     }
 
     [Fact]
@@ -192,7 +209,7 @@ public class AutoRebalanceJobTests
     {
         ArrangeRebalancePair(sourceOptedIn: true);
 
-        await WithEngine(enabled: false, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: false, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -210,7 +227,7 @@ public class AutoRebalanceJobTests
         // swap flag must not be drained.
         ArrangeRebalancePair(sourceOptedIn: false, sourceLiquidityFlag: true);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -224,7 +241,7 @@ public class AutoRebalanceJobTests
     /// on a node pinned to one in-flight rebalance so the second plan is dropped. Pairing is
     /// first-fit in classification order, so chan 1001 pairs with peerD1 and chan 1003 with peerD2.
     /// </summary>
-    private void ArrangeTwoRebalancePairs()
+    private void ArrangeTwoRebalancePairs(int maxRebalancesInFlight = 1)
     {
         var node = new Node
         {
@@ -236,18 +253,12 @@ public class AutoRebalanceJobTests
             AutoRebalanceEnabled = true,
             RebalanceBudgetSats = 1_000_000,
             MaxRebalanceCostToEarnRatio = 0.5,
-            // Pinned, not inherited: this test asserts the drop path, so the cap has to be 1 here
-            // regardless of what ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT is set to.
-            MaxRebalancesInFlight = 1,
+            // Pinned, not inherited, so the cap tests don't depend on
+            // ROUTING_ENGINE_REBALANCE_DEFAULT_MAX_IN_FLIGHT.
+            MaxRebalancesInFlight = maxRebalancesInFlight,
         };
         _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node });
 
-        Channel Db(int id, ulong chanId, bool optIn) => new()
-        {
-            Id = id, ChanId = chanId, Status = Channel.ChannelStatus.Open,
-            IsAutoRebalanceEnabled = optIn,
-            FundingTx = $"tx{id}", FundingTxOutputIndex = 0,
-        };
 
         _channelRepository.Setup(x => x.GetOpenChannels()).ReturnsAsync(new List<Channel>
         {
@@ -270,11 +281,6 @@ public class AutoRebalanceJobTests
         _rebalanceRepository.Setup(x => x.GetConsumedFeesSince(node.Id, It.IsAny<DateTimeOffset>())).ReturnsAsync(0L);
         _rebalanceRepository.Setup(x => x.GetInFlightByNode(node.Id)).ReturnsAsync(0);
 
-        Lnrpc.Channel Lnd(ulong chanId, long local, long remote, string peer) => new()
-        {
-            ChanId = chanId, Capacity = 20_000_000, LocalBalance = local, RemoteBalance = remote,
-            Active = true, Initiator = true, RemotePubkey = peer,
-        };
 
         _lightningClientService
             .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
@@ -304,7 +310,7 @@ public class AutoRebalanceJobTests
     {
         ArrangeTwoRebalancePairs();
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -341,9 +347,6 @@ public class AutoRebalanceJobTests
     [Fact]
     public async Task Execute_PricesEveryChannelInOneRoundTrip()
     {
-        // Each GetChanInfo is an LND round-trip, so only channels whose rate drives a decision are
-        // priced. Chan 1003 is a fallback source (live local 0.70 but ema 0.60, so it never tripped
-        // the +0.15 trigger) and fallback sources are chosen by balance, never by cost.
         var node = new Node
         {
             Id = 20,
@@ -356,11 +359,6 @@ public class AutoRebalanceJobTests
         };
         _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node });
 
-        Channel Db(int id, ulong chanId, bool optIn) => new()
-        {
-            Id = id, ChanId = chanId, Status = Channel.ChannelStatus.Open,
-            IsAutoRebalanceEnabled = optIn, FundingTx = $"tx{id}", FundingTxOutputIndex = 0,
-        };
         _channelRepository.Setup(x => x.GetOpenChannels()).ReturnsAsync(new List<Channel>
         {
             Db(101, 1001, optIn: true),   // detected source
@@ -396,7 +394,7 @@ public class AutoRebalanceJobTests
         _rebalanceService.Setup(x => x.RebalanceAsync(It.IsAny<RebalanceRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Rebalance());
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -418,7 +416,7 @@ public class AutoRebalanceJobTests
         _lightningService.Setup(x => x.GetLocalOutboundFeeRatesPpmAsync(It.IsAny<Node>()))
             .ReturnsAsync((Dictionary<ulong, long>?)null);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });

--- a/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
@@ -23,6 +23,7 @@ using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.Helpers;
 using NodeGuard.Services;
 using NodeGuard.Tests.Helpers;
+using NodeGuard.Tests.Jobs;
 using Quartz;
 using Channel = NodeGuard.Data.Models.Channel;
 
@@ -145,19 +146,6 @@ public class ChannelFeeOptimizerJobTests
             BuildSnapshotService(),
             _lightningService.Object);
 
-    private static async Task WithEngine(bool enabled, Func<Task> body)
-    {
-        var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
-        Constants.ROUTING_ENGINE_ENABLED = enabled;
-        try
-        {
-            await body();
-        }
-        finally
-        {
-            Constants.ROUTING_ENGINE_ENABLED = prevEnabled;
-        }
-    }
 
     [Fact]
     public async Task Execute_LiveNode_AppliesComputedPolicy()
@@ -165,7 +153,7 @@ public class ChannelFeeOptimizerJobTests
         var node = BuildNode();
         ArrangeSingleSinkChannel(node, inFlightRebalance: false);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -181,7 +169,7 @@ public class ChannelFeeOptimizerJobTests
         var node = BuildNode();
         ArrangeSingleSinkChannel(node, inFlightRebalance: true);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -199,7 +187,7 @@ public class ChannelFeeOptimizerJobTests
         var node = BuildNode();
         ArrangeSingleSinkChannel(node, inFlightRebalance: false);
 
-        await WithEngine(enabled: false, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: false, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -410,7 +398,7 @@ public class ChannelFeeOptimizerJobTests
                 },
             });
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });
@@ -425,7 +413,7 @@ public class ChannelFeeOptimizerJobTests
         var node = BuildNode();
         ArrangeSingleSinkChannel(node, inFlightRebalance: false);
 
-        await WithEngine(enabled: true, async () =>
+        await RoutingEngineSwitch.WithEngine(enabled: true, async () =>
         {
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
         });

--- a/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/ChannelFeeOptimizerJobTests.cs
@@ -28,20 +28,37 @@ using Channel = NodeGuard.Data.Models.Channel;
 
 namespace NodeGuard.Jobs;
 
+
+[Collection("RoutingEngine")]
 public class ChannelFeeOptimizerJobTests
 {
     private const string NodePubKey = "managedPubKey";
     private const ulong ChanId = 123;
     private const int ChannelDbId = 10;
 
+    // The arranged channel is comfortably above ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS (10M).
+    // Kept as one constant because the job gates on the DB SatsAmount while the control law reads
+    // the LND balances — if the two drift the channel is silently filtered out of every test.
+    private const long ChannelSizeSats = 16_000_000;
+
+    private readonly Mock<ILogger<ChannelFeeOptimizerJob>> _logger = new();
+
     private readonly Mock<INodeRepository> _nodeRepository = new();
     private readonly Mock<IChannelRepository> _channelRepository = new();
     private readonly Mock<IChannelRoutingStateRepository> _routingStateRepository = new();
     private readonly Mock<IChannelFeeStateRepository> _feeStateRepository = new();
-    private readonly Mock<IForwardingHtlcEventRepository> _forwardingHtlcEventRepository = new();
     private readonly Mock<IRebalanceRepository> _rebalanceRepository = new();
+    private readonly Mock<IRebalanceService> _rebalanceService = new();
     private readonly Mock<ILightningService> _lightningService = new();
     private readonly Mock<ILightningClientService> _lightningClientService = new();
+
+    // The real snapshot service over the mocked repos/LND, so these tests still cover the
+    // open-channel + routing-state filtering that feeds the job.
+    private IRoutingEngineSnapshotService BuildSnapshotService() =>
+        new RoutingEngineSnapshotService(
+            _routingStateRepository.Object,
+            _feeStateRepository.Object,
+            _lightningClientService.Object);
 
     private Node BuildNode() => new()
     {
@@ -61,11 +78,12 @@ public class ChannelFeeOptimizerJobTests
             Id = ChannelDbId,
             ChanId = ChanId,
             Status = Channel.ChannelStatus.Open,
+            SatsAmount = ChannelSizeSats,
             IsDynamicFeeEnabled = true,
             FundingTx = "txid123",
             FundingTxOutputIndex = 1,
         };
-        _channelRepository.Setup(x => x.GetChannelsByOpenAndDynamicFeeEnabled())
+        _channelRepository.Setup(x => x.GetOpenChannels())
             .ReturnsAsync(new List<Channel> { dbChannel });
 
         // Too remote (ema 0.40 < target 0.50) + Sink → raise outbound, negative inbound.
@@ -92,7 +110,7 @@ public class ChannelFeeOptimizerJobTests
                 new Lnrpc.Channel
                 {
                     ChanId = ChanId,
-                    Capacity = 16_000_000,
+                    Capacity = ChannelSizeSats,
                     LocalBalance = 4_000_000,
                     RemoteBalance = 12_000_000,
                     Active = true,
@@ -119,14 +137,13 @@ public class ChannelFeeOptimizerJobTests
 
     private ChannelFeeOptimizerJob BuildJob() =>
         new(
-            new Mock<ILogger<ChannelFeeOptimizerJob>>().Object,
+            _logger.Object,
             _nodeRepository.Object,
             _channelRepository.Object,
-            _routingStateRepository.Object,
             _feeStateRepository.Object,
             _rebalanceRepository.Object,
-            _lightningService.Object,
-            _lightningClientService.Object);
+            BuildSnapshotService(),
+            _lightningService.Object);
 
     private static async Task WithEngine(bool enabled, Func<Task> body)
     {
@@ -235,7 +252,7 @@ public class ChannelFeeOptimizerJobTests
 
             await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
 
-            _channelRepository.Verify(x => x.GetChannelsByOpenAndDynamicFeeEnabled(), Times.Never);
+            _channelRepository.Verify(x => x.GetOpenChannels(), Times.Never);
             VerifyNoFeeWrite();
         }
         finally
@@ -274,7 +291,8 @@ public class ChannelFeeOptimizerJobTests
         var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
         var prevMinSize = Constants.ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS;
         Constants.ROUTING_ENGINE_ENABLED = true;
-        Constants.ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS = 20_000_000; // the arranged channel is 16M
+        // One sat above the arranged channel, so this pins the exact boundary of the size gate.
+        Constants.ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS = ChannelSizeSats + 1;
         try
         {
             var node = BuildNode();
@@ -357,4 +375,66 @@ public class ChannelFeeOptimizerJobTests
             Constants.ROUTING_ENGINE_ENABLED = prevEnabled;
         }
     }
+
+    [Fact]
+    public async Task Execute_ChannelSharedWithAnotherManagedNode_IsStillActuated()
+    {
+        var node = BuildNode();
+        ArrangeSingleSinkChannel(node, inFlightRebalance: false);
+
+        // The peer is also managed by NodeGuard and it opened the channel. The old ownership dedup
+        // handed the channel to the initiator alone, so this side was never actuated: it could not
+        // see its own depleted channel as a rebalance destination and its outbound policy was
+        // frozen. Both sides now carry their own state and both get actuated.
+        var peer = new Node { Id = 21, PubKey = "peerPubKey", Name = "bob", DynamicFeeManagementEnabled = true };
+        _nodeRepository.Setup(x => x.GetAllManagedByNodeGuard(false)).ReturnsAsync(new List<Node> { node, peer });
+        _routingStateRepository.Setup(x => x.GetByManagedNodePubKey(peer.PubKey)).ReturnsAsync(new List<ChannelRoutingState>());
+        _feeStateRepository.Setup(x => x.GetByManagedNodePubKey(peer.PubKey)).ReturnsAsync(new List<ChannelFeeState>());
+
+        _lightningClientService
+            .Setup(x => x.ListChannels(It.IsAny<Node>(), It.IsAny<Lnrpc.Lightning.LightningClient>()))
+            .ReturnsAsync(new Lnrpc.ListChannelsResponse
+            {
+                Channels =
+                {
+                    new Lnrpc.Channel
+                    {
+                        ChanId = ChanId,
+                        Capacity = ChannelSizeSats,
+                        LocalBalance = 4_000_000,
+                        RemoteBalance = 12_000_000,
+                        Active = true,
+                        Initiator = false, // the managed peer opened it
+                        RemotePubkey = peer.PubKey,
+                    },
+                },
+            });
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        _lightningService.Verify(x => x.SetChannelFeePolicy(
+            "txid123:1", NodePubKey, 1000, 2550u, 40u, 0, -50, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_ColdStartFeeState_IsStampedWithTheActuatingNode()
+    {
+        var node = BuildNode();
+        ArrangeSingleSinkChannel(node, inFlightRebalance: false);
+
+        await WithEngine(enabled: true, async () =>
+        {
+            await BuildJob().Execute(Mock.Of<IJobExecutionContext>());
+        });
+
+        // A fee state created from scratch must name its node, or it lands outside every
+        // per-node query and the control loop cold-starts forever.
+        _feeStateRepository.Verify(x => x.UpsertByChannelAndNode(
+            It.Is<ChannelFeeState>(f => f.ChannelId == ChannelDbId && f.ManagedNodePubKey == NodePubKey)),
+            Times.Once);
+    }
+
 }

--- a/test/NodeGuard.Tests/Jobs/RoutingEngineCollection.cs
+++ b/test/NodeGuard.Tests/Jobs/RoutingEngineCollection.cs
@@ -17,6 +17,8 @@
  *
  */
 
+using NodeGuard.Helpers;
+
 namespace NodeGuard.Tests.Jobs;
 
 /// <summary>
@@ -27,4 +29,29 @@ namespace NodeGuard.Tests.Jobs;
 [CollectionDefinition("RoutingEngine", DisableParallelization = true)]
 public class RoutingEngineCollection
 {
+}
+
+/// <summary>
+/// Helpers shared by the routing-engine job tests.
+/// </summary>
+public static class RoutingEngineSwitch
+{
+    /// <summary>
+    /// Runs <paramref name="body"/> with the global kill switch forced to <paramref name="enabled"/>,
+    /// restoring the previous value afterwards even if the body throws. One copy, because a missed
+    /// restore leaks static state into every other class in the collection.
+    /// </summary>
+    public static async Task WithEngine(bool enabled, Func<Task> body)
+    {
+        var prevEnabled = Constants.ROUTING_ENGINE_ENABLED;
+        Constants.ROUTING_ENGINE_ENABLED = enabled;
+        try
+        {
+            await body();
+        }
+        finally
+        {
+            Constants.ROUTING_ENGINE_ENABLED = prevEnabled;
+        }
+    }
 }

--- a/test/NodeGuard.Tests/Jobs/RoutingEngineCollection.cs
+++ b/test/NodeGuard.Tests/Jobs/RoutingEngineCollection.cs
@@ -1,0 +1,30 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+namespace NodeGuard.Tests.Jobs;
+
+/// <summary>
+/// The routing-engine job tests share this collection so they run sequentially: they tune the
+/// engine by assigning to the static <c>Constants.ROUTING_ENGINE_*</c> fields and restore them in
+/// a finally block, so running the classes in parallel lets one class observe another's tuning.
+/// </summary>
+[CollectionDefinition("RoutingEngine", DisableParallelization = true)]
+public class RoutingEngineCollection
+{
+}

--- a/test/NodeGuard.Tests/Jobs/TargetRatioReevaluationJobTests.cs
+++ b/test/NodeGuard.Tests/Jobs/TargetRatioReevaluationJobTests.cs
@@ -30,7 +30,7 @@ using Channel = NodeGuard.Data.Models.Channel;
 namespace NodeGuard.Jobs;
 
 /// <summary>
-/// Wiring tests for the Phase-1 sensor/classifier. The pure categorization math lives in
+/// Wiring tests for the sensor/classifier. The pure categorization math lives in
 /// <see cref="PeerCategorizationServiceTests"/>; here the real <see cref="PeerCategorizationService"/>
 /// is used so these prove the JOB feeds it correctly: age gate, ownership/eligibility filter, the
 /// push/pull → net-flow sign convention, first-insert EMA seeding, failure handling, and the kill switch.

--- a/test/NodeGuard.Tests/Services/RebalanceInitiatorServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/RebalanceInitiatorServiceTests.cs
@@ -1,0 +1,426 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+
+namespace NodeGuard.Services;
+
+public class RebalanceInitiatorServiceTests
+{
+    private static readonly RebalanceInitiatorTunables Tunables = new(
+        RebalanceTrigger: 0.15,
+        MinAmountSats: 10_000,
+        MaxAmountSats: 5_000_000,
+        CostToEarnRatio: 0.5,
+        MaxInitiations: 5);
+
+    private static ChannelSignal Chan(
+        int id, string peer, long local, long remote,
+        double ema, double target, bool active = true, bool optIn = true)
+        => new(id, (ulong)id, peer, local + remote, local, remote, ema, target, active, optIn);
+
+    // ── Classify: sources ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Classify_TooLocalOptedIn_BecomesSource_ExcessSizedOnLiveBalance()
+    {
+        // d = 0.80 - 0.50 = 0.30 > 0.15; targetLocal = 0.5 * 1_000_000 = 500_000; excess = 300_000.
+        var channels = new[] { Chan(1, "peerA", local: 800_000, remote: 200_000, ema: 0.80, target: 0.50) };
+
+        var result = RebalanceInitiatorService.Classify(channels, Tunables);
+
+        result.Sources.Should().ContainSingle();
+        result.Sources[0].ChannelId.Should().Be(1);
+        result.Sources[0].ExcessSats.Should().Be(300_000);
+    }
+
+    [Fact]
+    public void Classify_TooLocalButNotOptedIn_IsNotSource()
+    {
+        var channels = new[] { Chan(1, "peerA", 800_000, 200_000, 0.80, 0.50, optIn: false) };
+
+        RebalanceInitiatorService.Classify(channels, Tunables).Sources.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Classify_AboveTargetButWithinTrigger_IsNotSource()
+    {
+        // d = 0.60 - 0.50 = 0.10 <= 0.15 → not "too local" enough to drain.
+        var channels = new[] { Chan(1, "peerA", 600_000, 400_000, 0.60, 0.50) };
+
+        RebalanceInitiatorService.Classify(channels, Tunables).Sources.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Classify_InactiveChannel_IsNeitherSourceNorDestination()
+    {
+        var channels = new[] { Chan(1, "peerA", 900_000, 100_000, 0.90, 0.50, active: false) };
+
+        var result = RebalanceInitiatorService.Classify(channels, Tunables);
+
+        result.Sources.Should().BeEmpty();
+        result.Destinations.Should().BeEmpty();
+    }
+
+    // ── Classify: destinations (peer aggregate) ─────────────────────────────────────────
+
+    [Fact]
+    public void Classify_TooRemotePeer_BecomesDestination_WithDeficit()
+    {
+        // aggEma 0.20 vs target 0.50 → d = -0.30 < -0.15; deficit = 500_000 - 200_000 = 300_000.
+        var channels = new[] { Chan(1, "peerA", local: 200_000, remote: 800_000, ema: 0.20, target: 0.50) };
+
+        var result = RebalanceInitiatorService.Classify(channels, Tunables);
+
+        result.Destinations.Should().ContainSingle();
+        result.Destinations[0].PeerPubKey.Should().Be("peerA");
+        result.Destinations[0].DeficitSats.Should().Be(300_000);
+        result.Destinations[0].Members.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Classify_AggregatesMultipleChannelsToSamePeer()
+    {
+        // Chan A balanced (0.50), Chan B depleted (0.10); both base 1_000_000, target 0.50.
+        // aggEma = (0.50 + 0.10)/2 = 0.30 → d = -0.20 < -0.15.
+        // deficit = target 1_000_000 - peerLocal 600_000 = 400_000.
+        var channels = new[]
+        {
+            Chan(1, "peerA", 500_000, 500_000, 0.50, 0.50),
+            Chan(2, "peerA", 100_000, 900_000, 0.10, 0.50),
+        };
+
+        var result = RebalanceInitiatorService.Classify(channels, Tunables);
+
+        result.Destinations.Should().ContainSingle();
+        result.Destinations[0].DeficitSats.Should().Be(400_000);
+        result.Destinations[0].Members.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Classify_PeerAggregateWithinTrigger_IsNotDestination()
+    {
+        // aggEma 0.42 vs target 0.50 → d = -0.08, inside the 0.15 trigger.
+        var channels = new[] { Chan(1, "peerA", 420_000, 580_000, 0.42, 0.50) };
+
+        RebalanceInitiatorService.Classify(channels, Tunables).Destinations.Should().BeEmpty();
+    }
+
+    // ── BuildPlans ──────────────────────────────────────────────────────────────────────
+
+    private static RebalanceClassification Classify(params ChannelSignal[] channels)
+        => RebalanceInitiatorService.Classify(channels, Tunables);
+
+    [Fact]
+    public void BuildPlans_TakesTheFirstAvailableSource_RegardlessOfEarnRate()
+    {
+        // Two drainable sources on different peers; the FIRST one is the dear one (2000ppm vs 50ppm).
+        // Pairing is first-fit in classification order, so chan 1 is drained anyway — there is no
+        // cheapest-source preference. Listing it first is what makes this assertion meaningful.
+        var classification = Classify(
+            Chan(1, "dear", 800_000, 200_000, 0.80, 0.50),
+            Chan(2, "cheap", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 2000, [2] = 50, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].SourceChannelId.Should().Be(1);
+        plans[0].DestinationPeerPubKey.Should().Be("dest");
+    }
+
+    [Fact]
+    public void BuildPlans_ProfitGate_SetsMaxFeePctFromDestEarnRate()
+    {
+        var classification = Classify(
+            Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        // maxCostPpm = 0.5 * 2500 = 1250 → MaxFeePct = 1250 / 10_000 = 0.125.
+        plans.Should().ContainSingle();
+        plans[0].MaxFeePct.Should().BeApproximately(0.125, 1e-9);
+    }
+
+    [Fact]
+    public void BuildPlans_ZeroEarnDestination_IsSkipped()
+    {
+        var classification = Classify(
+            Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 0 }; // dest earns nothing
+
+        RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlans_DestinationWithoutKnownEarnRate_IsSkipped()
+    {
+        var classification = Classify(
+            Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50 }; // no entry for the dest channel
+
+        RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlans_AvoidsSamePeerPairing()
+    {
+        // Peer "A" is BOTH a too-local source (chan 1) and — thanks to a deeply depleted sibling
+        // (chan 2) — a too-remote destination in aggregate, and it is classified before peer "B".
+        // The only source is on peer "A", so A can't be refilled from itself; B is refilled instead.
+        var classification = Classify(
+            Chan(1, "A", 800_000, 200_000, 0.80, 0.50),        // source, peer A, excess 300_000
+            Chan(2, "A", 50_000, 2_950_000, 0.02, 0.50),       // pulls peer A aggregate too-remote
+            Chan(3, "B", 200_000, 800_000, 0.20, 0.50));       // destination, peer B
+        var earn = new Dictionary<int, long> { [1] = 4000, [2] = 4000, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].SourceChannelId.Should().Be(1);
+        plans[0].DestinationPeerPubKey.Should().Be("B"); // NOT "A", despite A being tried first
+    }
+
+    [Fact]
+    public void BuildPlans_SizesToMinOfExcessAndDeficit()
+    {
+        // source excess 300_000, dest deficit 400_000 → amount 300_000.
+        var classification = Classify(
+            Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].AmountSats.Should().Be(300_000);
+    }
+
+    [Fact]
+    public void BuildPlans_ClampsAmountToMax()
+    {
+        // source excess 6_000_000, dest deficit 8_000_000, both above the 5_000_000 cap → amount 5_000_000.
+        var classification = Classify(
+            Chan(1, "src", 9_000_000, 3_000_000, 0.75, 0.25),   // excess = 9M - 3M = 6M
+            Chan(3, "dest", 2_000_000, 18_000_000, 0.10, 0.50)); // deficit = 10M - 2M = 8M
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].AmountSats.Should().Be(5_000_000);
+    }
+
+    [Fact]
+    public void BuildPlans_SkipsWhenSourceExcessBelowMin()
+    {
+        // Chan 1 qualifies as a source by the smoothed signal (ema 0.80 → d 0.30) but its LIVE excess
+        // is only 5_000 sats — below the 10_000 min — so it can't feed the depleted destination.
+        var classification = Classify(
+            Chan(1, "src", 505_000, 495_000, 0.80, 0.50),   // source, live excess = 505_000 - 500_000 = 5_000
+            Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+
+        classification.Sources.Should().ContainSingle();
+        classification.Sources[0].ExcessSats.Should().Be(5_000);
+        RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlans_UsesEachSourceAtMostOncePerRun()
+    {
+        // Two depleted destinations, a single drainable source → only one plan.
+        var classification = Classify(
+            Chan(1, "src", 5_000_000, 1_000_000, 0.83, 0.50),
+            Chan(3, "destA", 200_000, 800_000, 0.20, 0.50),
+            Chan(4, "destB", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500, [4] = 2400 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].SourceChannelId.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildPlans_RespectsMaxInitiationsCap()
+    {
+        var tunables = Tunables with { MaxInitiations = 1 };
+        var classification = Classify(
+            Chan(1, "srcA", 800_000, 200_000, 0.80, 0.50),
+            Chan(2, "srcB", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "destA", 200_000, 800_000, 0.20, 0.50),
+            Chan(4, "destB", 200_000, 800_000, 0.20, 0.50));
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500, [4] = 2400 };
+
+        RebalanceInitiatorService.BuildPlans(classification, earn, tunables).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void BuildPlans_WeightsDestinationEarnRateByBalanceBase()
+    {
+        // Dest peer has two channels: 1000ppm (base 1M) and 3000ppm (base 3M).
+        // Weighted avg = (1000·1M + 3000·3M) / 4M = 10_000M/4M = 2500ppm → maxFeePct = 0.5·2500/10_000 = 0.125.
+        var classification = Classify(
+            Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
+            Chan(3, "dest", 200_000, 800_000, 0.20, 0.50),      // base 1M
+            Chan(4, "dest", 600_000, 2_400_000, 0.20, 0.50));   // base 3M
+        var earn = new Dictionary<int, long> { [1] = 50, [3] = 1000, [4] = 3000 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].MaxFeePct.Should().BeApproximately(0.125, 1e-9);
+    }
+
+    // ── Fallback pairing: act on a detected imbalance even with no qualifying counterparty ──
+
+    [Fact]
+    public void Classify_ChannelInsideTheDeadband_LandsInBothFallbackPools()
+    {
+        // Perfectly on target: not a source, not a destination, but able to play either role.
+        // Lendable down to 0.35 → 500_000 - 350_000 = 150_000. Absorbable up to 0.65 → 150_000.
+        var result = Classify(Chan(1, "peerA", local: 500_000, remote: 500_000, ema: 0.50, target: 0.50));
+
+        result.Sources.Should().BeEmpty();
+        result.Destinations.Should().BeEmpty();
+        result.FallbackSources.Should().ContainSingle().Which.ExcessSats.Should().Be(150_000);
+        result.FallbackDestinations.Should().ContainSingle().Which.DeficitSats.Should().Be(150_000);
+    }
+
+    [Fact]
+    public void BuildPlans_SourceWithNoQualifyingDestination_DrainsIntoTheFirstFallbackPeerThatFits()
+    {
+        var classification = Classify(
+            Chan(1, "src", 800_000, 200_000, 0.80, 0.50),    // source, excess 300_000
+            Chan(2, "peerB", 500_000, 500_000, 0.50, 0.50),  // fallback dest, absorbable 150_000
+            Chan(3, "peerC", 450_000, 550_000, 0.45, 0.50)); // fallback dest, absorbable 200_000
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 2000, [3] = 2000 };
+
+        classification.Destinations.Should().BeEmpty("neither peer tripped the -0.15 trigger");
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].SourceChannelId.Should().Be(1);
+        // peerB, not the emptier peerC: pass 2 takes the first fallback destination that yields a
+        // plan, and has no preference for the one with the most room.
+        plans[0].DestinationPeerPubKey.Should().Be("peerB");
+        plans[0].IsFallbackPairing.Should().BeTrue();
+        // Capped by peerB's room up to target + deadband (650_000 - 500_000), NOT the source's
+        // full 300_000 excess — refilling must never turn the destination into next cycle's source.
+        plans[0].AmountSats.Should().Be(150_000);
+    }
+
+    [Fact]
+    public void BuildPlans_DestinationWithNoQualifyingSource_IsFundedByTheFirstFallbackChannel()
+    {
+        var classification = Classify(
+            Chan(1, "peerA", 600_000, 400_000, 0.60, 0.50),  // fallback source, lendable 250_000
+            Chan(2, "peerB", 900_000, 100_000, 0.55, 0.50),  // fallback source, lendable 550_000
+            Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));  // destination, deficit 400_000
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500 };
+
+        classification.Sources.Should().BeEmpty("neither peer tripped the +0.15 trigger");
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        // peerA, not the fuller peerB: the fallback pool is drawn from in classification order.
+        plans[0].SourceChannelId.Should().Be(1);
+        plans[0].DestinationPeerPubKey.Should().Be("dest");
+        plans[0].IsFallbackPairing.Should().BeTrue();
+        // Bounded by what peerA may lend (250_000), not the destination's full 400_000 deficit.
+        plans[0].AmountSats.Should().Be(250_000);
+    }
+
+    [Fact]
+    public void BuildPlans_FallbackSourceIsNotDrainedBelowItsOwnDeadband()
+    {
+        var classification = Classify(
+            Chan(1, "peerA", 400_000, 600_000, 0.40, 0.50), // fallback source: lendable to 0.35 = 50_000
+            Chan(2, "dest", 0, 1_000_000, 0.00, 0.50));     // destination, deficit 500_000
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        // 50_000, not the 400_000 it actually holds: lending stops at target - deadband so the
+        // fallback source can't become next cycle's destination.
+        plans[0].AmountSats.Should().Be(50_000);
+    }
+
+    [Fact]
+    public void BuildPlans_FallbackPairingIsStillProfitGated()
+    {
+        var classification = Classify(
+            Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
+            Chan(2, "peerB", 500_000, 500_000, 0.50, 0.50));
+        // The only available destination earns nothing, so there is no margin to pay a route with.
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 0 };
+
+        RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlans_RefillsAFallbackDestinationAtMostOncePerRun()
+    {
+        // Two drainable sources, and the only fallback destination has room for 150_000. Each plan
+        // is clamped to that room on its own, so without a per-run guard both sources would send
+        // peerX 150_000 and land it 300_000 above where it started — past target + deadband, making
+        // the peer we just refilled next cycle's source.
+        var classification = Classify(
+            Chan(1, "srcA", 800_000, 200_000, 0.80, 0.50),   // detected source, excess 300_000
+            Chan(2, "srcB", 800_000, 200_000, 0.80, 0.50),   // detected source, excess 300_000
+            Chan(3, "peerX", 500_000, 500_000, 0.50, 0.50)); // fallback dest, absorbable 150_000
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 50, [3] = 2000 };
+
+        classification.Destinations.Should().BeEmpty("peerX did not trip the -0.15 trigger");
+        classification.FallbackDestinations.Should().ContainSingle()
+            .Which.DeficitSats.Should().Be(150_000);
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle("peerX has room for one refill, not one per source");
+        plans[0].DestinationPeerPubKey.Should().Be("peerX");
+        plans[0].AmountSats.Should().Be(150_000);
+        plans.Sum(p => p.AmountSats).Should().Be(150_000, "the peer's room is a per-run allowance");
+    }
+
+    [Fact]
+    public void BuildPlans_PrefersAQualifyingSourceOverAFallbackOne()
+    {
+        var classification = Classify(
+            Chan(1, "src", 800_000, 200_000, 0.80, 0.50),    // qualifying source
+            Chan(2, "peerB", 950_000, 50_000, 0.55, 0.50),   // fallback source, far more to lend
+            Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));  // destination
+        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500 };
+
+        var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
+
+        plans.Should().ContainSingle();
+        plans[0].SourceChannelId.Should().Be(1, "a channel that tripped the trigger is drained before one that did not");
+        plans[0].IsFallbackPairing.Should().BeFalse();
+    }
+}

--- a/test/NodeGuard.Tests/Services/RebalanceInitiatorServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/RebalanceInitiatorServiceTests.cs
@@ -33,7 +33,7 @@ public class RebalanceInitiatorServiceTests
     private static ChannelSignal Chan(
         int id, string peer, long local, long remote,
         double ema, double target, bool active = true, bool optIn = true)
-        => new(id, (ulong)id, peer, local + remote, local, remote, ema, target, active, optIn);
+        => new(id, (ulong)id, peer, local, remote, ema, target, active, optIn);
 
     // ── Classify: sources ───────────────────────────────────────────────────────────────
 
@@ -137,7 +137,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "dear", 800_000, 200_000, 0.80, 0.50),
             Chan(2, "cheap", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 2000, [2] = 50, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 2000, [2] = 50, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -152,7 +152,7 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -167,7 +167,7 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 0 }; // dest earns nothing
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 0 }; // dest earns nothing
 
         RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
     }
@@ -178,7 +178,7 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "cheap", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50 }; // no entry for the dest channel
+        var earn = new Dictionary<ulong, long> { [1] = 50 }; // no entry for the dest channel
 
         RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
     }
@@ -193,7 +193,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "A", 800_000, 200_000, 0.80, 0.50),        // source, peer A, excess 300_000
             Chan(2, "A", 50_000, 2_950_000, 0.02, 0.50),       // pulls peer A aggregate too-remote
             Chan(3, "B", 200_000, 800_000, 0.20, 0.50));       // destination, peer B
-        var earn = new Dictionary<int, long> { [1] = 4000, [2] = 4000, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 4000, [2] = 4000, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -209,7 +209,7 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -224,27 +224,12 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "src", 9_000_000, 3_000_000, 0.75, 0.25),   // excess = 9M - 3M = 6M
             Chan(3, "dest", 2_000_000, 18_000_000, 0.10, 0.50)); // deficit = 10M - 2M = 8M
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
         plans.Should().ContainSingle();
         plans[0].AmountSats.Should().Be(5_000_000);
-    }
-
-    [Fact]
-    public void BuildPlans_SkipsWhenSourceExcessBelowMin()
-    {
-        // Chan 1 qualifies as a source by the smoothed signal (ema 0.80 → d 0.30) but its LIVE excess
-        // is only 5_000 sats — below the 10_000 min — so it can't feed the depleted destination.
-        var classification = Classify(
-            Chan(1, "src", 505_000, 495_000, 0.80, 0.50),   // source, live excess = 505_000 - 500_000 = 5_000
-            Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500 };
-
-        classification.Sources.Should().ContainSingle();
-        classification.Sources[0].ExcessSats.Should().Be(5_000);
-        RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
     }
 
     [Fact]
@@ -255,7 +240,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "src", 5_000_000, 1_000_000, 0.83, 0.50),
             Chan(3, "destA", 200_000, 800_000, 0.20, 0.50),
             Chan(4, "destB", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 2500, [4] = 2400 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 2500, [4] = 2400 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -272,7 +257,7 @@ public class RebalanceInitiatorServiceTests
             Chan(2, "srcB", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "destA", 200_000, 800_000, 0.20, 0.50),
             Chan(4, "destB", 200_000, 800_000, 0.20, 0.50));
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500, [4] = 2400 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 60, [3] = 2500, [4] = 2400 };
 
         RebalanceInitiatorService.BuildPlans(classification, earn, tunables).Should().ContainSingle();
     }
@@ -286,7 +271,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
             Chan(3, "dest", 200_000, 800_000, 0.20, 0.50),      // base 1M
             Chan(4, "dest", 600_000, 2_400_000, 0.20, 0.50));   // base 3M
-        var earn = new Dictionary<int, long> { [1] = 50, [3] = 1000, [4] = 3000 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [3] = 1000, [4] = 3000 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -310,13 +295,39 @@ public class RebalanceInitiatorServiceTests
     }
 
     [Fact]
-    public void BuildPlans_SourceWithNoQualifyingDestination_DrainsIntoTheFirstFallbackPeerThatFits()
+    public void Classify_LendableBelowMinAmount_IsNotAFallbackSource()
+    {
+        // Inside the deadband, so not a detected source — and it can only lend down to 0.35
+        // (355_000 - 350_000 = 5_000), below the 10_000 floor, so it isn't worth a hop as a source.
+        var result = Classify(Chan(1, "peerA", local: 355_000, remote: 645_000, ema: 0.355, target: 0.50));
+
+        result.Sources.Should().BeEmpty();
+        result.FallbackSources.Should().BeEmpty("5_000 lendable is below MinAmountSats");
+        // Still a usable counterparty in the other direction: 650_000 - 355_000 = 295_000 to absorb.
+        result.FallbackDestinations.Should().ContainSingle().Which.DeficitSats.Should().Be(295_000);
+    }
+
+    [Fact]
+    public void Classify_AbsorbableBelowMinAmount_IsNotAFallbackDestination()
+    {
+        // Mirror image: inside the deadband, and it can only absorb up to 0.65
+        // (650_000 - 645_000 = 5_000), below the floor.
+        var result = Classify(Chan(1, "peerA", local: 645_000, remote: 355_000, ema: 0.645, target: 0.50));
+
+        result.Destinations.Should().BeEmpty();
+        result.FallbackDestinations.Should().BeEmpty("5_000 absorbable is below MinAmountSats");
+        // Still lendable: 645_000 - 350_000 = 295_000.
+        result.FallbackSources.Should().ContainSingle().Which.ExcessSats.Should().Be(295_000);
+    }
+
+    [Fact]
+    public void BuildPlans_SourceWithNoQualifyingDestination_DrainsIntoTheRoomiestFallbackPeer()
     {
         var classification = Classify(
             Chan(1, "src", 800_000, 200_000, 0.80, 0.50),    // source, excess 300_000
             Chan(2, "peerB", 500_000, 500_000, 0.50, 0.50),  // fallback dest, absorbable 150_000
             Chan(3, "peerC", 450_000, 550_000, 0.45, 0.50)); // fallback dest, absorbable 200_000
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 2000, [3] = 2000 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 2000, [3] = 2000 };
 
         classification.Destinations.Should().BeEmpty("neither peer tripped the -0.15 trigger");
 
@@ -324,35 +335,35 @@ public class RebalanceInitiatorServiceTests
 
         plans.Should().ContainSingle();
         plans[0].SourceChannelId.Should().Be(1);
-        // peerB, not the emptier peerC: pass 2 takes the first fallback destination that yields a
-        // plan, and has no preference for the one with the most room.
-        plans[0].DestinationPeerPubKey.Should().Be("peerB");
+        // peerC over peerB: fallback destinations are ranked by the room they have (200_000 vs
+        // 150_000), so the deeper one absorbs first.
+        plans[0].DestinationPeerPubKey.Should().Be("peerC");
         plans[0].IsFallbackPairing.Should().BeTrue();
-        // Capped by peerB's room up to target + deadband (650_000 - 500_000), NOT the source's
+        // Capped by peerC's room up to target + deadband (650_000 - 450_000), NOT the source's
         // full 300_000 excess — refilling must never turn the destination into next cycle's source.
-        plans[0].AmountSats.Should().Be(150_000);
+        plans[0].AmountSats.Should().Be(200_000);
     }
 
     [Fact]
-    public void BuildPlans_DestinationWithNoQualifyingSource_IsFundedByTheFirstFallbackChannel()
+    public void BuildPlans_DestinationWithNoQualifyingSource_IsFundedByTheLargestFallbackChannel()
     {
         var classification = Classify(
             Chan(1, "peerA", 600_000, 400_000, 0.60, 0.50),  // fallback source, lendable 250_000
             Chan(2, "peerB", 900_000, 100_000, 0.55, 0.50),  // fallback source, lendable 550_000
             Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));  // destination, deficit 400_000
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 60, [3] = 2500 };
 
         classification.Sources.Should().BeEmpty("neither peer tripped the +0.15 trigger");
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
         plans.Should().ContainSingle();
-        // peerA, not the fuller peerB: the fallback pool is drawn from in classification order.
-        plans[0].SourceChannelId.Should().Be(1);
+        // peerB over peerA: the fallback pool is ranked by how much it can lend (550_000 vs 250_000).
+        plans[0].SourceChannelId.Should().Be(2);
         plans[0].DestinationPeerPubKey.Should().Be("dest");
         plans[0].IsFallbackPairing.Should().BeTrue();
-        // Bounded by what peerA may lend (250_000), not the destination's full 400_000 deficit.
-        plans[0].AmountSats.Should().Be(250_000);
+        // peerB can lend 550_000, so the destination's 400_000 deficit is what binds here.
+        plans[0].AmountSats.Should().Be(400_000);
     }
 
     [Fact]
@@ -361,7 +372,7 @@ public class RebalanceInitiatorServiceTests
         var classification = Classify(
             Chan(1, "peerA", 400_000, 600_000, 0.40, 0.50), // fallback source: lendable to 0.35 = 50_000
             Chan(2, "dest", 0, 1_000_000, 0.00, 0.50));     // destination, deficit 500_000
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 
@@ -378,7 +389,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "src", 800_000, 200_000, 0.80, 0.50),
             Chan(2, "peerB", 500_000, 500_000, 0.50, 0.50));
         // The only available destination earns nothing, so there is no margin to pay a route with.
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 0 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 0 };
 
         RebalanceInitiatorService.BuildPlans(classification, earn, Tunables).Should().BeEmpty();
     }
@@ -394,7 +405,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "srcA", 800_000, 200_000, 0.80, 0.50),   // detected source, excess 300_000
             Chan(2, "srcB", 800_000, 200_000, 0.80, 0.50),   // detected source, excess 300_000
             Chan(3, "peerX", 500_000, 500_000, 0.50, 0.50)); // fallback dest, absorbable 150_000
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 50, [3] = 2000 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 50, [3] = 2000 };
 
         classification.Destinations.Should().BeEmpty("peerX did not trip the -0.15 trigger");
         classification.FallbackDestinations.Should().ContainSingle()
@@ -415,7 +426,7 @@ public class RebalanceInitiatorServiceTests
             Chan(1, "src", 800_000, 200_000, 0.80, 0.50),    // qualifying source
             Chan(2, "peerB", 950_000, 50_000, 0.55, 0.50),   // fallback source, far more to lend
             Chan(3, "dest", 100_000, 900_000, 0.10, 0.50));  // destination
-        var earn = new Dictionary<int, long> { [1] = 50, [2] = 60, [3] = 2500 };
+        var earn = new Dictionary<ulong, long> { [1] = 50, [2] = 60, [3] = 2500 };
 
         var plans = RebalanceInitiatorService.BuildPlans(classification, earn, Tunables);
 


### PR DESCRIPTION
Adds automated channel rebalancing to the routing engine: `RebalanceInitiatorService` (pure,
unit-tested) sorts channels into drainable sources and depleted destination peers and pairs them
into sized, profit-gated plans, which `AutoRebalanceJob` dispatches through `RebalanceService` on
its own 10-minute cadence.

Every plan is bounded before it goes out — per-channel `IsAutoRebalanceEnabled` opt-in, a deadband
either side of each channel's target ratio, a fee ceiling of `CostToEarnRatio × the destination
peer's earn rate`, and per-node budget / in-flight / per-run caps — plus per-node dry-run and the
global `ROUTING_ENGINE_ENABLED` kill switch, which is off by default, so merging this changes no
behaviour until it's switched on.

Supporting changes: `ChannelRoutingState` becomes per (channel, managed node) so both ends of a
channel NodeGuard manages actuate independently; the new `RoutingEngineSnapshotService` builds the
per-node channel view now shared with `ChannelFeeOptimizerJob`; two migrations and unit tests for
the planner and the job.