### PR TITLE
Enhance error logging for max HTLC update failures in LightningService

### DIFF
--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -2040,7 +2040,9 @@ namespace NodeGuard.Services
 
             if (response?.FailedUpdates != null && response.FailedUpdates.Count > 0)
             {
-                _logger.LogError("Failed to update max htlc for channel: {ChanPoint}", lndChannel.ChannelPoint);
+                string errorMessages = string.Join("; ", response.FailedUpdates);
+                _logger.LogError("Failed to update max htlc for channel {ChanPoint}: [{Errors}]", lndChannel.ChannelPoint, errorMessages);
+                
                 throw new Exception($"Failed to update max htlc for channel: {lndChannel.ChannelPoint}");
             }
 


### PR DESCRIPTION
Improve error logging by including detailed error messages for failed max HTLC updates, aiding in troubleshooting and diagnostics.