### PR TITLE
Add RBF fee bump support via gRPC with error handling and e2e tests

### DIFF
--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -12,7 +12,7 @@ Its rebalance/routing-engine core is four scenarios — **(1)** manual rebalance
 SINK→SOURCE, driving its own LND traffic in-process via `LndTestClient`), **(4)** automatic rebalancing
 (`AutoRebalanceE2ETests`; shapes an imbalance, switches the node's rebalancer on and asserts on what
 `AutoRebalanceJob` decided) — and the same pass also runs the wallet/UTXO e2e tests
-(`DustUtxoWithdrawalE2ETests`, `GetNewWalletAddressE2ETests`). Every e2e class is **order-agnostic** (it
+(`DustUtxoWithdrawalE2ETests`, `WithdrawalRbfBumpE2ETests`, `GetNewWalletAddressE2ETests`). Every e2e class is **order-agnostic** (it
 provisions its own channels and resets its own state) and they run **serially** via the shared
 `[Collection("E2E")]` — one regtest chain can't take concurrent channel opens/traffic.
 
@@ -38,7 +38,7 @@ Tests live in `test/NodeGuard.Tests/E2E/`. The rebalance/routing-engine scenario
 `FeeEngineE2ETests`, `FeeEngineFlowE2ETests` and `AutoRebalanceE2ETests`, layered on `E2ETestBase` →
 `RoutingEngineE2EBase` (Postgres + routing-state plumbing) → `FeeEngineE2EBase` (fee-state helpers), with
 `LndTestClient` (direct LND gRPC driver used by the flow and auto-rebalance scenarios); the wallet/UTXO
-tests (`DustUtxoWithdrawalE2ETests`, `GetNewWalletAddressE2ETests`) sit alongside them. All are
+tests (`DustUtxoWithdrawalE2ETests`, `WithdrawalRbfBumpE2ETests`, `GetNewWalletAddressE2ETests`) sit alongside them. All are
 `[Collection("E2E")]` and gated by `[E2EFact]` (they run when NodeGuard gRPC is reachable, or
 `RUN_E2E_TESTS=1`).
 
@@ -69,6 +69,10 @@ tests (`DustUtxoWithdrawalE2ETests`, `GetNewWalletAddressE2ETests`) sit alongsid
   `ROUTING_ENGINE_REBALANCE_MAX_AMOUNT_SATS` / `ROUTING_ENGINE_REBALANCE_DEADBAND` from its own env — **keep
   those two in sync between the `nodeguard` and `e2e-runner` services**, or the test asserts against numbers
   NodeGuard didn't plan with.
+- **RBF bump scenario** (`WithdrawalRbfBumpE2ETests`): `RequestWithdrawal` on the hot wallet, then `BumpWithdrawal`
+  over gRPC, asserting bitcoind evicts the original for the higher-fee replacement, NodeGuard marks the original
+  `WITHDRAWAL_BUMPED`, and the replacement settles once mined. It relies on `MONITOR_WITHDRAWALS_CRON` being fast on
+  the `nodeguard` service (10s here; prod keeps the every-5-minutes default) and never mines between the two calls.
 - **Adding an e2e test**: put it in `[Collection("E2E")]` (so it serialises with the others on the one
   regtest chain — without it the class runs in parallel and they interfere), have it provision the
   resources it needs and reset its own state, and gate it with `[E2EFact]`.

--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -96,6 +96,9 @@ services:
       # MonitorChannelsJob discovers the externally-opened channels the fee tests reuse (Bob→Carol,
       # Alice→Bob); a fast 5s cron records them promptly (prod keeps the default hourly cron).
       MONITOR_CHANNELS_CRON: "0/5 * * * * ?"
+      # WithdrawalRbfBumpE2ETests waits for the bumped withdrawal to settle once mined; poll confirmations every 10s
+      # instead of the default every-5-minutes cron.
+      MONITOR_WITHDRAWALS_CRON: "0/10 * * * * ?"
       ROUTING_ENGINE_ENABLED: "true"
       ROUTING_ENGINE_DRY_RUN: "false"
       ROUTING_ENGINE_FEE_MIN_CHANNEL_SIZE_SATS: "15000000"

--- a/src/Data/Models/WalletWithdrawalRequest.cs
+++ b/src/Data/Models/WalletWithdrawalRequest.cs
@@ -198,6 +198,12 @@ namespace NodeGuard.Data.Models
 
         public WalletWithdrawalRequest? BumpingWalletWithdrawalRequest { get; set; }
 
+        /// <summary>
+        /// True when this request replaces <see cref="BumpingWalletWithdrawalRequest"/> to CANCEL it (RBF): same inputs,
+        /// a single output back to the wallet, and the replaced request ends up Cancelled instead of Bumped.
+        /// </summary>
+        public bool IsRbfCancellation { get; set; }
+
         public List<WalletWithdrawalRequestPSBT> WalletWithdrawalRequestPSBTs { get; set; }
 
         public List<FMUTXO> UTXOs { get; set; }

--- a/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
@@ -236,18 +236,23 @@ namespace NodeGuard.Data.Repositories
                 return (false, "The wallet does not have a derivation strategy.");
             }
 
-            var balance = await _nBXplorerService.GetBalanceAsync(derivationStrategyBase, default);
-
-            if (balance == null)
+            // An RBF replacement (fee bump or cancellation) re-spends inputs that are already locked by the request it
+            // replaces, so the wallet's confirmed balance says nothing about whether it can be funded.
+            if (type.BumpingWalletWithdrawalRequestId == null)
             {
-                return (false, "Balance could not be retrieved from the wallet.");
-            }
+                var balance = await _nBXplorerService.GetBalanceAsync(derivationStrategyBase, default);
 
-            var requestMoneyAmount = new Money(type.TotalAmount, MoneyUnit.BTC);
+                if (balance == null)
+                {
+                    return (false, "Balance could not be retrieved from the wallet.");
+                }
 
-            if ((Money)balance.Confirmed < requestMoneyAmount)
-            {
-                return (false, $"The wallet {type.Wallet.Name} does not have enough funds to complete this withdrawal request. The wallet has {balance.Confirmed} BTC and the withdrawal request is for {requestMoneyAmount} BTC.");
+                var requestMoneyAmount = new Money(type.TotalAmount, MoneyUnit.BTC);
+
+                if ((Money)balance.Confirmed < requestMoneyAmount)
+                {
+                    return (false, $"The wallet {type.Wallet.Name} does not have enough funds to complete this withdrawal request. The wallet has {balance.Confirmed} BTC and the withdrawal request is for {requestMoneyAmount} BTC.");
+                }
             }
 
 

--- a/src/Helpers/CustomExceptions.cs
+++ b/src/Helpers/CustomExceptions.cs
@@ -41,9 +41,32 @@ public class NotEnoughBalanceInWalletException : Exception
    public NotEnoughBalanceInWalletException(string? message = null): base(message) {}
 }
 
+/// <summary>
+/// Why a fee bump (RBF) was refused. Lets callers act on the refusal without matching message text: the UI shows the
+/// message as-is, the gRPC API maps the reason to a status code.
+/// </summary>
+public enum BumpingErrorReason
+{
+   Unknown,
+   RequestNotFound,
+   InvalidState,
+   AlreadyConfirmed,
+   TransactionNotFound,
+   ChangelessMultipleDestinations,
+   InvalidFeeRate,
+   FeeRateNotHigher,
+   FeeExceedsInputs,
+   PersistenceError
+}
+
 public class BumpingException : Exception
 {
-   public BumpingException(string? message = null): base(message) {}
+   public BumpingErrorReason Reason { get; }
+
+   public BumpingException(string? message = null, BumpingErrorReason reason = BumpingErrorReason.Unknown): base(message)
+   {
+      Reason = reason;
+   }
 }
 
 public class CustomArgumentNullException : ArgumentNullException

--- a/src/Migrations/20260904164600_AddIsRbfCancellationToWalletWithdrawalRequest.Designer.cs
+++ b/src/Migrations/20260904164600_AddIsRbfCancellationToWalletWithdrawalRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904164600_AddIsRbfCancellationToWalletWithdrawalRequest")]
+    partial class AddIsRbfCancellationToWalletWithdrawalRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260904164600_AddIsRbfCancellationToWalletWithdrawalRequest.cs
+++ b/src/Migrations/20260904164600_AddIsRbfCancellationToWalletWithdrawalRequest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsRbfCancellationToWalletWithdrawalRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRbfCancellation",
+                table: "WalletWithdrawalRequests",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsRbfCancellation",
+                table: "WalletWithdrawalRequests");
+        }
+    }
+}

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -448,6 +448,7 @@
                                 </DropdownToggle>
                                 <DropdownMenu>
                                     <DropdownItem Clicked="async () => await ShowBumpfeeModal(context)">Bump fee</DropdownItem>
+                                    <DropdownItem Clicked="async () => await ShowBumpfeeModal(context, cancellation: true)">Cancel (RBF)</DropdownItem>
                                 </DropdownMenu>
                             </Dropdown>
                     }
@@ -481,6 +482,7 @@
 <BumpfeeModal
     @ref="_bumpfeeRef"
     WithdrawalRequest="_selectedRequest"
+    Cancellation="_bumpIsCancellation"
     SubmitBumpfeeModal="@SubmitBumpfeeModal"/>
 
 <CancelOrRejectPopup
@@ -540,6 +542,7 @@
     private WalletWithdrawalRequest? _selectedRequest;
     private PSBTSign? _psbtSignRef;
     private BumpfeeModal? _bumpfeeRef;
+    private bool _bumpIsCancellation;
     private string _signedPSBT;
     private string? _templatePsbtString;
     private int? _selectedWalletId;
@@ -931,8 +934,9 @@
         }
     }
 
-    private async Task ShowBumpfeeModal(WalletWithdrawalRequest walletWithdrawalRequest)
+    private async Task ShowBumpfeeModal(WalletWithdrawalRequest walletWithdrawalRequest, bool cancellation = false)
     {   
+        _bumpIsCancellation = cancellation;
         if (walletWithdrawalRequest == null)
         {
             ToastService.ShowError("Invalid request");
@@ -980,7 +984,8 @@
             return;
         }
         
-        if (request.Changeless && request.WalletWithdrawalRequestDestinations!.Count > 1)
+        // A cancellation replaces every output, so the shape of the original does not matter to it.
+        if (!cancellation && request.Changeless && request.WalletWithdrawalRequestDestinations!.Count > 1)
         {
             ToastService.ShowError("Fee bumping is not supported for changeless transactions. Please create a new withdrawal with higher fees instead.");
             await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, request, "Bump requested for changeless transaction with multiple outputs.");
@@ -1044,7 +1049,7 @@
                                 await CreateJob();
                                 if (_selectedRequest?.BumpingWalletWithdrawalRequestId != null)
                                 {
-                                    await WithdrawalRequestService.MarkOriginalAsBumpedAsync(_selectedRequest);
+                                    await WithdrawalRequestService.MarkOriginalAsReplacedAsync(_selectedRequest);
                                 }
                             }
                         }
@@ -1096,10 +1101,12 @@
                 return;
             }
 
-            // The bump was validated, created and its UTXOs locked by WithdrawalRequestService (see BumpfeeModal).
+            // The replacement was validated, created and its UTXOs locked by WithdrawalRequestService (see BumpfeeModal).
             _selectedRequest = newRequest;
             await _bumpfeeRef.HideModal();
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Success, newRequest, "Bump withdrawal request created.");
+            await LogWithdrawalAuditAsync(newRequest.IsRbfCancellation ? AuditActionType.Cancel : AuditActionType.BumpFee,
+                AuditEventType.Success, newRequest,
+                newRequest.IsRbfCancellation ? "RBF cancellation request created." : "Bump withdrawal request created.");
             await GetData();
 
             if (newRequest.Wallet?.IsHotWallet == true)

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -510,6 +510,7 @@
 @inject IWalletWithdrawalRequestPsbtRepository WalletWithdrawalRequestPsbtRepository
 @inject IWalletRepository WalletRepository
 @inject IBitcoinService BitcoinService
+@inject IWithdrawalRequestService WithdrawalRequestService
 @inject ICoinSelectionService CoinSelectionService
 @inject ISchedulerFactory SchedulerFactory
 @inject ILocalStorageService LocalStorageService
@@ -1043,7 +1044,7 @@
                                 await CreateJob();
                                 if (_selectedRequest?.BumpingWalletWithdrawalRequestId != null)
                                 {
-                                    await UpdateBumpWalletWithdrawalRequest();
+                                    await WithdrawalRequestService.MarkOriginalAsBumpedAsync(_selectedRequest);
                                 }
                             }
                         }
@@ -1084,160 +1085,44 @@
         }
     }
 
-    private async Task CreateNewWithdrawal(WalletWithdrawalRequest newRequest)
-    {
-        _selectedMempoolRecommendedFeesType = newRequest.MempoolRecommendedFeesType;
-        _customSatPerVbAmount = (long)newRequest.CustomFeeRate;
-        _selectedRequest = newRequest;
-        if (newRequest.Wallet.IsHotWallet)
-        {
-            await GetData();
-            await _confirmationModal.ShowModal();
-            return;
-        }
-
-        newRequest.Wallet = null;
-
-        try {
-            if (_selectedRequest.Id == 0)
-            {
-                var createWithdrawalResult = await WalletWithdrawalRequestRepository.AddAsync(_selectedRequest);
-                if (!createWithdrawalResult.Item1)
-                {
-                    throw new ShowToUserException(createWithdrawalResult.Item2);
-                }
-            }
-            else
-            {
-                var updateResult = WalletWithdrawalRequestRepository.Update(_selectedRequest);
-                if (!updateResult.Item1)
-                {
-                    throw new ShowToUserException(updateResult.Item2);
-                }
-            }
-
-            ToastService.ShowSuccess("Success");
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Success, _selectedRequest, "Bump withdrawal request created.");
-            await GetData();
-
-            if (_selectedUTXOs.Count > 0)
-            {
-                await CoinSelectionService.LockUTXOs(_selectedUTXOs, newRequest, BitcoinRequestType.WalletWithdrawal);
-            }
-
-            _utxoSelectorModalRef.ClearModal();
-        }
-        catch (ShowToUserException e)
-        {
-            ToastService.ShowError(e.Message);
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, _selectedRequest, e.Message);
-            _userPendingRequests.Remove(newRequest);
-        }
-        catch (Exception e)
-        {
-            Logger.LogError("Error creating a new withdrawal request for bumping fee: {Error}", e.Message);
-            var message = string.IsNullOrWhiteSpace(e.Message) ? "Something went wrong" : e.Message;
-            ToastService.ShowError("Something went wrong");
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, _selectedRequest, message);
-        }
-    }
-
-    private async Task Bumpfee(WalletWithdrawalRequest request)
-    {
-        try
-        {
-            await CreateNewWithdrawal(request);
-        }
-        catch
-        {
-            ToastService.ShowError("Could not bump the withdrawal");
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, request, "Could not bump the withdrawal.");
-        }
-    }
-
     private async void SubmitBumpfeeModal(WalletWithdrawalRequest newRequest)
     {
         try
         {
-            if (newRequest != null && _bumpfeeRef != null)
-            {
-                newRequest.Wallet = await WalletRepository.GetById(newRequest.WalletId);
-                    
-                // Use either the custom fee rate or the recommended fee rate based on mempool fee type
-                decimal newFeeRate;
-                if (newRequest.MempoolRecommendedFeesType == MempoolRecommendedFeesType.CustomFee && newRequest.CustomFeeRate.HasValue)
-                {
-                    newFeeRate = (decimal)newRequest.CustomFeeRate.Value;
-                }
-                else
-                {
-                    // Use the recommended fee rate from NBXplorer service based on the selected mempool fee type
-                    var recommendedFeeRate = await GetRecommendedFeeRate(newRequest.MempoolRecommendedFeesType);
-                    newFeeRate = (decimal)recommendedFeeRate;
-                }
-
-                // If the new fee plus the amount exceeds the utxo sum value, show an error
-                // NOTE: revisit this when full rbf because we could add a UTXO
-                var txInfo = await NBXplorerService.GetTransactionAsync(uint256.Parse(_selectedRequest.TxId));
-                var tx = txInfo.Transaction;
-                long vSize = tx.GetVirtualSize();
-                decimal newFee = (vSize * newFeeRate) / 100_000_000m;
-
-                // Retrieve from database to get the UTXOs
-                _selectedRequest = await WalletWithdrawalRequestRepository.GetById(_selectedRequest.Id);
-
-                if (_selectedRequest == null)
-                {
-                    ToastService.ShowError("Withdrawal request not found");
-                    await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, _selectedRequest, "Withdrawal request not found while bumping.");
-                    return;
-                }
-
-                // This enables wds that have only one destination to be bumped by reducing the destination amount
-                if (_selectedRequest.UTXOs != null && _selectedRequest.UTXOs.Count > 0 && _selectedRequest.WalletWithdrawalRequestDestinations!.Count > 1)
-                {
-                    var inputAmount = Money.Satoshis(_selectedRequest.UTXOs.Sum(x => x.SatsAmount)).ToDecimal(MoneyUnit.BTC); // Convert to BTC
-                    // Check if the new fee plus the amount exceeds the sum of the selected UTXOs or returns dust
-                    if (inputAmount < newFee + _selectedRequest.TotalAmount + Constants.BITCOIN_DUST.ToDecimal(MoneyUnit.BTC))
-                    {
-                        ToastService.ShowError("The new fee plus the amount exceeds the sum of the selected UTXOs or returns dust. Please lower the fee rate.");
-                        await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, _selectedRequest, "New fee amount exceeds available UTXO value.");
-                        return;
-                    }
-                }
-
-                // If the request is changeless and it has more than 1 output, show an error
-                if (_selectedRequest.Changeless && _selectedRequest.WalletWithdrawalRequestDestinations!.Count > 1)
-                {
-                    ToastService.ShowError("Fee bumping is not supported for changeless transactions. Please create a new withdrawal with higher fees instead.");
-                    await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, _selectedRequest, "Fee bump not allowed for changeless multi-output transaction.");
-                    return;
-                }
-                
-                await Bumpfee(newRequest);
-                await _bumpfeeRef.HideModal();
-                StateHasChanged();
-            }
-            else
+            if (newRequest == null || _bumpfeeRef == null)
             {
                 ToastService.ShowError("Something went wrong");
                 await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, newRequest, "Invalid bump fee request parameters.");
+                return;
             }
-        }
-        catch (Exception)
-        {
-            ToastService.ShowError($"Something went wrong");
-            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, newRequest, "Unexpected error while bumping withdrawal.");
+
+            // The bump was validated, created and its UTXOs locked by WithdrawalRequestService (see BumpfeeModal).
+            _selectedRequest = newRequest;
             await _bumpfeeRef.HideModal();
+            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Success, newRequest, "Bump withdrawal request created.");
+            await GetData();
+
+            if (newRequest.Wallet?.IsHotWallet == true)
+            {
+                // No approvers on a hot wallet: once the user confirms, SubmitConfirmationModal schedules the signing and broadcast.
+                await _confirmationModal.ShowModal();
+            }
+            else
+            {
+                ToastService.ShowSuccess("Success");
+            }
+
+            StateHasChanged();
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error while bumping withdrawal request {RequestId}", newRequest?.Id);
+            ToastService.ShowError("Something went wrong");
+            await LogWithdrawalAuditAsync(AuditActionType.BumpFee, AuditEventType.Failure, newRequest, "Unexpected error while bumping withdrawal.");
+            if (_bumpfeeRef != null) await _bumpfeeRef.HideModal();
         }
     }
 
-    private async Task<long> GetRecommendedFeeRate(MempoolRecommendedFeesType feeType)
-    {
-        return (long?)await NBXplorerService.GetFeesByType(feeType) ?? 1;
-    }
-
-    
     private async Task ApproveRequestDelegate()
     {
         if (_selectedRequest != null)
@@ -1272,7 +1157,7 @@
             }
 
             // In case that is a bump, we return the old request status to pending confirmation.
-            await ResetStatusBumpedIfError(_selectedRequest);
+            await WithdrawalRequestService.RevertOriginalAsync(_selectedRequest);
 
             await HideRejectCancelModal();
         }
@@ -1359,30 +1244,6 @@
         await _confirmationModal.CloseModal();
     }
 
-    private async Task UpdateBumpWalletWithdrawalRequest()
-    {
-        if (_selectedRequest == null) throw new BumpingException("Invalid request");
-        
-        var outpoints = _selectedRequest.UTXOs.Select(u => OutPoint.Parse($"{u.TxId}:{u.OutputIndex}")).ToList();
-        _selectedUTXOs = await CoinSelectionService.GetUTXOsByOutpointAsync(_selectedRequest.Wallet.GetDerivationStrategy()!, outpoints);
-
-        // Update the status of the old withdrawal request
-        if (_selectedRequest.BumpingWalletWithdrawalRequestId != null)
-        {
-            _selectedRequest.BumpingWalletWithdrawalRequest = await WalletWithdrawalRequestRepository.GetById(_selectedRequest.BumpingWalletWithdrawalRequestId.Value);
-            if (_selectedRequest.BumpingWalletWithdrawalRequest == null)
-            {
-                throw new BumpingException("Could not find bumping withdrawal request");
-            }
-            _selectedRequest.BumpingWalletWithdrawalRequest.Status = WalletWithdrawalRequestStatus.Bumped;
-            var updateResultOldWithdrawal = WalletWithdrawalRequestRepository.Update(_selectedRequest.BumpingWalletWithdrawalRequest);
-            if (!updateResultOldWithdrawal.Item1)
-            {
-                throw new BumpingException("Something went wrong");
-            }
-        }
-    }
-
     private async Task SubmitConfirmationModal()
     {
         async Task CleanUp(string errorMessage)
@@ -1399,109 +1260,61 @@
         if (_selectedRequest != null)
         {
             try
-            {   
+            {
                 _selectedRequest.Wallet = await WalletRepository.GetById(_selectedRequest.WalletId);
-                _selectedRequest.WithdrawAllFunds = _isCheckedAllFunds || _amount == _selectedRequestWalletBalance;
-                _selectedRequest.MempoolRecommendedFeesType = _selectedMempoolRecommendedFeesType;
-                _selectedRequest.CustomFeeRate = _customSatPerVbAmount;
-                
+
                 if (_selectedRequest.Id == 0)
                 {
+                    // A fresh request from the datagrid: apply the form state and persist it. A bump (Id != 0) was already
+                    // created by WithdrawalRequestService with the fields of the request it replaces, and the (stale)
+                    // form state must not overwrite them.
+                    _selectedRequest.WithdrawAllFunds = _isCheckedAllFunds || _amount == _selectedRequestWalletBalance;
+                    _selectedRequest.MempoolRecommendedFeesType = _selectedMempoolRecommendedFeesType;
+                    _selectedRequest.CustomFeeRate = _customSatPerVbAmount;
+                    _selectedRequest.Changeless = _selectedUTXOs.Count > 0;
+
                     var createWithdrawalResult = await WalletWithdrawalRequestRepository.AddAsync(_selectedRequest);
                     if (!createWithdrawalResult.Item1)
                     {
                         throw new ShowToUserException(createWithdrawalResult.Item2);
                     }
-                }
-                else
-                {
-                    var updateResult = WalletWithdrawalRequestRepository.Update(_selectedRequest);
-                    if (!updateResult.Item1)
+
+                    if (_selectedUTXOs.Count > 0)
                     {
-                        throw new ShowToUserException(updateResult.Item2);
+                        await CoinSelectionService.LockUTXOs(_selectedUTXOs, _selectedRequest, BitcoinRequestType.WalletWithdrawal);
                     }
                 }
-
-                if (_selectedRequest.BumpingWalletWithdrawalRequestId != null)
-                {
-                    await UpdateBumpWalletWithdrawalRequest();
-                }
-
-                _selectedRequest.Changeless = _selectedUTXOs.Count > 0;
 
                 ToastService.ShowSuccess("Withdrawal request created!");
                 await LogWithdrawalAuditAsync(AuditActionType.Create, AuditEventType.Success, _selectedRequest, "Withdrawal request created.");
 
-                if (_selectedUTXOs.Count > 0)
-                {
-                    await CoinSelectionService.LockUTXOs(_selectedUTXOs, _selectedRequest, BitcoinRequestType.WalletWithdrawal);
-                }
+                // Moves the request to PSBTSignaturesPending (the status PerformWithdrawal requires), generates the template
+                // PSBT, marks a replaced request as Bumped and schedules PerformWithdrawalJob to sign and broadcast.
+                await WithdrawalRequestService.ScheduleHotWalletWithdrawalAsync(_selectedRequest.Id);
 
-                // GenerateTemplatePSBT persists the template row itself (tagged IsTemplatePSBT = true), so
-                // nothing further needs storing here. This used to store a SECOND copy of the same PSBT with
-                // IsTemplatePSBT left at its default false, which NumberOfSignaturesCollected then counted as
-                // a human signature — inflating the collected count by one on every request. Tagging that copy
-                // instead is not an option: PerformWithdrawal selects the template with
-                // .Single(x => x.IsTemplatePSBT), which throws when two exist.
-                await BitcoinService.GenerateTemplatePSBT(_selectedRequest);
-
-                ToastService.ShowSuccess("Signature collected");
-
-                _selectedRequest = await WalletWithdrawalRequestRepository.GetById(_selectedRequest.Id);
-
-                if (_selectedRequest != null
-                    && _selectedRequest.AreAllRequiredHumanSignaturesCollected)
-                {
-                    await CreateJob();
-                }
-                else
-                {
-                    throw new ShowToUserException("Invalid PSBT");
-                }
+                ToastService.ShowSuccess("Withdrawal scheduled for signing and broadcast");
+                await LogWithdrawalAuditAsync(AuditActionType.Approve, AuditEventType.Success, _selectedRequest, "Withdrawal job scheduled.");
 
                 await GetData();
                 StateHasChanged();
                 await _confirmationModal.CloseModal();
             }
-            catch (NoUTXOsAvailableException e)
+            catch (NoUTXOsAvailableException)
             {
                 await CleanUp("No UTXOs available for withdrawals were found for this wallet");
-                await ResetStatusBumpedIfError(_selectedRequest);
             }
             catch (ShowToUserException e)
             {
                 await CleanUp(e.Message);
-                await ResetStatusBumpedIfError(_selectedRequest);
             }
             catch (BumpingException e)
             {
                 await CleanUp(e.Message);
-                await ResetStatusBumpedIfError(_selectedRequest);
             }
             catch (Exception e)
             {
                 Logger.LogError(e, "Error while creating withdrawal");
                 await CleanUp("Something went wrong");
-                await ResetStatusBumpedIfError(_selectedRequest);
-            }
-        }
-    }
-
-    private async Task ResetStatusBumpedIfError(WalletWithdrawalRequest request)
-    {
-        if (request.BumpingWalletWithdrawalRequestId != null)
-        {
-            var bumpedRequest = await WalletWithdrawalRequestRepository.GetById(request.BumpingWalletWithdrawalRequestId.Value);
-
-            if (bumpedRequest != null)
-            {
-                bumpedRequest.Status = WalletWithdrawalRequestStatus.OnChainConfirmationPending;
-                var updateResult = WalletWithdrawalRequestRepository.Update(bumpedRequest);
-                if (!updateResult.Item1)
-                {
-                    ToastService.ShowError("Error while updating the bumped request, please contact a superadmin for troubleshooting");
-                    return;
-                }
             }
         }
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -145,6 +145,7 @@ namespace NodeGuard
             builder.Services.AddTransient<ILocalStorageService, LocalStorageService>();
             builder.Services.AddTransient<ILightningService, LightningService>();
             builder.Services.AddTransient<IBitcoinService, BitcoinService>();
+            builder.Services.AddTransient<IWithdrawalRequestService, WithdrawalRequestService>();
             builder.Services.AddTransient<NotificationService, NotificationService>();
             builder.Services.AddTransient<INBXplorerService, NBXplorerService>();
             builder.Services.AddTransient<ISwapsService, SwapsService>();

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -202,8 +202,12 @@ message RequestWithdrawalResponse {
 }
 
 message BumpWithdrawalRequest {
-  // The withdrawal request to replace. It must be waiting for on-chain confirmation with zero confirmations.
-  int32 request_id = 1;
+  // The withdrawal to replace, either by NodeGuard request id or by the txid RequestWithdrawal returned. It must be
+  // waiting for on-chain confirmation with zero confirmations.
+  oneof target {
+    int32 request_id = 1;
+    string tx_id = 4;
+  }
   // MempoolRecommended fee rate for the replacement
   FEES_TYPE mempool_fee_rate = 2;
   // Fee rate in sat/vbyte, required when mempool_fee_rate is CUSTOM_FEE. Must be higher than the rate of the replaced request.

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -28,6 +28,14 @@ service NodeGuardService {
     replaced request moves to WITHDRAWAL_BUMPED.
     */
   rpc BumpWithdrawal(BumpWithdrawalRequest) returns (BumpWithdrawalResponse);
+
+  /*
+    Cancels a withdrawal that is still waiting for on-chain confirmation by replacing its transaction (RBF) with one
+    that spends the same inputs and returns the funds, minus a higher fee, to a fresh address of the wallet, so the
+    original payment never confirms. Cold wallets get a new request that waits for approvals like RequestWithdrawal;
+    hot wallets sign and broadcast it asynchronously and the replaced request moves to WITHDRAWAL_CANCELLED.
+    */
+  rpc CancelWithdrawal(CancelWithdrawalRequest) returns (CancelWithdrawalResponse);
   /*
     Adds a new node to the nodeguard
    */
@@ -216,6 +224,27 @@ message BumpWithdrawalRequest {
 
 message BumpWithdrawalResponse {
   // Id of the new (bumping) withdrawal request
+  int32 request_id = 1;
+  // Transaction ID of the replacement
+  string txid = 2;
+  bool is_hot_wallet = 3;
+}
+
+message CancelWithdrawalRequest {
+  // The withdrawal to cancel, either by NodeGuard request id or by the txid RequestWithdrawal returned. It must be
+  // waiting for on-chain confirmation with zero confirmations.
+  oneof target {
+    int32 request_id = 1;
+    string tx_id = 4;
+  }
+  // MempoolRecommended fee rate for the replacement
+  FEES_TYPE mempool_fee_rate = 2;
+  // Fee rate in sat/vbyte, required when mempool_fee_rate is CUSTOM_FEE. Must be higher than the rate of the replaced request.
+  optional int32 custom_fee_rate = 3;
+}
+
+message CancelWithdrawalResponse {
+  // Id of the new (cancelling) withdrawal request, which returns the funds to the wallet
   int32 request_id = 1;
   // Transaction ID of the replacement
   string txid = 2;

--- a/src/Proto/nodeguard.proto
+++ b/src/Proto/nodeguard.proto
@@ -20,6 +20,14 @@ service NodeGuardService {
     Withdraws funds from a given wallet to a given address
     */
   rpc RequestWithdrawal(RequestWithdrawalRequest) returns (RequestWithdrawalResponse);
+
+  /*
+    Replaces a withdrawal that is still waiting for on-chain confirmation with a higher-fee version of the same
+    transaction (RBF): same inputs, same destinations, the extra fee is taken from the change. Cold wallets get a new
+    request that waits for approvals like RequestWithdrawal; hot wallets sign and broadcast it asynchronously and the
+    replaced request moves to WITHDRAWAL_BUMPED.
+    */
+  rpc BumpWithdrawal(BumpWithdrawalRequest) returns (BumpWithdrawalResponse);
   /*
     Adds a new node to the nodeguard
    */
@@ -191,6 +199,23 @@ message RequestWithdrawalResponse {
   string txid = 1;
   bool is_hot_wallet = 2;
   int32 request_id = 3;
+}
+
+message BumpWithdrawalRequest {
+  // The withdrawal request to replace. It must be waiting for on-chain confirmation with zero confirmations.
+  int32 request_id = 1;
+  // MempoolRecommended fee rate for the replacement
+  FEES_TYPE mempool_fee_rate = 2;
+  // Fee rate in sat/vbyte, required when mempool_fee_rate is CUSTOM_FEE. Must be higher than the rate of the replaced request.
+  optional int32 custom_fee_rate = 3;
+}
+
+message BumpWithdrawalResponse {
+  // Id of the new (bumping) withdrawal request
+  int32 request_id = 1;
+  // Transaction ID of the replacement
+  string txid = 2;
+  bool is_hot_wallet = 3;
 }
 
 enum WALLET_TYPE {

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -271,7 +271,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
                     throw new RpcException(new Status(StatusCode.Internal, "Derivation strategy not found"));
 
                 utxos = await _coinSelectionService.GetUTXOsByOutpointAsync(derivationStrategyBase, outpoints);
-      
+
             }
 
             // Create destination objects for the withdrawal request
@@ -391,12 +391,14 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         ServerCallContext context)
     {
         WalletWithdrawalRequest? bumpRequest = null;
+        var target = DescribeBumpTarget(request);
         try
         {
             var feeType = (MempoolRecommendedFeesType)request.MempoolFeeRate;
             decimal? customFeeRate = request.HasCustomFeeRate ? request.CustomFeeRate : null;
 
-            bumpRequest = await _withdrawalRequestService.CreateBumpRequestAsync(request.RequestId, feeType, customFeeRate);
+            var originalRequestId = await ResolveBumpTargetAsync(request);
+            bumpRequest = await _withdrawalRequestService.CreateBumpRequestAsync(originalRequestId, feeType, customFeeRate);
 
             var isHotWallet = bumpRequest.Wallet?.IsHotWallet ?? false;
 
@@ -415,21 +417,21 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         }
         catch (BumpingException e)
         {
-            _logger.LogWarning("Fee bump of withdrawal request {RequestId} refused ({Reason}): {Message}",
-                request.RequestId, e.Reason, e.Message);
+            _logger.LogWarning("Fee bump of withdrawal request {Target} refused ({Reason}): {Message}",
+                target, e.Reason, e.Message);
             CancelWithdrawalRequest(bumpRequest);
             throw new RpcException(new Status(ToStatusCode(e.Reason), e.Message));
         }
         catch (NoUTXOsAvailableException)
         {
             CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError("No available UTXOs to bump withdrawal request {RequestId}", request.RequestId);
+            _logger.LogError("No available UTXOs to bump withdrawal request {Target}", target);
             throw new RpcException(new Status(StatusCode.ResourceExhausted, "No available UTXOs for wallet"));
         }
         catch (ShowToUserException e)
         {
             CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError(e, "Error bumping withdrawal request {RequestId}", request.RequestId);
+            _logger.LogError(e, "Error bumping withdrawal request {Target}", target);
             throw new RpcException(new Status(StatusCode.FailedPrecondition, e.Message));
         }
         catch (RpcException)
@@ -440,9 +442,48 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         catch (Exception e)
         {
             CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError(e, "Error bumping withdrawal request {RequestId}", request.RequestId);
+            _logger.LogError(e, "Error bumping withdrawal request {Target}", target);
             throw new RpcException(new Status(StatusCode.Internal, "Error bumping withdrawal request"));
         }
+    }
+
+    /// <summary>
+    /// The withdrawal to bump can be addressed by NodeGuard request id or by the txid RequestWithdrawal returned; the
+    /// latter is resolved here so the service only ever deals with request ids.
+    /// </summary>
+    private async Task<int> ResolveBumpTargetAsync(BumpWithdrawalRequest request)
+    {
+        switch (request.TargetCase)
+        {
+            case BumpWithdrawalRequest.TargetOneofCase.RequestId:
+                return request.RequestId;
+
+            case BumpWithdrawalRequest.TargetOneofCase.TxId:
+                if (!uint256.TryParse(request.TxId, out var txId))
+                {
+                    throw new RpcException(new Status(StatusCode.InvalidArgument, "tx_id is not a valid transaction id"));
+                }
+
+                // Stored txids are lowercase hex; normalising through uint256 makes the lookup case-insensitive.
+                var withdrawalRequest = await _walletWithdrawalRequestRepository.GetByTxHash(txId.ToString());
+                if (withdrawalRequest == null)
+                {
+                    throw new RpcException(new Status(StatusCode.NotFound,
+                        $"No withdrawal request found for txid {txId}"));
+                }
+
+                return withdrawalRequest.Id;
+
+            default:
+                throw new RpcException(new Status(StatusCode.InvalidArgument, "request_id or tx_id is required"));
+        }
+    }
+
+    private static string DescribeBumpTarget(BumpWithdrawalRequest request)
+    {
+        return request.TargetCase == BumpWithdrawalRequest.TargetOneofCase.TxId
+            ? $"txid {request.TxId}"
+            : $"id {request.RequestId}";
     }
 
     private static StatusCode ToStatusCode(BumpingErrorReason reason)
@@ -1499,7 +1540,8 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
 
     public override async Task<SetChannelFeePolicyResponse> SetChannelFeePolicy(SetChannelFeePolicyRequest request, ServerCallContext context)
     {
-        try {
+        try
+        {
             await _lightningService.SetChannelFeePolicy(request.ChanPoint, request.NodePubkey, request.BaseFeeMsat, request.FeeRatePpm, request.TimeLockDelta, request.InboundFeePolicy?.BaseFeeMsat, request.InboundFeePolicy?.FeeRatePpm);
         }
         catch (ArgumentException e)

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -28,6 +28,8 @@ public interface INodeGuardService
 
     Task<BumpWithdrawalResponse> BumpWithdrawal(BumpWithdrawalRequest request, ServerCallContext context);
 
+    Task<CancelWithdrawalResponse> CancelWithdrawal(CancelWithdrawalRequest request, ServerCallContext context);
+
     Task<GetAvailableWalletsResponse>
         GetAvailableWallets(GetAvailableWalletsRequest request, ServerCallContext context);
 
@@ -350,7 +352,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         }
         catch (NoUTXOsAvailableException)
         {
-            CancelWithdrawalRequest(withdrawalRequest);
+            MarkWithdrawalRequestCancelled(withdrawalRequest);
             _logger.LogError("No available UTXOs for wallet with id {walletId}", request.WalletId);
             throw new RpcException(new Status(StatusCode.ResourceExhausted, "No available UTXOs for wallet"));
         }
@@ -361,19 +363,19 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         }
         catch (RpcException e)
         {
-            CancelWithdrawalRequest(withdrawalRequest);
+            MarkWithdrawalRequestCancelled(withdrawalRequest);
             _logger.LogError(e.Message);
             throw new RpcException(new Status(e.Status.StatusCode, e.Status.Detail));
         }
         catch (Exception e)
         {
-            CancelWithdrawalRequest(withdrawalRequest);
+            MarkWithdrawalRequestCancelled(withdrawalRequest);
             _logger.LogError(e, "Error requesting withdrawal for wallet with id {walletId}", request.WalletId);
             throw new RpcException(new Status(StatusCode.Internal, "Error requesting withdrawal for wallet"));
         }
     }
 
-    private void CancelWithdrawalRequest(WalletWithdrawalRequest? withdrawalRequest)
+    private void MarkWithdrawalRequestCancelled(WalletWithdrawalRequest? withdrawalRequest)
     {
         if (withdrawalRequest != null)
         {
@@ -390,100 +392,131 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
     public override async Task<BumpWithdrawalResponse> BumpWithdrawal(BumpWithdrawalRequest request,
         ServerCallContext context)
     {
-        WalletWithdrawalRequest? bumpRequest = null;
-        var target = DescribeBumpTarget(request);
+        var target = request.TargetCase switch
+        {
+            BumpWithdrawalRequest.TargetOneofCase.RequestId => new ReplacementTarget(request.RequestId, null),
+            BumpWithdrawalRequest.TargetOneofCase.TxId => new ReplacementTarget(null, request.TxId),
+            _ => new ReplacementTarget(null, null),
+        };
+
+        var (requestId, txid, isHotWallet) = await ReplaceWithdrawalAsync(target,
+            (MempoolRecommendedFeesType)request.MempoolFeeRate,
+            request.HasCustomFeeRate ? request.CustomFeeRate : null,
+            cancellation: false);
+
+        return new BumpWithdrawalResponse { RequestId = requestId, Txid = txid, IsHotWallet = isHotWallet };
+    }
+
+    public override async Task<CancelWithdrawalResponse> CancelWithdrawal(CancelWithdrawalRequest request,
+        ServerCallContext context)
+    {
+        var target = request.TargetCase switch
+        {
+            CancelWithdrawalRequest.TargetOneofCase.RequestId => new ReplacementTarget(request.RequestId, null),
+            CancelWithdrawalRequest.TargetOneofCase.TxId => new ReplacementTarget(null, request.TxId),
+            _ => new ReplacementTarget(null, null),
+        };
+
+        var (requestId, txid, isHotWallet) = await ReplaceWithdrawalAsync(target,
+            (MempoolRecommendedFeesType)request.MempoolFeeRate,
+            request.HasCustomFeeRate ? request.CustomFeeRate : null,
+            cancellation: true);
+
+        return new CancelWithdrawalResponse { RequestId = requestId, Txid = txid, IsHotWallet = isHotWallet };
+    }
+
+    /// <summary>The withdrawal to replace, addressed by NodeGuard request id or by the txid RequestWithdrawal returned.</summary>
+    private readonly record struct ReplacementTarget(int? RequestId, string? TxId)
+    {
+        public override string ToString() => TxId != null ? $"txid {TxId}" : $"id {RequestId}";
+    }
+
+    /// <summary>
+    /// Shared body of BumpWithdrawal and CancelWithdrawal: resolve the target, create the replacement through
+    /// WithdrawalRequestService and, for hot wallets, execute it; cold wallets only get the template so the approvers
+    /// reuse it, exactly as RequestWithdrawal does.
+    /// </summary>
+    private async Task<(int RequestId, string Txid, bool IsHotWallet)> ReplaceWithdrawalAsync(ReplacementTarget target,
+        MempoolRecommendedFeesType feeType, decimal? customFeeRate, bool cancellation)
+    {
+        var action = cancellation ? "cancellation" : "fee bump";
+        WalletWithdrawalRequest? replacement = null;
         try
         {
-            var feeType = (MempoolRecommendedFeesType)request.MempoolFeeRate;
-            decimal? customFeeRate = request.HasCustomFeeRate ? request.CustomFeeRate : null;
+            var originalRequestId = await ResolveReplacementTargetAsync(target);
 
-            var originalRequestId = await ResolveBumpTargetAsync(request);
-            bumpRequest = await _withdrawalRequestService.CreateBumpRequestAsync(originalRequestId, feeType, customFeeRate);
+            replacement = cancellation
+                ? await _withdrawalRequestService.CreateCancelRequestAsync(originalRequestId, feeType, customFeeRate)
+                : await _withdrawalRequestService.CreateBumpRequestAsync(originalRequestId, feeType, customFeeRate);
 
-            var isHotWallet = bumpRequest.Wallet?.IsHotWallet ?? false;
+            var isHotWallet = replacement.Wallet?.IsHotWallet ?? false;
 
-            // Hot wallets: NodeGuard signs and broadcasts through PerformWithdrawalJob. Cold wallets: the template is
-            // generated now so the approvers reuse it, exactly as RequestWithdrawal does.
             var psbt = isHotWallet
-                ? await _withdrawalRequestService.ScheduleHotWalletWithdrawalAsync(bumpRequest.Id)
-                : await _bitcoinService.GenerateTemplatePSBT(bumpRequest);
+                ? await _withdrawalRequestService.ScheduleHotWalletWithdrawalAsync(replacement.Id)
+                : await _bitcoinService.GenerateTemplatePSBT(replacement);
 
-            return new BumpWithdrawalResponse
-            {
-                RequestId = bumpRequest.Id,
-                Txid = psbt.GetGlobalTransaction().GetHash().ToString(),
-                IsHotWallet = isHotWallet,
-            };
+            return (replacement.Id, psbt.GetGlobalTransaction().GetHash().ToString(), isHotWallet);
         }
         catch (BumpingException e)
         {
-            _logger.LogWarning("Fee bump of withdrawal request {Target} refused ({Reason}): {Message}",
-                target, e.Reason, e.Message);
-            CancelWithdrawalRequest(bumpRequest);
+            _logger.LogWarning("RBF {Action} of withdrawal request {Target} refused ({Reason}): {Message}",
+                action, target, e.Reason, e.Message);
+            MarkWithdrawalRequestCancelled(replacement);
             throw new RpcException(new Status(ToStatusCode(e.Reason), e.Message));
         }
         catch (NoUTXOsAvailableException)
         {
-            CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError("No available UTXOs to bump withdrawal request {Target}", target);
+            MarkWithdrawalRequestCancelled(replacement);
+            _logger.LogError("No available UTXOs for the RBF {Action} of withdrawal request {Target}", action, target);
             throw new RpcException(new Status(StatusCode.ResourceExhausted, "No available UTXOs for wallet"));
         }
         catch (ShowToUserException e)
         {
-            CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError(e, "Error bumping withdrawal request {Target}", target);
+            MarkWithdrawalRequestCancelled(replacement);
+            _logger.LogError(e, "Error in the RBF {Action} of withdrawal request {Target}", action, target);
             throw new RpcException(new Status(StatusCode.FailedPrecondition, e.Message));
         }
         catch (RpcException)
         {
-            CancelWithdrawalRequest(bumpRequest);
+            MarkWithdrawalRequestCancelled(replacement);
             throw;
         }
         catch (Exception e)
         {
-            CancelWithdrawalRequest(bumpRequest);
-            _logger.LogError(e, "Error bumping withdrawal request {Target}", target);
-            throw new RpcException(new Status(StatusCode.Internal, "Error bumping withdrawal request"));
+            MarkWithdrawalRequestCancelled(replacement);
+            _logger.LogError(e, "Error in the RBF {Action} of withdrawal request {Target}", action, target);
+            throw new RpcException(new Status(StatusCode.Internal, $"Error in the RBF {action} of the withdrawal request"));
         }
     }
 
     /// <summary>
-    /// The withdrawal to bump can be addressed by NodeGuard request id or by the txid RequestWithdrawal returned; the
-    /// latter is resolved here so the service only ever deals with request ids.
+    /// A txid is validated, normalised (stored txids are lowercase hex) and resolved to the request that broadcast it,
+    /// so the service only ever deals with request ids.
     /// </summary>
-    private async Task<int> ResolveBumpTargetAsync(BumpWithdrawalRequest request)
+    private async Task<int> ResolveReplacementTargetAsync(ReplacementTarget target)
     {
-        switch (request.TargetCase)
+        if (target.RequestId is { } requestId)
         {
-            case BumpWithdrawalRequest.TargetOneofCase.RequestId:
-                return request.RequestId;
-
-            case BumpWithdrawalRequest.TargetOneofCase.TxId:
-                if (!uint256.TryParse(request.TxId, out var txId))
-                {
-                    throw new RpcException(new Status(StatusCode.InvalidArgument, "tx_id is not a valid transaction id"));
-                }
-
-                // Stored txids are lowercase hex; normalising through uint256 makes the lookup case-insensitive.
-                var withdrawalRequest = await _walletWithdrawalRequestRepository.GetByTxHash(txId.ToString());
-                if (withdrawalRequest == null)
-                {
-                    throw new RpcException(new Status(StatusCode.NotFound,
-                        $"No withdrawal request found for txid {txId}"));
-                }
-
-                return withdrawalRequest.Id;
-
-            default:
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "request_id or tx_id is required"));
+            return requestId;
         }
-    }
 
-    private static string DescribeBumpTarget(BumpWithdrawalRequest request)
-    {
-        return request.TargetCase == BumpWithdrawalRequest.TargetOneofCase.TxId
-            ? $"txid {request.TxId}"
-            : $"id {request.RequestId}";
+        if (target.TxId is { } rawTxId)
+        {
+            if (!uint256.TryParse(rawTxId, out var txId))
+            {
+                throw new RpcException(new Status(StatusCode.InvalidArgument, "tx_id is not a valid transaction id"));
+            }
+
+            var withdrawalRequest = await _walletWithdrawalRequestRepository.GetByTxHash(txId.ToString());
+            if (withdrawalRequest == null)
+            {
+                throw new RpcException(new Status(StatusCode.NotFound, $"No withdrawal request found for txid {txId}"));
+            }
+
+            return withdrawalRequest.Id;
+        }
+
+        throw new RpcException(new Status(StatusCode.InvalidArgument, "request_id or tx_id is required"));
     }
 
     private static StatusCode ToStatusCode(BumpingErrorReason reason)

--- a/src/Rpc/NodeGuardService.cs
+++ b/src/Rpc/NodeGuardService.cs
@@ -26,6 +26,8 @@ public interface INodeGuardService
 
     Task<RequestWithdrawalResponse> RequestWithdrawal(RequestWithdrawalRequest request, ServerCallContext context);
 
+    Task<BumpWithdrawalResponse> BumpWithdrawal(BumpWithdrawalRequest request, ServerCallContext context);
+
     Task<GetAvailableWalletsResponse>
         GetAvailableWallets(GetAvailableWalletsRequest request, ServerCallContext context);
 
@@ -90,6 +92,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
     private readonly IHtlcMonitoringScheduler _htlcMonitoringScheduler;
     private readonly IRebalanceService _rebalanceService;
     private readonly IRebalanceRepository _rebalanceRepository;
+    private readonly IWithdrawalRequestService _withdrawalRequestService;
 
     public NodeGuardService(ILogger<NodeGuardService> logger,
         ILiquidityRuleRepository liquidityRuleRepository,
@@ -108,7 +111,8 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         IUTXOTagRepository utxoTagRepository,
         IHtlcMonitoringScheduler htlcMonitoringScheduler,
         IRebalanceService rebalanceService,
-        IRebalanceRepository rebalanceRepository
+        IRebalanceRepository rebalanceRepository,
+        IWithdrawalRequestService withdrawalRequestService
     )
     {
         _logger = logger;
@@ -129,6 +133,7 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
         _htlcMonitoringScheduler = htlcMonitoringScheduler;
         _rebalanceService = rebalanceService;
         _rebalanceRepository = rebalanceRepository;
+        _withdrawalRequestService = withdrawalRequestService;
         _scheduler = Task.Run(() => _schedulerFactory.GetScheduler()).Result;
     }
 
@@ -380,6 +385,80 @@ public class NodeGuardService : Nodeguard.NodeGuardService.NodeGuardServiceBase,
                     withdrawalRequest.Id, withdrawalRequest.WalletId);
             }
         }
+    }
+
+    public override async Task<BumpWithdrawalResponse> BumpWithdrawal(BumpWithdrawalRequest request,
+        ServerCallContext context)
+    {
+        WalletWithdrawalRequest? bumpRequest = null;
+        try
+        {
+            var feeType = (MempoolRecommendedFeesType)request.MempoolFeeRate;
+            decimal? customFeeRate = request.HasCustomFeeRate ? request.CustomFeeRate : null;
+
+            bumpRequest = await _withdrawalRequestService.CreateBumpRequestAsync(request.RequestId, feeType, customFeeRate);
+
+            var isHotWallet = bumpRequest.Wallet?.IsHotWallet ?? false;
+
+            // Hot wallets: NodeGuard signs and broadcasts through PerformWithdrawalJob. Cold wallets: the template is
+            // generated now so the approvers reuse it, exactly as RequestWithdrawal does.
+            var psbt = isHotWallet
+                ? await _withdrawalRequestService.ScheduleHotWalletWithdrawalAsync(bumpRequest.Id)
+                : await _bitcoinService.GenerateTemplatePSBT(bumpRequest);
+
+            return new BumpWithdrawalResponse
+            {
+                RequestId = bumpRequest.Id,
+                Txid = psbt.GetGlobalTransaction().GetHash().ToString(),
+                IsHotWallet = isHotWallet,
+            };
+        }
+        catch (BumpingException e)
+        {
+            _logger.LogWarning("Fee bump of withdrawal request {RequestId} refused ({Reason}): {Message}",
+                request.RequestId, e.Reason, e.Message);
+            CancelWithdrawalRequest(bumpRequest);
+            throw new RpcException(new Status(ToStatusCode(e.Reason), e.Message));
+        }
+        catch (NoUTXOsAvailableException)
+        {
+            CancelWithdrawalRequest(bumpRequest);
+            _logger.LogError("No available UTXOs to bump withdrawal request {RequestId}", request.RequestId);
+            throw new RpcException(new Status(StatusCode.ResourceExhausted, "No available UTXOs for wallet"));
+        }
+        catch (ShowToUserException e)
+        {
+            CancelWithdrawalRequest(bumpRequest);
+            _logger.LogError(e, "Error bumping withdrawal request {RequestId}", request.RequestId);
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, e.Message));
+        }
+        catch (RpcException)
+        {
+            CancelWithdrawalRequest(bumpRequest);
+            throw;
+        }
+        catch (Exception e)
+        {
+            CancelWithdrawalRequest(bumpRequest);
+            _logger.LogError(e, "Error bumping withdrawal request {RequestId}", request.RequestId);
+            throw new RpcException(new Status(StatusCode.Internal, "Error bumping withdrawal request"));
+        }
+    }
+
+    private static StatusCode ToStatusCode(BumpingErrorReason reason)
+    {
+        return reason switch
+        {
+            BumpingErrorReason.RequestNotFound => StatusCode.NotFound,
+            BumpingErrorReason.InvalidState
+                or BumpingErrorReason.AlreadyConfirmed
+                or BumpingErrorReason.TransactionNotFound
+                or BumpingErrorReason.ChangelessMultipleDestinations => StatusCode.FailedPrecondition,
+            BumpingErrorReason.InvalidFeeRate
+                or BumpingErrorReason.FeeRateNotHigher
+                or BumpingErrorReason.FeeExceedsInputs => StatusCode.InvalidArgument,
+            _ => StatusCode.Internal,
+        };
     }
 
     public override async Task<GetAvailableWalletsResponse> GetAvailableWallets(GetAvailableWalletsRequest request,

--- a/src/Services/WithdrawalRequestService.cs
+++ b/src/Services/WithdrawalRequestService.cs
@@ -18,6 +18,7 @@
  */
 
 using NBitcoin;
+using NBXplorer.DerivationStrategy;
 using NodeGuard.Data.Models;
 using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.Helpers;
@@ -47,6 +48,15 @@ public interface IWithdrawalRequestService
         decimal? customFeeRate);
 
     /// <summary>
+    /// Validates and creates the RBF CANCELLATION of a withdrawal that is waiting for on-chain confirmation: the same
+    /// locked UTXOs, a higher fee rate, and a single output that returns the funds to a fresh address of the wallet, so
+    /// the original payment never confirms. Same status rules as <see cref="CreateBumpRequestAsync"/>; once executed the
+    /// replaced request ends up Cancelled instead of Bumped.
+    /// </summary>
+    Task<WalletWithdrawalRequest> CreateCancelRequestAsync(int originalRequestId, MempoolRecommendedFeesType feeType,
+        decimal? customFeeRate);
+
+    /// <summary>
     /// Executes a hot-wallet request (fresh or bump): moves it to PSBTSignaturesPending, generates and persists the
     /// template PSBT, marks the request it replaces (if any) as Bumped and schedules <see cref="PerformWithdrawalJob"/>,
     /// which signs and broadcasts. On failure the replaced request is put back to OnChainConfirmationPending and the
@@ -56,21 +66,24 @@ public interface IWithdrawalRequestService
     Task<PSBT> ScheduleHotWalletWithdrawalAsync(int requestId);
 
     /// <summary>
-    /// Marks the request replaced by <paramref name="bumpRequest"/> as Bumped. Cold-wallet flow: called when the last
-    /// human signature lands and the withdrawal job is scheduled. No-op when the request is not a bump.
+    /// Marks the request replaced by <paramref name="replacement"/> as Bumped (fee bump) or Cancelled (RBF cancellation).
+    /// Cold-wallet flow: called when the last human signature lands and the withdrawal job is scheduled. No-op when the
+    /// request is not a replacement.
     /// </summary>
-    Task MarkOriginalAsBumpedAsync(WalletWithdrawalRequest bumpRequest);
+    Task MarkOriginalAsReplacedAsync(WalletWithdrawalRequest replacement);
 
     /// <summary>
-    /// Puts the request replaced by <paramref name="bumpRequest"/> back to OnChainConfirmationPending when the bump is
-    /// abandoned (cancelled, rejected or failed) and the original had already been marked Bumped. No-op otherwise.
+    /// Puts the request replaced by <paramref name="replacement"/> back to OnChainConfirmationPending when the replacement
+    /// is abandoned (cancelled, rejected or failed) and the original had already been marked Bumped / Cancelled by it.
+    /// No-op otherwise.
     /// </summary>
-    Task RevertOriginalAsync(WalletWithdrawalRequest bumpRequest);
+    Task RevertOriginalAsync(WalletWithdrawalRequest replacement);
 }
 
 public class WithdrawalRequestService : IWithdrawalRequestService
 {
     public const string BumpDescriptionPrefix = "Bump of request";
+    public const string CancelDescriptionPrefix = "Cancel of request";
 
     private readonly ILogger<WithdrawalRequestService> _logger;
     private readonly IWalletWithdrawalRequestRepository _walletWithdrawalRequestRepository;
@@ -97,8 +110,21 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         _schedulerFactory = schedulerFactory;
     }
 
-    public async Task<WalletWithdrawalRequest> CreateBumpRequestAsync(int originalRequestId,
+    public Task<WalletWithdrawalRequest> CreateBumpRequestAsync(int originalRequestId,
         MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+        => CreateReplacementAsync(originalRequestId, feeType, customFeeRate, cancellation: false);
+
+    public Task<WalletWithdrawalRequest> CreateCancelRequestAsync(int originalRequestId,
+        MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+        => CreateReplacementAsync(originalRequestId, feeType, customFeeRate, cancellation: true);
+
+    /// <summary>
+    /// A fee bump keeps the original destinations and pays the higher fee from the change; a cancellation keeps only the
+    /// inputs and sends everything, minus the fee, back to the wallet. Everything else — validation, status rules, UTXO
+    /// locking — is the same.
+    /// </summary>
+    private async Task<WalletWithdrawalRequest> CreateReplacementAsync(int originalRequestId,
+        MempoolRecommendedFeesType feeType, decimal? customFeeRate, bool cancellation)
     {
         var original = await _walletWithdrawalRequestRepository.GetById(originalRequestId)
                        ?? throw new BumpingException("Withdrawal request not found", BumpingErrorReason.RequestNotFound);
@@ -106,7 +132,7 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         if (original.Status != WalletWithdrawalRequestStatus.OnChainConfirmationPending)
         {
             throw new BumpingException(
-                "Bumpfee can only be used for transactions that are pending on-chain confirmation.",
+                "Only withdrawals that are pending on-chain confirmation can be replaced.",
                 BumpingErrorReason.InvalidState);
         }
 
@@ -123,7 +149,7 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         if (originalTx.Confirmations > 0)
         {
             throw new BumpingException(
-                "Bumpfee can only be used for transactions with no confirmations. This transaction has already been mined.",
+                "Only transactions with no confirmations can be replaced. This transaction has already been mined.",
                 BumpingErrorReason.AlreadyConfirmed);
         }
 
@@ -134,7 +160,8 @@ public class WithdrawalRequestService : IWithdrawalRequestService
                 BumpingErrorReason.InvalidState);
         }
 
-        if (original.Changeless && destinations.Count > 1)
+        // A cancellation replaces every output, so the shape of the original does not matter to it.
+        if (!cancellation && original.Changeless && destinations.Count > 1)
         {
             throw new BumpingException(
                 "Fee bumping is not supported for changeless transactions. Please create a new withdrawal with higher fees instead.",
@@ -144,6 +171,10 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         var wallet = original.Wallet
                      ?? throw new BumpingException("The wallet of the withdrawal request could not be loaded.",
                          BumpingErrorReason.InvalidState);
+
+        var derivationStrategy = wallet.GetDerivationStrategy()
+                                 ?? throw new BumpingException("The wallet has no derivation strategy.",
+                                     BumpingErrorReason.InvalidState);
 
         var newFeeRate = await ResolveFeeRateAsync(feeType, customFeeRate);
 
@@ -156,8 +187,8 @@ public class WithdrawalRequestService : IWithdrawalRequestService
 
         // A single-destination request can shrink its destination to pay the higher fee (GenerateTemplatePSBT's
         // changeless branch subtracts the fee from the output), so the inputs-cover-everything check only applies
-        // when there is more than one destination.
-        if (original.UTXOs is { Count: > 0 } && destinations.Count > 1)
+        // when there is more than one destination. A cancellation has a single output by construction.
+        if (!cancellation && original.UTXOs is { Count: > 0 } && destinations.Count > 1)
         {
             var vSize = originalTx.Transaction.GetVirtualSize();
             var newFee = vSize * newFeeRate / 100_000_000m;
@@ -170,49 +201,70 @@ public class WithdrawalRequestService : IWithdrawalRequestService
             }
         }
 
-        var bump = new WalletWithdrawalRequest
+        // RBF replaces the very same inputs: the replacement locks exactly the UTXOs of the request it replaces.
+        var lockedUtxos = await _fmutxoRepository.GetLockedUTXOsByWithdrawalId(original.Id);
+        if (lockedUtxos.Count == 0)
         {
-            Description = $"{BumpDescriptionPrefix} {original.Id}: {StripBumpPrefix(original.Description)}",
-            Changeless = original.Changeless,
-            WithdrawAllFunds = original.WithdrawAllFunds,
+            throw new BumpingException("The withdrawal request to replace has no UTXOs locked.",
+                BumpingErrorReason.InvalidState);
+        }
+
+        List<WalletWithdrawalRequestDestination> replacementDestinations;
+        if (cancellation)
+        {
+            // Everything the inputs hold goes back to a fresh address of the same wallet; GenerateTemplatePSBT's
+            // changeless branch then subtracts the fee from that single output.
+            var returnAddress = await _nbXplorerService.GetUnusedAsync(derivationStrategy, DerivationFeature.Deposit, 0, true)
+                                ?? throw new BumpingException("Could not derive an address of the wallet to return the funds to.",
+                                    BumpingErrorReason.PersistenceError);
+
+            replacementDestinations = new List<WalletWithdrawalRequestDestination>
+            {
+                new()
+                {
+                    Address = returnAddress.Address.ToString(),
+                    Amount = Money.Satoshis(lockedUtxos.Sum(u => u.SatsAmount)).ToDecimal(MoneyUnit.BTC),
+                },
+            };
+        }
+        else
+        {
+            replacementDestinations = destinations
+                .Select(d => new WalletWithdrawalRequestDestination { Address = d.Address, Amount = d.Amount })
+                .ToList();
+        }
+
+        var prefix = cancellation ? CancelDescriptionPrefix : BumpDescriptionPrefix;
+        var replacement = new WalletWithdrawalRequest
+        {
+            Description = $"{prefix} {original.Id}: {StripReplacementPrefix(original.Description)}",
+            Changeless = cancellation || original.Changeless,
+            WithdrawAllFunds = !cancellation && original.WithdrawAllFunds,
             MempoolRecommendedFeesType = feeType,
             CustomFeeRate = newFeeRate,
             UserRequestorId = original.UserRequestorId,
             RequestMetadata = original.RequestMetadata,
             BumpingWalletWithdrawalRequestId = original.Id,
+            IsRbfCancellation = cancellation,
             WalletId = original.WalletId,
             // Hot wallets have no human approvers, so the request goes straight to PSBTSignaturesPending, the status
             // PerformWithdrawal requires. Same convention as TransferFundsModal and NodeGuardService.RequestWithdrawal.
             Status = wallet.IsHotWallet
                 ? WalletWithdrawalRequestStatus.PSBTSignaturesPending
                 : WalletWithdrawalRequestStatus.Pending,
-            WalletWithdrawalRequestDestinations = destinations
-                .Select(d => new WalletWithdrawalRequestDestination { Address = d.Address, Amount = d.Amount })
-                .ToList(),
+            WalletWithdrawalRequestDestinations = replacementDestinations,
         };
 
-        var (added, addError) = await _walletWithdrawalRequestRepository.AddAsync(bump);
+        var (added, addError) = await _walletWithdrawalRequestRepository.AddAsync(replacement);
         if (!added)
         {
-            _logger.LogError("Error creating the bump of withdrawal request {RequestId}: {Error}", original.Id, addError);
-            throw new BumpingException(addError ?? "Could not create the bump request",
+            _logger.LogError("Error creating the replacement of withdrawal request {RequestId}: {Error}", original.Id, addError);
+            throw new BumpingException(addError ?? "Could not create the replacement request",
                 BumpingErrorReason.PersistenceError);
         }
 
         try
         {
-            // RBF replaces the very same inputs: the bump locks exactly the UTXOs of the request it replaces.
-            var lockedUtxos = await _fmutxoRepository.GetLockedUTXOsByWithdrawalId(original.Id);
-            if (lockedUtxos.Count == 0)
-            {
-                throw new BumpingException("The withdrawal request to replace has no UTXOs locked.",
-                    BumpingErrorReason.InvalidState);
-            }
-
-            var derivationStrategy = wallet.GetDerivationStrategy()
-                                     ?? throw new BumpingException("The wallet has no derivation strategy.",
-                                         BumpingErrorReason.InvalidState);
-
             var outpoints = lockedUtxos.Select(u => OutPoint.Parse($"{u.TxId}:{u.OutputIndex}")).ToList();
             var utxos = await _coinSelectionService.GetUTXOsByOutpointAsync(derivationStrategy, outpoints);
             if (utxos.Select(u => u.Outpoint).Distinct().Count() != outpoints.Count)
@@ -222,18 +274,18 @@ public class WithdrawalRequestService : IWithdrawalRequestService
                     BumpingErrorReason.InvalidState);
             }
 
-            await _coinSelectionService.LockUTXOs(utxos, bump, BitcoinRequestType.WalletWithdrawal);
+            await _coinSelectionService.LockUTXOs(utxos, replacement, BitcoinRequestType.WalletWithdrawal);
         }
         catch (Exception)
         {
-            // Never leave a half-prepared bump behind as a pending request.
-            bump.Status = WalletWithdrawalRequestStatus.Cancelled;
-            bump.RejectCancelDescription = "The bump request could not be prepared";
-            _walletWithdrawalRequestRepository.Update(bump);
+            // Never leave a half-prepared replacement behind as a pending request.
+            replacement.Status = WalletWithdrawalRequestStatus.Cancelled;
+            replacement.RejectCancelDescription = "The replacement request could not be prepared";
+            _walletWithdrawalRequestRepository.Update(replacement);
             throw;
         }
 
-        return await _walletWithdrawalRequestRepository.GetById(bump.Id) ?? bump;
+        return await _walletWithdrawalRequestRepository.GetById(replacement.Id) ?? replacement;
     }
 
     public async Task<PSBT> ScheduleHotWalletWithdrawalAsync(int requestId)
@@ -275,7 +327,7 @@ public class WithdrawalRequestService : IWithdrawalRequestService
 
             if (request.BumpingWalletWithdrawalRequestId != null)
             {
-                await MarkOriginalAsBumpedAsync(request);
+                await MarkOriginalAsReplacedAsync(request);
             }
 
             var scheduler = await _schedulerFactory.GetScheduler();
@@ -294,33 +346,48 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         }
     }
 
-    public async Task MarkOriginalAsBumpedAsync(WalletWithdrawalRequest bumpRequest)
+    public async Task MarkOriginalAsReplacedAsync(WalletWithdrawalRequest replacement)
     {
-        if (bumpRequest.BumpingWalletWithdrawalRequestId is not { } originalId) return;
+        if (replacement.BumpingWalletWithdrawalRequestId is not { } originalId) return;
 
         var original = await _walletWithdrawalRequestRepository.GetById(originalId)
-                       ?? throw new BumpingException("Could not find bumping withdrawal request",
+                       ?? throw new BumpingException("Could not find the replaced withdrawal request",
                            BumpingErrorReason.RequestNotFound);
 
-        if (original.Status == WalletWithdrawalRequestStatus.Bumped) return;
+        var targetStatus = replacement.IsRbfCancellation
+            ? WalletWithdrawalRequestStatus.Cancelled
+            : WalletWithdrawalRequestStatus.Bumped;
+        if (original.Status == targetStatus) return;
 
-        original.Status = WalletWithdrawalRequestStatus.Bumped;
+        original.Status = targetStatus;
+        if (replacement.IsRbfCancellation)
+        {
+            original.RejectCancelDescription = CancellationReason(replacement.Id);
+        }
+
         var (updated, error) = _walletWithdrawalRequestRepository.Update(original);
         if (!updated)
         {
-            throw new BumpingException($"Could not mark withdrawal request {originalId} as bumped: {error}",
+            throw new BumpingException($"Could not mark withdrawal request {originalId} as {targetStatus}: {error}",
                 BumpingErrorReason.PersistenceError);
         }
     }
 
-    public async Task RevertOriginalAsync(WalletWithdrawalRequest bumpRequest)
+    public async Task RevertOriginalAsync(WalletWithdrawalRequest replacement)
     {
-        if (bumpRequest.BumpingWalletWithdrawalRequestId is not { } originalId) return;
+        if (replacement.BumpingWalletWithdrawalRequestId is not { } originalId) return;
 
         var original = await _walletWithdrawalRequestRepository.GetById(originalId);
-        if (original == null || original.Status != WalletWithdrawalRequestStatus.Bumped) return;
+        if (original == null) return;
+
+        var markedByThisReplacement = original.Status == WalletWithdrawalRequestStatus.Bumped
+                                      || (replacement.IsRbfCancellation
+                                          && original.Status == WalletWithdrawalRequestStatus.Cancelled
+                                          && original.RejectCancelDescription == CancellationReason(replacement.Id));
+        if (!markedByThisReplacement) return;
 
         original.Status = WalletWithdrawalRequestStatus.OnChainConfirmationPending;
+        original.RejectCancelDescription = null;
         var (updated, error) = _walletWithdrawalRequestRepository.Update(original);
         if (!updated)
         {
@@ -352,11 +419,16 @@ public class WithdrawalRequestService : IWithdrawalRequestService
         return recommended.Value;
     }
 
-    /// <summary>Bumps of bumps keep a single "Bump of request N:" prefix, pointing at the request being replaced.</summary>
-    private static string StripBumpPrefix(string? description)
+    private static string CancellationReason(int replacementId) => $"Cancelled by RBF replacement request {replacementId}";
+
+    /// <summary>
+    /// Replacements of replacements keep a single "Bump of request N:" / "Cancel of request N:" prefix, pointing at the
+    /// request being replaced.
+    /// </summary>
+    private static string StripReplacementPrefix(string? description)
     {
         var text = description ?? string.Empty;
-        if (!text.StartsWith(BumpDescriptionPrefix)) return text;
+        if (!text.StartsWith(BumpDescriptionPrefix) && !text.StartsWith(CancelDescriptionPrefix)) return text;
 
         var colon = text.IndexOf(':');
         return colon >= 0 ? text[(colon + 1)..].Trim() : text;

--- a/src/Services/WithdrawalRequestService.cs
+++ b/src/Services/WithdrawalRequestService.cs
@@ -1,0 +1,364 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using NBitcoin;
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
+using NodeGuard.Jobs;
+using Quartz;
+
+namespace NodeGuard.Services;
+
+/// <summary>
+/// Withdrawal-request lifecycle steps shared by the Blazor UI and the gRPC API: RBF fee bumps and the execution of
+/// hot-wallet requests.
+///
+/// Keeping the orchestration here, rather than in BumpfeeModal.razor / Withdrawals.razor, lets the gRPC API expose it and the
+/// E2E suite exercise the same code the pages run. Hot-wallet requests are moved to PSBTSignaturesPending explicitly: it is
+/// the status PerformWithdrawal requires, and a hot wallet has no approvers whose signatures would get it there.
+/// </summary>
+public interface IWithdrawalRequestService
+{
+    /// <summary>
+    /// Validates and creates the RBF bump of a withdrawal that is waiting for on-chain confirmation: same destinations
+    /// and the same locked UTXOs, higher fee rate. Cold-wallet bumps start Pending (approvers sign them like any other
+    /// request); hot-wallet bumps start in PSBTSignaturesPending and are executed with
+    /// <see cref="ScheduleHotWalletWithdrawalAsync"/>. Throws <see cref="BumpingException"/> with a user-facing message
+    /// and a <see cref="BumpingErrorReason"/> when the bump is refused.
+    /// </summary>
+    Task<WalletWithdrawalRequest> CreateBumpRequestAsync(int originalRequestId, MempoolRecommendedFeesType feeType,
+        decimal? customFeeRate);
+
+    /// <summary>
+    /// Executes a hot-wallet request (fresh or bump): moves it to PSBTSignaturesPending, generates and persists the
+    /// template PSBT, marks the request it replaces (if any) as Bumped and schedules <see cref="PerformWithdrawalJob"/>,
+    /// which signs and broadcasts. On failure the replaced request is put back to OnChainConfirmationPending and the
+    /// exception is rethrown; the caller decides what happens to the request itself.
+    /// </summary>
+    /// <returns>The template PSBT; its global transaction hash is the txid that will be broadcast.</returns>
+    Task<PSBT> ScheduleHotWalletWithdrawalAsync(int requestId);
+
+    /// <summary>
+    /// Marks the request replaced by <paramref name="bumpRequest"/> as Bumped. Cold-wallet flow: called when the last
+    /// human signature lands and the withdrawal job is scheduled. No-op when the request is not a bump.
+    /// </summary>
+    Task MarkOriginalAsBumpedAsync(WalletWithdrawalRequest bumpRequest);
+
+    /// <summary>
+    /// Puts the request replaced by <paramref name="bumpRequest"/> back to OnChainConfirmationPending when the bump is
+    /// abandoned (cancelled, rejected or failed) and the original had already been marked Bumped. No-op otherwise.
+    /// </summary>
+    Task RevertOriginalAsync(WalletWithdrawalRequest bumpRequest);
+}
+
+public class WithdrawalRequestService : IWithdrawalRequestService
+{
+    public const string BumpDescriptionPrefix = "Bump of request";
+
+    private readonly ILogger<WithdrawalRequestService> _logger;
+    private readonly IWalletWithdrawalRequestRepository _walletWithdrawalRequestRepository;
+    private readonly IFMUTXORepository _fmutxoRepository;
+    private readonly ICoinSelectionService _coinSelectionService;
+    private readonly INBXplorerService _nbXplorerService;
+    private readonly IBitcoinService _bitcoinService;
+    private readonly ISchedulerFactory _schedulerFactory;
+
+    public WithdrawalRequestService(ILogger<WithdrawalRequestService> logger,
+        IWalletWithdrawalRequestRepository walletWithdrawalRequestRepository,
+        IFMUTXORepository fmutxoRepository,
+        ICoinSelectionService coinSelectionService,
+        INBXplorerService nbXplorerService,
+        IBitcoinService bitcoinService,
+        ISchedulerFactory schedulerFactory)
+    {
+        _logger = logger;
+        _walletWithdrawalRequestRepository = walletWithdrawalRequestRepository;
+        _fmutxoRepository = fmutxoRepository;
+        _coinSelectionService = coinSelectionService;
+        _nbXplorerService = nbXplorerService;
+        _bitcoinService = bitcoinService;
+        _schedulerFactory = schedulerFactory;
+    }
+
+    public async Task<WalletWithdrawalRequest> CreateBumpRequestAsync(int originalRequestId,
+        MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+    {
+        var original = await _walletWithdrawalRequestRepository.GetById(originalRequestId)
+                       ?? throw new BumpingException("Withdrawal request not found", BumpingErrorReason.RequestNotFound);
+
+        if (original.Status != WalletWithdrawalRequestStatus.OnChainConfirmationPending)
+        {
+            throw new BumpingException(
+                "Bumpfee can only be used for transactions that are pending on-chain confirmation.",
+                BumpingErrorReason.InvalidState);
+        }
+
+        if (string.IsNullOrEmpty(original.TxId))
+        {
+            throw new BumpingException("The withdrawal request has no transaction to replace.",
+                BumpingErrorReason.InvalidState);
+        }
+
+        var originalTx = await _nbXplorerService.GetTransactionAsync(uint256.Parse(original.TxId))
+                         ?? throw new BumpingException("The transaction to replace could not be retrieved.",
+                             BumpingErrorReason.TransactionNotFound);
+
+        if (originalTx.Confirmations > 0)
+        {
+            throw new BumpingException(
+                "Bumpfee can only be used for transactions with no confirmations. This transaction has already been mined.",
+                BumpingErrorReason.AlreadyConfirmed);
+        }
+
+        var destinations = original.WalletWithdrawalRequestDestinations ?? new List<WalletWithdrawalRequestDestination>();
+        if (destinations.Count == 0)
+        {
+            throw new BumpingException("Original withdrawal request destinations not found",
+                BumpingErrorReason.InvalidState);
+        }
+
+        if (original.Changeless && destinations.Count > 1)
+        {
+            throw new BumpingException(
+                "Fee bumping is not supported for changeless transactions. Please create a new withdrawal with higher fees instead.",
+                BumpingErrorReason.ChangelessMultipleDestinations);
+        }
+
+        var wallet = original.Wallet
+                     ?? throw new BumpingException("The wallet of the withdrawal request could not be loaded.",
+                         BumpingErrorReason.InvalidState);
+
+        var newFeeRate = await ResolveFeeRateAsync(feeType, customFeeRate);
+
+        var currentFeeRate = original.CustomFeeRate ?? 0;
+        if (newFeeRate <= currentFeeRate)
+        {
+            throw new BumpingException($"Fee must be greater than the current one ({currentFeeRate} sat/vb)",
+                BumpingErrorReason.FeeRateNotHigher);
+        }
+
+        // A single-destination request can shrink its destination to pay the higher fee (GenerateTemplatePSBT's
+        // changeless branch subtracts the fee from the output), so the inputs-cover-everything check only applies
+        // when there is more than one destination.
+        if (original.UTXOs is { Count: > 0 } && destinations.Count > 1)
+        {
+            var vSize = originalTx.Transaction.GetVirtualSize();
+            var newFee = vSize * newFeeRate / 100_000_000m;
+            var inputAmount = Money.Satoshis(original.UTXOs.Sum(x => x.SatsAmount)).ToDecimal(MoneyUnit.BTC);
+            if (inputAmount < newFee + original.TotalAmount + Constants.BITCOIN_DUST.ToDecimal(MoneyUnit.BTC))
+            {
+                throw new BumpingException(
+                    "The new fee plus the amount exceeds the sum of the selected UTXOs or returns dust. Please lower the fee rate.",
+                    BumpingErrorReason.FeeExceedsInputs);
+            }
+        }
+
+        var bump = new WalletWithdrawalRequest
+        {
+            Description = $"{BumpDescriptionPrefix} {original.Id}: {StripBumpPrefix(original.Description)}",
+            Changeless = original.Changeless,
+            WithdrawAllFunds = original.WithdrawAllFunds,
+            MempoolRecommendedFeesType = feeType,
+            CustomFeeRate = newFeeRate,
+            UserRequestorId = original.UserRequestorId,
+            RequestMetadata = original.RequestMetadata,
+            BumpingWalletWithdrawalRequestId = original.Id,
+            WalletId = original.WalletId,
+            // Hot wallets have no human approvers, so the request goes straight to PSBTSignaturesPending, the status
+            // PerformWithdrawal requires. Same convention as TransferFundsModal and NodeGuardService.RequestWithdrawal.
+            Status = wallet.IsHotWallet
+                ? WalletWithdrawalRequestStatus.PSBTSignaturesPending
+                : WalletWithdrawalRequestStatus.Pending,
+            WalletWithdrawalRequestDestinations = destinations
+                .Select(d => new WalletWithdrawalRequestDestination { Address = d.Address, Amount = d.Amount })
+                .ToList(),
+        };
+
+        var (added, addError) = await _walletWithdrawalRequestRepository.AddAsync(bump);
+        if (!added)
+        {
+            _logger.LogError("Error creating the bump of withdrawal request {RequestId}: {Error}", original.Id, addError);
+            throw new BumpingException(addError ?? "Could not create the bump request",
+                BumpingErrorReason.PersistenceError);
+        }
+
+        try
+        {
+            // RBF replaces the very same inputs: the bump locks exactly the UTXOs of the request it replaces.
+            var lockedUtxos = await _fmutxoRepository.GetLockedUTXOsByWithdrawalId(original.Id);
+            if (lockedUtxos.Count == 0)
+            {
+                throw new BumpingException("The withdrawal request to replace has no UTXOs locked.",
+                    BumpingErrorReason.InvalidState);
+            }
+
+            var derivationStrategy = wallet.GetDerivationStrategy()
+                                     ?? throw new BumpingException("The wallet has no derivation strategy.",
+                                         BumpingErrorReason.InvalidState);
+
+            var outpoints = lockedUtxos.Select(u => OutPoint.Parse($"{u.TxId}:{u.OutputIndex}")).ToList();
+            var utxos = await _coinSelectionService.GetUTXOsByOutpointAsync(derivationStrategy, outpoints);
+            if (utxos.Select(u => u.Outpoint).Distinct().Count() != outpoints.Count)
+            {
+                throw new BumpingException(
+                    "The UTXOs of the transaction to replace are no longer available. It may have been confirmed.",
+                    BumpingErrorReason.InvalidState);
+            }
+
+            await _coinSelectionService.LockUTXOs(utxos, bump, BitcoinRequestType.WalletWithdrawal);
+        }
+        catch (Exception)
+        {
+            // Never leave a half-prepared bump behind as a pending request.
+            bump.Status = WalletWithdrawalRequestStatus.Cancelled;
+            bump.RejectCancelDescription = "The bump request could not be prepared";
+            _walletWithdrawalRequestRepository.Update(bump);
+            throw;
+        }
+
+        return await _walletWithdrawalRequestRepository.GetById(bump.Id) ?? bump;
+    }
+
+    public async Task<PSBT> ScheduleHotWalletWithdrawalAsync(int requestId)
+    {
+        var request = await _walletWithdrawalRequestRepository.GetById(requestId)
+                      ?? throw new InvalidOperationException($"Withdrawal request {requestId} not found");
+
+        if (request.Wallet is not { IsHotWallet: true })
+        {
+            throw new InvalidOperationException(
+                $"Withdrawal request {requestId} is not on a hot wallet, it needs human signatures");
+        }
+
+        switch (request.Status)
+        {
+            case WalletWithdrawalRequestStatus.Pending:
+                // PerformWithdrawal refuses anything but PSBTSignaturesPending/FinalizingPSBT. A hot wallet has no
+                // approvers whose signatures would move the request there, so it is promoted here, before the job that
+                // signs and broadcasts is scheduled.
+                request.Status = WalletWithdrawalRequestStatus.PSBTSignaturesPending;
+                var (updated, error) = _walletWithdrawalRequestRepository.Update(request);
+                if (!updated)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not update the status of withdrawal request {requestId}: {error}");
+                }
+
+                break;
+            case WalletWithdrawalRequestStatus.PSBTSignaturesPending:
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Withdrawal request {requestId} cannot be executed from status {request.Status}");
+        }
+
+        try
+        {
+            var templatePsbt = await _bitcoinService.GenerateTemplatePSBT(request);
+
+            if (request.BumpingWalletWithdrawalRequestId != null)
+            {
+                await MarkOriginalAsBumpedAsync(request);
+            }
+
+            var scheduler = await _schedulerFactory.GetScheduler();
+            var map = new JobDataMap();
+            map.Put("withdrawalRequestId", request.Id);
+            var job = SimpleJob.Create<PerformWithdrawalJob>(map, request.Id.ToString());
+            await scheduler.ScheduleJob(job.Job, job.Trigger);
+
+            return templatePsbt;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error executing withdrawal request {RequestId}", request.Id);
+            await RevertOriginalAsync(request);
+            throw;
+        }
+    }
+
+    public async Task MarkOriginalAsBumpedAsync(WalletWithdrawalRequest bumpRequest)
+    {
+        if (bumpRequest.BumpingWalletWithdrawalRequestId is not { } originalId) return;
+
+        var original = await _walletWithdrawalRequestRepository.GetById(originalId)
+                       ?? throw new BumpingException("Could not find bumping withdrawal request",
+                           BumpingErrorReason.RequestNotFound);
+
+        if (original.Status == WalletWithdrawalRequestStatus.Bumped) return;
+
+        original.Status = WalletWithdrawalRequestStatus.Bumped;
+        var (updated, error) = _walletWithdrawalRequestRepository.Update(original);
+        if (!updated)
+        {
+            throw new BumpingException($"Could not mark withdrawal request {originalId} as bumped: {error}",
+                BumpingErrorReason.PersistenceError);
+        }
+    }
+
+    public async Task RevertOriginalAsync(WalletWithdrawalRequest bumpRequest)
+    {
+        if (bumpRequest.BumpingWalletWithdrawalRequestId is not { } originalId) return;
+
+        var original = await _walletWithdrawalRequestRepository.GetById(originalId);
+        if (original == null || original.Status != WalletWithdrawalRequestStatus.Bumped) return;
+
+        original.Status = WalletWithdrawalRequestStatus.OnChainConfirmationPending;
+        var (updated, error) = _walletWithdrawalRequestRepository.Update(original);
+        if (!updated)
+        {
+            _logger.LogError("Could not put withdrawal request {RequestId} back to OnChainConfirmationPending: {Error}",
+                originalId, error);
+        }
+    }
+
+    private async Task<decimal> ResolveFeeRateAsync(MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+    {
+        if (feeType == MempoolRecommendedFeesType.CustomFee)
+        {
+            if (customFeeRate is null or <= 0)
+            {
+                throw new BumpingException("A custom fee rate greater than zero is required.",
+                    BumpingErrorReason.InvalidFeeRate);
+            }
+
+            return customFeeRate.Value;
+        }
+
+        var recommended = await _nbXplorerService.GetFeesByType(feeType);
+        if (recommended is null or <= 0)
+        {
+            throw new BumpingException("The recommended fee rate could not be retrieved.",
+                BumpingErrorReason.InvalidFeeRate);
+        }
+
+        return recommended.Value;
+    }
+
+    /// <summary>Bumps of bumps keep a single "Bump of request N:" prefix, pointing at the request being replaced.</summary>
+    private static string StripBumpPrefix(string? description)
+    {
+        var text = description ?? string.Empty;
+        if (!text.StartsWith(BumpDescriptionPrefix)) return text;
+
+        var colon = text.IndexOf(':');
+        return colon >= 0 ? text[(colon + 1)..].Trim() : text;
+    }
+}

--- a/src/Shared/BumpfeeModal.razor
+++ b/src/Shared/BumpfeeModal.razor
@@ -64,11 +64,8 @@
 @inject IBitcoinService BitcoinService
 @inject IPriceConversionService PriceConversionService
 @inject INBXplorerService NBXplorerService
-@inject IWalletWithdrawalRequestRepository WalletWithdrawalRequestRepository
-@inject IWalletWithdrawalRequestDestinationRepository WalletWithdrawalRequestDestinationRepository
-@inject ICoinSelectionService CoinSelectionService
 @inject IWalletRepository WalletRepository
-@inject IFMUTXORepository FMUTXORepository
+@inject IWithdrawalRequestService WithdrawalRequestService
 @inject IToastService ToastService
 @inject ILogger<BumpfeeModal> Logger
 @code {
@@ -116,69 +113,26 @@
         if (_customSatPerVbAmount <= oldFee)
         {
             ToastService.ShowError($"Fee must be greater than the current one ({oldFee} sat/vb)");
+            return;
         }
-        else
+
+        try
         {
-            var newRequest = new WalletWithdrawalRequest();
-            if (WithdrawalRequest.Description.StartsWith("Bump of request"))
-            {
-                var formerDescription = WithdrawalRequest.Description.Substring(WithdrawalRequest.Description.IndexOf(":") + 1);
-                WithdrawalRequest.Description = formerDescription.Trim();
-            }
-
-            newRequest.Description = $"Bump of request {WithdrawalRequest.Id}: {WithdrawalRequest.Description}";
-            newRequest.Changeless = WithdrawalRequest.Changeless;
-            newRequest.WithdrawAllFunds = WithdrawalRequest.WithdrawAllFunds;
-            newRequest.MempoolRecommendedFeesType = _selectedMempoolRecommendedFeesType;
-            newRequest.CustomFeeRate = _customSatPerVbAmount;
-            newRequest.UserRequestorId = WithdrawalRequest.UserRequestorId;
-            newRequest.RequestMetadata = WithdrawalRequest.RequestMetadata;
-            newRequest.BumpingWalletWithdrawalRequestId = WithdrawalRequest.Id;
-            newRequest.WalletId = WithdrawalRequest.WalletId;
-
-            // Get destinations from the original request
-            var originalDestinations = await WalletWithdrawalRequestDestinationRepository.GetByWalletWithdrawalRequestId(WithdrawalRequest.Id);
-            if (originalDestinations == null || originalDestinations.Count == 0)
-            {
-                throw new ShowToUserException("Original withdrawal request destinations not found");
-            }
-
-            newRequest.WalletWithdrawalRequestDestinations = originalDestinations.Select(d => new WalletWithdrawalRequestDestination
-            {
-                Address = d.Address,
-                Amount = d.Amount,
-                WalletWithdrawalRequestId = newRequest.Id
-            }).ToList();
-
-            var addResult = await WalletWithdrawalRequestRepository.AddAsync(newRequest);
-            if (!addResult.Item1)
-            {
-                Logger.LogError("Error creating a new withdrawal request for bumping fee: {Error}", addResult.Item2);
-                ToastService.ShowError("Something went wrong");
-                return;
-            }
-
-            newRequest = await WalletWithdrawalRequestRepository.GetById(newRequest.Id);
-
-            // Get utxos from the original request
-            var mUTXOs = await FMUTXORepository.GetLockedUTXOsByWithdrawalId(WithdrawalRequest.Id);
-
-            newRequest!.UTXOs = mUTXOs;
-            var outpoints = mUTXOs.Select(u => OutPoint.Parse($"{u.TxId}:{u.OutputIndex}")).ToList();
-            var UTXOs = await CoinSelectionService.GetUTXOsByOutpointAsync(WithdrawalRequest.Wallet.GetDerivationStrategy()!, outpoints);
-
-            await CoinSelectionService.LockUTXOs(UTXOs, newRequest, BitcoinRequestType.WalletWithdrawal);
-
-            var updateResult = WalletWithdrawalRequestRepository.Update(newRequest);
-            if (!updateResult.Item1)
-            {
-                Logger.LogError("Error creating a new withdrawal request for bumping fee: {Error}", updateResult.Item2);
-                ToastService.ShowError("Something went wrong");
-                return;
-            }
-
+            // Validation, creation and UTXO locking of the bump live in WithdrawalRequestService, shared with the
+            // BumpWithdrawal gRPC method (and covered end to end there).
+            var newRequest = await WithdrawalRequestService.CreateBumpRequestAsync(WithdrawalRequest.Id,
+                _selectedMempoolRecommendedFeesType, _customSatPerVbAmount);
 
             SubmitBumpfeeModal?.Invoke(newRequest);
+        }
+        catch (BumpingException e)
+        {
+            ToastService.ShowError(e.Message);
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error creating a new withdrawal request for bumping fee");
+            ToastService.ShowError("Something went wrong");
         }
     }
     

--- a/src/Shared/BumpfeeModal.razor
+++ b/src/Shared/BumpfeeModal.razor
@@ -5,10 +5,19 @@
     {
     <ModalContent Centered>
         <ModalHeader>
-            <ModalTitle>Request fee bump</ModalTitle>
+            <ModalTitle>@(Cancellation ? "Cancel withdrawal (RBF)" : "Request fee bump")</ModalTitle>
             <CloseButton />
         </ModalHeader>
         <ModalBody>
+            @if (Cancellation)
+            {
+                <Alert Color="Color.Warning" Visible>
+                    <AlertMessage>
+                        The pending transaction is replaced by one that spends the same inputs and returns the funds to this
+                        wallet. The destination will not be paid. The replacement needs a higher fee rate than the current one.
+                    </AlertMessage>
+                </Alert>
+            }
             <Fields Flex="Flex.JustifyContent.Center">
                 <Field>
                     <FieldLabel>New fee rate</FieldLabel>
@@ -53,8 +62,8 @@
         </ModalBody>
         <ModalFooter>
             <Button Color="Color.Secondary" Clicked="@HideModal">Cancel</Button>
-            <Button id="approve-button" Color="Color.Primary" Clicked="@HandleOnClick">
-                Approve
+            <Button id="approve-button" Color="@(Cancellation ? Color.Danger : Color.Primary)" Clicked="@HandleOnClick">
+                @(Cancellation ? "Cancel withdrawal" : "Approve")
             </Button>
         </ModalFooter>
     </ModalContent>
@@ -76,6 +85,10 @@
 
     [Parameter]
     public Action<WalletWithdrawalRequest> SubmitBumpfeeModal { get; set; }
+
+    /// <summary>False: bump the fee of the withdrawal. True: cancel it with an RBF replacement that returns the funds to the wallet.</summary>
+    [Parameter]
+    public bool Cancellation { get; set; }
 
     private decimal? _selectedWalletBalance;
     private decimal _btcPrice;
@@ -118,10 +131,13 @@
 
         try
         {
-            // Validation, creation and UTXO locking of the bump live in WithdrawalRequestService, shared with the
-            // BumpWithdrawal gRPC method (and covered end to end there).
-            var newRequest = await WithdrawalRequestService.CreateBumpRequestAsync(WithdrawalRequest.Id,
-                _selectedMempoolRecommendedFeesType, _customSatPerVbAmount);
+            // Validation, creation and UTXO locking of the replacement live in WithdrawalRequestService, shared with
+            // the BumpWithdrawal / CancelWithdrawal gRPC methods (and covered end to end there).
+            var newRequest = Cancellation
+                ? await WithdrawalRequestService.CreateCancelRequestAsync(WithdrawalRequest.Id,
+                    _selectedMempoolRecommendedFeesType, _customSatPerVbAmount)
+                : await WithdrawalRequestService.CreateBumpRequestAsync(WithdrawalRequest.Id,
+                    _selectedMempoolRecommendedFeesType, _customSatPerVbAmount);
 
             SubmitBumpfeeModal?.Invoke(newRequest);
         }
@@ -131,7 +147,7 @@
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Error creating a new withdrawal request for bumping fee");
+            Logger.LogError(e, "Error creating the RBF replacement of withdrawal request {RequestId}", WithdrawalRequest.Id);
             ToastService.ShowError("Something went wrong");
         }
     }

--- a/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
@@ -96,10 +96,11 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
             s => s[withdrawal.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalPendingConfirmation,
             attempts: 30, delay: TimeSpan.FromSeconds(2), what: "original pending confirmation");
 
-        // 2. Bump it. Nothing has been mined, so the original is still replaceable.
+        // 2. Bump it, addressed by the txid RequestWithdrawal returned (the id form is exercised by the guards below).
+        //    Nothing has been mined, so the original is still replaceable.
         var bump = await client.BumpWithdrawalAsync(new BumpWithdrawalRequest
         {
-            RequestId = withdrawal.RequestId,
+            TxId = withdrawal.Txid,
             MempoolFeeRate = FEES_TYPE.CustomFee,
             CustomFeeRate = BumpedFeeRateSatPerVb,
         }, headers);
@@ -157,6 +158,15 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
         }, headers).ResponseAsync;
         (await bumpLower.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.InvalidArgument,
             "a replacement must pay a higher fee rate than the transaction it replaces");
+
+        var unknownTxId = () => client.BumpWithdrawalAsync(new BumpWithdrawalRequest
+        {
+            TxId = uint256.One.ToString(),
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb,
+        }, headers).ResponseAsync;
+        (await unknownTxId.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.NotFound,
+            "a txid NodeGuard never broadcast cannot be bumped");
 
         // 5. Mine: the replacement confirms, the original never does, and NodeGuard settles the bump.
         await MineAsync(rpc, 6);

--- a/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
@@ -1,0 +1,195 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using Grpc.Core;
+using NBitcoin;
+using NBitcoin.RPC;
+using Nodeguard;
+using Xunit.Abstractions;
+
+namespace NodeGuard.Tests.E2E;
+
+/// <summary>
+/// End-to-end coverage for RBF fee bumping of a hot-wallet withdrawal against a LIVE NodeGuard + bitcoind, driven over
+/// gRPC: RequestWithdrawal broadcasts an RBF-signalling transaction; BumpWithdrawal replaces it with a higher-fee version
+/// of the same payment; bitcoind evicts the original; NodeGuard marks the original WITHDRAWAL_BUMPED and, once mined,
+/// settles the replacement. The UI and the RPC share WithdrawalRequestService, so this scenario exercises the same
+/// orchestration the Withdrawals page runs.
+///
+/// Shared plumbing in <see cref="E2ETestBase"/>; gated by <see cref="E2EFactAttribute"/>. Env: see
+/// <see cref="DustUtxoWithdrawalE2ETests"/>. Never mine between the withdrawal and the bump — the original must still be
+/// unconfirmed. Settlement needs MonitorWithdrawalsJob to run promptly (MONITOR_WITHDRAWALS_CRON is 10s in the e2e stack).
+/// </summary>
+[Trait("Category", "E2E")]
+[Collection("E2E")]
+public class WithdrawalRbfBumpE2ETests : E2ETestBase
+{
+    private const long WithdrawalAmountSats = 1_000_000;
+    private const int OriginalFeeRateSatPerVb = 2;
+    private const int BumpedFeeRateSatPerVb = 10;
+    private const long ProbeAmountSats = 2_000_000;
+
+    public WithdrawalRbfBumpE2ETests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [E2EFact]
+    public async Task BumpWithdrawal_ReplacesTheUnconfirmedHotWalletTransaction()
+    {
+        var client = CreateClient(out var headers);
+        var rpc = CreateBitcoindRpc();
+        var walletId = int.Parse(Env("E2E_HOT_WALLET_ID", "3"));
+
+        // 0. NodeGuard up and the dev hot wallet spendable (DbInitializer funds it; another e2e may hold it briefly).
+        await RetryAsync(async () =>
+        {
+            var resp = await client.GetNodesAsync(new GetNodesRequest(), headers);
+            if (resp.Nodes.Count == 0) throw new InvalidOperationException("no nodes seeded yet");
+            return true;
+        }, attempts: 90, delay: TimeSpan.FromSeconds(4), what: "GetNodes (NodeGuard readiness)");
+
+        await RetryAsync(async () =>
+        {
+            var available = await client.GetAvailableUtxosAsync(
+                new GetAvailableUtxosRequest { WalletId = walletId, Amount = ProbeAmountSats }, headers);
+            if (available.Confirmed.Sum(u => u.Amount) < ProbeAmountSats)
+                throw new InvalidOperationException("hot wallet has no spendable UTXO yet");
+            return true;
+        }, attempts: 60, delay: TimeSpan.FromSeconds(4), what: "GetAvailableUtxos (hot wallet funded)");
+
+        // 1. A hot-wallet withdrawal at a low fee rate. NodeGuard signs and broadcasts it asynchronously.
+        var destination = await rpc.GetNewAddressAsync();
+        var withdrawal = await client.RequestWithdrawalAsync(new RequestWithdrawalRequest
+        {
+            WalletId = walletId,
+            Description = "E2E RBF bump test",
+            Destinations = { new Destination { Address = destination.ToString(), AmountSats = WithdrawalAmountSats } },
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = OriginalFeeRateSatPerVb,
+        }, headers);
+        _output.WriteLine($"withdrawal request {withdrawal.RequestId} → txid {withdrawal.Txid}");
+        withdrawal.IsHotWallet.Should().BeTrue();
+        var originalTxId = uint256.Parse(withdrawal.Txid);
+
+        var originalTx = await WaitForBroadcastAsync(rpc, originalTxId, "original withdrawal broadcast");
+        originalTx.RBF.Should().BeTrue("withdrawals must signal BIP125 replaceability, or they could never be bumped");
+        var originalEntry = await rpc.GetMempoolEntryAsync(originalTxId);
+
+        await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId),
+            s => s[withdrawal.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalPendingConfirmation,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: "original pending confirmation");
+
+        // 2. Bump it. Nothing has been mined, so the original is still replaceable.
+        var bump = await client.BumpWithdrawalAsync(new BumpWithdrawalRequest
+        {
+            RequestId = withdrawal.RequestId,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb,
+        }, headers);
+        _output.WriteLine($"bump request {bump.RequestId} → txid {bump.Txid}");
+        bump.IsHotWallet.Should().BeTrue();
+        bump.RequestId.Should().NotBe(withdrawal.RequestId, "a bump is a new withdrawal request pointing at the one it replaces");
+        bump.Txid.Should().NotBe(withdrawal.Txid, "a higher fee shrinks the change output, hence a different txid");
+        var bumpTxId = uint256.Parse(bump.Txid);
+
+        // 3. The replacement is in the mempool, the original was evicted, and the replacement is the same payment at a
+        //    higher fee: same inputs, same destination output, smaller change.
+        var bumpTx = await WaitForBroadcastAsync(rpc, bumpTxId, "replacement broadcast");
+        await RetryAsync(async () =>
+        {
+            var evicted = await rpc.GetMempoolEntryAsync(originalTxId, throwIfNotFound: false);
+            return evicted == null ? true : throw new InvalidOperationException("original still in the mempool");
+        }, attempts: 15, delay: TimeSpan.FromSeconds(2), what: "original evicted by the replacement");
+
+        bumpTx.Inputs.Select(i => i.PrevOut).Should().BeEquivalentTo(originalTx.Inputs.Select(i => i.PrevOut),
+            "RBF replaces the very same inputs");
+        bumpTx.Outputs.Should().ContainSingle(
+            o => o.ScriptPubKey == destination.ScriptPubKey && o.Value == Money.Satoshis(WithdrawalAmountSats),
+            "the destination and its amount are untouched");
+        ChangeSats(bumpTx, destination).Should().BeLessThan(ChangeSats(originalTx, destination),
+            "the extra fee comes out of the change");
+
+        var bumpEntry = await rpc.GetMempoolEntryAsync(bumpTxId);
+        bumpEntry.BaseFee.Satoshi.Should().BeGreaterThan(originalEntry.BaseFee.Satoshi, "BIP125 requires the replacement to pay more");
+        new FeeRate(bumpEntry.BaseFee, bumpTx.GetVirtualSize()).SatoshiPerByte.Should()
+            .BeGreaterThanOrEqualTo(BumpedFeeRateSatPerVb * 0.8m,
+                "the replacement targets the requested rate (the fee is estimated on the unsigned size)");
+
+        // NodeGuard's view: the bump is pending confirmation with the replacement txid, the original is bumped.
+        var statuses = await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId, bump.RequestId),
+            s => s[bump.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalPendingConfirmation
+                 && s[withdrawal.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalBumped,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: "bump pending confirmation, original bumped");
+        statuses[bump.RequestId].TxId.Should().Be(bump.Txid);
+
+        // 4. Guards: a bumped request cannot be bumped again, and a bump must raise the fee rate.
+        var bumpAgain = () => client.BumpWithdrawalAsync(new BumpWithdrawalRequest
+        {
+            RequestId = withdrawal.RequestId,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb + 5,
+        }, headers).ResponseAsync;
+        (await bumpAgain.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.FailedPrecondition,
+            "the original is WITHDRAWAL_BUMPED, not pending confirmation");
+
+        var bumpLower = () => client.BumpWithdrawalAsync(new BumpWithdrawalRequest
+        {
+            RequestId = bump.RequestId,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb - 5,
+        }, headers).ResponseAsync;
+        (await bumpLower.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.InvalidArgument,
+            "a replacement must pay a higher fee rate than the transaction it replaces");
+
+        // 5. Mine: the replacement confirms, the original never does, and NodeGuard settles the bump.
+        await MineAsync(rpc, 6);
+
+        var bumpInfo = await rpc.GetRawTransactionInfoAsync(bumpTxId);
+        ((uint?)bumpInfo.Confirmations ?? 0).Should().BeGreaterThan(0u, "the replacement was mined");
+        (await rpc.GetRawTransactionAsync(originalTxId, throwIfNotFound: false)).Should().BeNull(
+            "the replaced transaction was evicted and can never confirm");
+
+        var settled = await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId, bump.RequestId),
+            s => s[bump.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalSettled,
+            attempts: 40, delay: TimeSpan.FromSeconds(5), what: "bump settled by MonitorWithdrawalsJob");
+        settled[withdrawal.RequestId].Status.Should().Be(WITHDRAWAL_REQUEST_STATUS.WithdrawalBumped,
+            "the replaced request stays bumped");
+    }
+
+    private async Task<Transaction> WaitForBroadcastAsync(RPCClient rpc, uint256 txId, string what)
+    {
+        return await RetryAsync(async () =>
+        {
+            var tx = await rpc.GetRawTransactionAsync(txId, throwIfNotFound: false);
+            return tx ?? throw new InvalidOperationException($"{txId} not broadcast yet");
+        }, attempts: 30, delay: TimeSpan.FromSeconds(4), what: what);
+    }
+
+    private static async Task<Dictionary<int, WithdrawalRequest>> GetStatusesAsync(
+        NodeGuardService.NodeGuardServiceClient client, Metadata headers, params int[] requestIds)
+    {
+        var response = await client.GetWithdrawalsRequestStatusAsync(
+            new GetWithdrawalsRequestStatusRequest { RequestIds = { requestIds } }, headers);
+        return response.WithdrawalRequests.ToDictionary(r => r.RequestId);
+    }
+
+    private static long ChangeSats(Transaction tx, BitcoinAddress destination)
+        => tx.Outputs.Where(o => o.ScriptPubKey != destination.ScriptPubKey).Sum(o => o.Value.Satoshi);
+}

--- a/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
+++ b/test/NodeGuard.Tests/E2E/WithdrawalRbfBumpE2ETests.cs
@@ -27,15 +27,17 @@ using Xunit.Abstractions;
 namespace NodeGuard.Tests.E2E;
 
 /// <summary>
-/// End-to-end coverage for RBF fee bumping of a hot-wallet withdrawal against a LIVE NodeGuard + bitcoind, driven over
-/// gRPC: RequestWithdrawal broadcasts an RBF-signalling transaction; BumpWithdrawal replaces it with a higher-fee version
-/// of the same payment; bitcoind evicts the original; NodeGuard marks the original WITHDRAWAL_BUMPED and, once mined,
-/// settles the replacement. The UI and the RPC share WithdrawalRequestService, so this scenario exercises the same
-/// orchestration the Withdrawals page runs.
+/// End-to-end coverage for the RBF replacements of a hot-wallet withdrawal against a LIVE NodeGuard + bitcoind, driven
+/// over gRPC. Fee bump: RequestWithdrawal broadcasts an RBF-signalling transaction, BumpWithdrawal replaces it with a
+/// higher-fee version of the same payment, bitcoind evicts the original, NodeGuard marks it WITHDRAWAL_BUMPED and, once
+/// mined, settles the replacement. Cancellation: CancelWithdrawal replaces it with a transaction that returns the funds to
+/// the wallet, the destination is never paid and the original ends up WITHDRAWAL_CANCELLED. The UI and the RPCs share
+/// WithdrawalRequestService, so these scenarios exercise the same orchestration the Withdrawals page runs.
 ///
 /// Shared plumbing in <see cref="E2ETestBase"/>; gated by <see cref="E2EFactAttribute"/>. Env: see
-/// <see cref="DustUtxoWithdrawalE2ETests"/>. Never mine between the withdrawal and the bump — the original must still be
-/// unconfirmed. Settlement needs MonitorWithdrawalsJob to run promptly (MONITOR_WITHDRAWALS_CRON is 10s in the e2e stack).
+/// <see cref="DustUtxoWithdrawalE2ETests"/>. Never mine between the withdrawal and its replacement — the original must
+/// still be unconfirmed. Settlement needs MonitorWithdrawalsJob to run promptly (MONITOR_WITHDRAWALS_CRON is 10s in the
+/// e2e stack).
 /// </summary>
 [Trait("Category", "E2E")]
 [Collection("E2E")]
@@ -55,37 +57,11 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
     {
         var client = CreateClient(out var headers);
         var rpc = CreateBitcoindRpc();
-        var walletId = int.Parse(Env("E2E_HOT_WALLET_ID", "3"));
-
-        // 0. NodeGuard up and the dev hot wallet spendable (DbInitializer funds it; another e2e may hold it briefly).
-        await RetryAsync(async () =>
-        {
-            var resp = await client.GetNodesAsync(new GetNodesRequest(), headers);
-            if (resp.Nodes.Count == 0) throw new InvalidOperationException("no nodes seeded yet");
-            return true;
-        }, attempts: 90, delay: TimeSpan.FromSeconds(4), what: "GetNodes (NodeGuard readiness)");
-
-        await RetryAsync(async () =>
-        {
-            var available = await client.GetAvailableUtxosAsync(
-                new GetAvailableUtxosRequest { WalletId = walletId, Amount = ProbeAmountSats }, headers);
-            if (available.Confirmed.Sum(u => u.Amount) < ProbeAmountSats)
-                throw new InvalidOperationException("hot wallet has no spendable UTXO yet");
-            return true;
-        }, attempts: 60, delay: TimeSpan.FromSeconds(4), what: "GetAvailableUtxos (hot wallet funded)");
+        var walletId = await EnsureHotWalletReadyAsync(client, headers);
 
         // 1. A hot-wallet withdrawal at a low fee rate. NodeGuard signs and broadcasts it asynchronously.
         var destination = await rpc.GetNewAddressAsync();
-        var withdrawal = await client.RequestWithdrawalAsync(new RequestWithdrawalRequest
-        {
-            WalletId = walletId,
-            Description = "E2E RBF bump test",
-            Destinations = { new Destination { Address = destination.ToString(), AmountSats = WithdrawalAmountSats } },
-            MempoolFeeRate = FEES_TYPE.CustomFee,
-            CustomFeeRate = OriginalFeeRateSatPerVb,
-        }, headers);
-        _output.WriteLine($"withdrawal request {withdrawal.RequestId} → txid {withdrawal.Txid}");
-        withdrawal.IsHotWallet.Should().BeTrue();
+        var withdrawal = await RequestHotWithdrawalAsync(client, headers, walletId, destination, "E2E RBF bump test");
         var originalTxId = uint256.Parse(withdrawal.Txid);
 
         var originalTx = await WaitForBroadcastAsync(rpc, originalTxId, "original withdrawal broadcast");
@@ -113,11 +89,7 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
         // 3. The replacement is in the mempool, the original was evicted, and the replacement is the same payment at a
         //    higher fee: same inputs, same destination output, smaller change.
         var bumpTx = await WaitForBroadcastAsync(rpc, bumpTxId, "replacement broadcast");
-        await RetryAsync(async () =>
-        {
-            var evicted = await rpc.GetMempoolEntryAsync(originalTxId, throwIfNotFound: false);
-            return evicted == null ? true : throw new InvalidOperationException("original still in the mempool");
-        }, attempts: 15, delay: TimeSpan.FromSeconds(2), what: "original evicted by the replacement");
+        await WaitUntilEvictedAsync(rpc, originalTxId);
 
         bumpTx.Inputs.Select(i => i.PrevOut).Should().BeEquivalentTo(originalTx.Inputs.Select(i => i.PrevOut),
             "RBF replaces the very same inputs");
@@ -140,7 +112,7 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
             attempts: 30, delay: TimeSpan.FromSeconds(2), what: "bump pending confirmation, original bumped");
         statuses[bump.RequestId].TxId.Should().Be(bump.Txid);
 
-        // 4. Guards: a bumped request cannot be bumped again, and a bump must raise the fee rate.
+        // 4. Guards: a bumped request cannot be bumped again, a bump must raise the fee rate, and an unknown txid is not found.
         var bumpAgain = () => client.BumpWithdrawalAsync(new BumpWithdrawalRequest
         {
             RequestId = withdrawal.RequestId,
@@ -183,6 +155,132 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
             "the replaced request stays bumped");
     }
 
+    [E2EFact]
+    public async Task CancelWithdrawal_ReturnsTheFundsOfTheUnconfirmedHotWalletTransaction()
+    {
+        var client = CreateClient(out var headers);
+        var rpc = CreateBitcoindRpc();
+        var walletId = await EnsureHotWalletReadyAsync(client, headers);
+
+        // 1. A hot-wallet withdrawal at a low fee rate, broadcast but unconfirmed.
+        var destination = await rpc.GetNewAddressAsync();
+        var withdrawal = await RequestHotWithdrawalAsync(client, headers, walletId, destination, "E2E RBF cancel test");
+        var originalTxId = uint256.Parse(withdrawal.Txid);
+
+        var originalTx = await WaitForBroadcastAsync(rpc, originalTxId, "original withdrawal broadcast");
+        var originalEntry = await rpc.GetMempoolEntryAsync(originalTxId);
+
+        await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId),
+            s => s[withdrawal.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalPendingConfirmation,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: "original pending confirmation");
+
+        // 2. Cancel it by txid: same inputs, the funds come back to the wallet at a higher fee rate.
+        var cancel = await client.CancelWithdrawalAsync(new CancelWithdrawalRequest
+        {
+            TxId = withdrawal.Txid,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb,
+        }, headers);
+        _output.WriteLine($"cancel request {cancel.RequestId} → txid {cancel.Txid}");
+        cancel.IsHotWallet.Should().BeTrue();
+        cancel.RequestId.Should().NotBe(withdrawal.RequestId);
+        cancel.Txid.Should().NotBe(withdrawal.Txid);
+        var cancelTxId = uint256.Parse(cancel.Txid);
+
+        // 3. The replacement evicted the original and pays nobody but the wallet itself.
+        var cancelTx = await WaitForBroadcastAsync(rpc, cancelTxId, "cancellation broadcast");
+        await WaitUntilEvictedAsync(rpc, originalTxId);
+
+        cancelTx.Inputs.Select(i => i.PrevOut).Should().BeEquivalentTo(originalTx.Inputs.Select(i => i.PrevOut),
+            "RBF replaces the very same inputs");
+        cancelTx.Outputs.Should().ContainSingle("everything goes back to one fresh address of the wallet");
+        cancelTx.Outputs.Should().NotContain(o => o.ScriptPubKey == destination.ScriptPubKey,
+            "the original destination must never be paid");
+
+        var cancelEntry = await rpc.GetMempoolEntryAsync(cancelTxId);
+        cancelEntry.BaseFee.Satoshi.Should().BeGreaterThan(originalEntry.BaseFee.Satoshi, "BIP125 requires the replacement to pay more");
+        (cancelTx.TotalOut + cancelEntry.BaseFee).Should().Be(originalTx.TotalOut + originalEntry.BaseFee,
+            "both transactions spend the same inputs: whatever is not fee comes back to the wallet");
+
+        // NodeGuard's view: the cancellation is pending confirmation, the original is cancelled with a reason.
+        var statuses = await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId, cancel.RequestId),
+            s => s[cancel.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalPendingConfirmation
+                 && s[withdrawal.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalCancelled,
+            attempts: 30, delay: TimeSpan.FromSeconds(2), what: "cancellation pending confirmation, original cancelled");
+        statuses[cancel.RequestId].TxId.Should().Be(cancel.Txid);
+        statuses[withdrawal.RequestId].RejectOrCancelReason.Should().Contain("RBF");
+
+        // 4. Guard: a cancelled request cannot be replaced again.
+        var cancelAgain = () => client.CancelWithdrawalAsync(new CancelWithdrawalRequest
+        {
+            RequestId = withdrawal.RequestId,
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = BumpedFeeRateSatPerVb + 5,
+        }, headers).ResponseAsync;
+        (await cancelAgain.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+
+        // 5. Mine: the cancellation confirms, the original never does, the funds are a spendable UTXO of the wallet again.
+        await MineAsync(rpc, 6);
+        (await rpc.GetRawTransactionAsync(originalTxId, throwIfNotFound: false)).Should().BeNull(
+            "the cancelled transaction was evicted and can never confirm");
+
+        var settled = await PollAsync(() => GetStatusesAsync(client, headers, withdrawal.RequestId, cancel.RequestId),
+            s => s[cancel.RequestId].Status == WITHDRAWAL_REQUEST_STATUS.WithdrawalSettled,
+            attempts: 40, delay: TimeSpan.FromSeconds(5), what: "cancellation settled by MonitorWithdrawalsJob");
+        settled[withdrawal.RequestId].Status.Should().Be(WITHDRAWAL_REQUEST_STATUS.WithdrawalCancelled);
+
+        var returnedOutpoint = new OutPoint(cancelTxId, 0).ToString();
+        await RetryAsync(async () =>
+        {
+            var utxos = await client.GetUtxosAsync(new GetUtxosRequest(), headers);
+            return utxos.Confirmed.Any(u => u.Outpoint == returnedOutpoint)
+                ? true
+                : throw new InvalidOperationException("returned funds not indexed as a confirmed UTXO of the wallet yet");
+        }, attempts: 30, delay: TimeSpan.FromSeconds(4), what: "returned funds spendable again");
+    }
+
+    // ---- plumbing ------------------------------------------------------------------------------------------------
+
+    /// <summary>NodeGuard up and the dev hot wallet spendable (DbInitializer funds it; another e2e may hold it briefly).</summary>
+    private async Task<int> EnsureHotWalletReadyAsync(NodeGuardService.NodeGuardServiceClient client, Metadata headers)
+    {
+        var walletId = int.Parse(Env("E2E_HOT_WALLET_ID", "3"));
+
+        await RetryAsync(async () =>
+        {
+            var resp = await client.GetNodesAsync(new GetNodesRequest(), headers);
+            if (resp.Nodes.Count == 0) throw new InvalidOperationException("no nodes seeded yet");
+            return true;
+        }, attempts: 90, delay: TimeSpan.FromSeconds(4), what: "GetNodes (NodeGuard readiness)");
+
+        await RetryAsync(async () =>
+        {
+            var available = await client.GetAvailableUtxosAsync(
+                new GetAvailableUtxosRequest { WalletId = walletId, Amount = ProbeAmountSats }, headers);
+            if (available.Confirmed.Sum(u => u.Amount) < ProbeAmountSats)
+                throw new InvalidOperationException("hot wallet has no spendable UTXO yet");
+            return true;
+        }, attempts: 60, delay: TimeSpan.FromSeconds(4), what: "GetAvailableUtxos (hot wallet funded)");
+
+        return walletId;
+    }
+
+    private async Task<RequestWithdrawalResponse> RequestHotWithdrawalAsync(NodeGuardService.NodeGuardServiceClient client,
+        Metadata headers, int walletId, BitcoinAddress destination, string description)
+    {
+        var withdrawal = await client.RequestWithdrawalAsync(new RequestWithdrawalRequest
+        {
+            WalletId = walletId,
+            Description = description,
+            Destinations = { new Destination { Address = destination.ToString(), AmountSats = WithdrawalAmountSats } },
+            MempoolFeeRate = FEES_TYPE.CustomFee,
+            CustomFeeRate = OriginalFeeRateSatPerVb,
+        }, headers);
+        _output.WriteLine($"withdrawal request {withdrawal.RequestId} → txid {withdrawal.Txid}");
+        withdrawal.IsHotWallet.Should().BeTrue();
+        return withdrawal;
+    }
+
     private async Task<Transaction> WaitForBroadcastAsync(RPCClient rpc, uint256 txId, string what)
     {
         return await RetryAsync(async () =>
@@ -190,6 +288,15 @@ public class WithdrawalRbfBumpE2ETests : E2ETestBase
             var tx = await rpc.GetRawTransactionAsync(txId, throwIfNotFound: false);
             return tx ?? throw new InvalidOperationException($"{txId} not broadcast yet");
         }, attempts: 30, delay: TimeSpan.FromSeconds(4), what: what);
+    }
+
+    private async Task WaitUntilEvictedAsync(RPCClient rpc, uint256 txId)
+    {
+        await RetryAsync(async () =>
+        {
+            var entry = await rpc.GetMempoolEntryAsync(txId, throwIfNotFound: false);
+            return entry == null ? true : throw new InvalidOperationException("original still in the mempool");
+        }, attempts: 15, delay: TimeSpan.FromSeconds(2), what: "original evicted by the replacement");
     }
 
     private static async Task<Dictionary<int, WithdrawalRequest>> GetStatusesAsync(

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -78,7 +78,8 @@ namespace NodeGuard.Rpc
             IUTXOTagRepository? utxoTagRepository = null,
             IHtlcMonitoringScheduler? htlcMonitoringScheduler = null,
             IRebalanceService? rebalanceService = null,
-            IRebalanceRepository? rebalanceRepository = null)
+            IRebalanceRepository? rebalanceRepository = null,
+            IWithdrawalRequestService? withdrawalRequestService = null)
         {
             return new NodeGuardService(
                 logger ?? _logger.Object,
@@ -98,7 +99,8 @@ namespace NodeGuard.Rpc
                 utxoTagRepository ?? new Mock<IUTXOTagRepository>().Object,
                 htlcMonitoringScheduler ?? CreateHtlcMonitoringSchedulerMock().Object,
                 rebalanceService ?? new Mock<IRebalanceService>().Object,
-                rebalanceRepository ?? new Mock<IRebalanceRepository>().Object);
+                rebalanceRepository ?? new Mock<IRebalanceRepository>().Object,
+                withdrawalRequestService ?? new Mock<IWithdrawalRequestService>().Object);
         }
 
         [Fact]
@@ -800,6 +802,143 @@ namespace NodeGuard.Rpc
 
             //Assert
             await resp.Should().ThrowAsync<RpcException>();
+        }
+
+        [Fact]
+        public async Task BumpWithdrawal_HotWallet_SchedulesTheReplacementAndReturnsItsTxid()
+        {
+            //Arrange
+            var bump = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = true }, BumpingWalletWithdrawalRequestId = 10 };
+            var psbt = SamplePsbt();
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateBumpRequestAsync(10, MempoolRecommendedFeesType.CustomFee, 10m)).ReturnsAsync(bump);
+            withdrawalRequestService.Setup(x => x.ScheduleHotWalletWithdrawalAsync(11)).ReturnsAsync(psbt);
+            var bitcoinService = new Mock<IBitcoinService>();
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                bitcoinService: bitcoinService.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var resp = await mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            resp.RequestId.Should().Be(11);
+            resp.IsHotWallet.Should().BeTrue();
+            resp.Txid.Should().Be(psbt.GetGlobalTransaction().GetHash().ToString());
+            withdrawalRequestService.Verify(x => x.ScheduleHotWalletWithdrawalAsync(11), Times.Once);
+            bitcoinService.Verify(x => x.GenerateTemplatePSBT(It.IsAny<WalletWithdrawalRequest>()), Times.Never,
+                "the hot-wallet execution (template + job) is the service's job");
+        }
+
+        [Fact]
+        public async Task BumpWithdrawal_ColdWallet_GeneratesTheTemplateWithoutScheduling()
+        {
+            //Arrange
+            var bump = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = false }, BumpingWalletWithdrawalRequestId = 10 };
+            var psbt = SamplePsbt();
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateBumpRequestAsync(10, MempoolRecommendedFeesType.FastestFee, null)).ReturnsAsync(bump);
+            var bitcoinService = new Mock<IBitcoinService>();
+            bitcoinService.Setup(x => x.GenerateTemplatePSBT(bump)).ReturnsAsync(psbt);
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                bitcoinService: bitcoinService.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var resp = await mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.FastestFee,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            resp.RequestId.Should().Be(11);
+            resp.IsHotWallet.Should().BeFalse();
+            resp.Txid.Should().Be(psbt.GetGlobalTransaction().GetHash().ToString());
+            withdrawalRequestService.Verify(x => x.ScheduleHotWalletWithdrawalAsync(It.IsAny<int>()), Times.Never,
+                "a cold-wallet bump waits for the approvers' signatures");
+        }
+
+        [Theory]
+        [InlineData(BumpingErrorReason.RequestNotFound, StatusCode.NotFound)]
+        [InlineData(BumpingErrorReason.InvalidState, StatusCode.FailedPrecondition)]
+        [InlineData(BumpingErrorReason.AlreadyConfirmed, StatusCode.FailedPrecondition)]
+        [InlineData(BumpingErrorReason.TransactionNotFound, StatusCode.FailedPrecondition)]
+        [InlineData(BumpingErrorReason.ChangelessMultipleDestinations, StatusCode.FailedPrecondition)]
+        [InlineData(BumpingErrorReason.InvalidFeeRate, StatusCode.InvalidArgument)]
+        [InlineData(BumpingErrorReason.FeeRateNotHigher, StatusCode.InvalidArgument)]
+        [InlineData(BumpingErrorReason.FeeExceedsInputs, StatusCode.InvalidArgument)]
+        [InlineData(BumpingErrorReason.PersistenceError, StatusCode.Internal)]
+        public async Task BumpWithdrawal_RefusedByTheService_MapsTheReasonToAStatusCode(BumpingErrorReason reason, StatusCode expected)
+        {
+            //Arrange
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService
+                .Setup(x => x.CreateBumpRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()))
+                .ThrowsAsync(new BumpingException("refused", reason));
+
+            var mockNodeGuardService = CreateNodeGuardService(withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var act = () => mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            var exception = (await act.Should().ThrowAsync<RpcException>()).Which;
+            exception.StatusCode.Should().Be(expected);
+            exception.Status.Detail.Should().Be("refused", "the user-facing reason travels to the API caller");
+        }
+
+        [Fact]
+        public async Task BumpWithdrawal_SchedulingFails_CancelsTheBumpRequest()
+        {
+            //Arrange
+            var bump = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = true }, BumpingWalletWithdrawalRequestId = 10 };
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateBumpRequestAsync(10, MempoolRecommendedFeesType.CustomFee, 10m)).ReturnsAsync(bump);
+            withdrawalRequestService.Setup(x => x.ScheduleHotWalletWithdrawalAsync(11)).ThrowsAsync(new Exception("boom"));
+            var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+            walletWithdrawalRequestRepository.Setup(x => x.Update(It.IsAny<WalletWithdrawalRequest>())).Returns((true, (string?)null));
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                walletWithdrawalRequestRepository: walletWithdrawalRequestRepository.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var act = () => mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            (await act.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.Internal);
+            walletWithdrawalRequestRepository.Verify(x => x.Update(It.Is<WalletWithdrawalRequest>(r => r.Id == 11
+                && r.Status == WalletWithdrawalRequestStatus.Cancelled)), Times.Once,
+                "a bump that could not be executed must not stay pending");
+        }
+
+        /// <summary>A parseable one-in/one-out PSBT; PSBT.FromTransaction refuses a transaction without inputs.</summary>
+        private static PSBT SamplePsbt()
+        {
+            var network = Network.RegTest;
+            var tx = network.CreateTransaction();
+            tx.Inputs.Add(new TxIn(new OutPoint(uint256.One, 0)));
+            tx.Outputs.Add(new TxOut(Money.Coins(0.01m),
+                BitcoinAddress.Create("bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal", network)));
+            return PSBT.FromTransaction(tx, network);
         }
 
         private Wallet InitMockRequestWithdrawal(out Mock<IWalletRepository> walletRepository,

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -930,6 +930,102 @@ namespace NodeGuard.Rpc
                 "a bump that could not be executed must not stay pending");
         }
 
+        [Fact]
+        public async Task BumpWithdrawal_ByTxId_ResolvesTheRequestToBump()
+        {
+            //Arrange
+            const string txId = "5f59c45bc3fa8362d5c38bce5c633bb901a57f268ec75e55548c00d2baec0d65";
+            var original = new WalletWithdrawalRequest { Id = 10, TxId = txId };
+            var bump = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = true }, BumpingWalletWithdrawalRequestId = 10 };
+            var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+            walletWithdrawalRequestRepository.Setup(x => x.GetByTxHash(txId)).ReturnsAsync(original);
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateBumpRequestAsync(10, MempoolRecommendedFeesType.CustomFee, 10m)).ReturnsAsync(bump);
+            withdrawalRequestService.Setup(x => x.ScheduleHotWalletWithdrawalAsync(11)).ReturnsAsync(SamplePsbt());
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                walletWithdrawalRequestRepository: walletWithdrawalRequestRepository.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var resp = await mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                // Uppercase on purpose: stored txids are lowercase and the lookup must not be case-sensitive.
+                TxId = txId.ToUpperInvariant(),
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            resp.RequestId.Should().Be(11);
+            withdrawalRequestService.Verify(x => x.CreateBumpRequestAsync(10, MempoolRecommendedFeesType.CustomFee, 10m), Times.Once,
+                "the txid must resolve to the request that broadcast it");
+        }
+
+        [Fact]
+        public async Task BumpWithdrawal_UnknownTxId_MapsToNotFound()
+        {
+            //Arrange
+            var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+            walletWithdrawalRequestRepository.Setup(x => x.GetByTxHash(It.IsAny<string>())).ReturnsAsync((WalletWithdrawalRequest?)null);
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                walletWithdrawalRequestRepository: walletWithdrawalRequestRepository.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var act = () => mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                TxId = uint256.One.ToString(),
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            (await act.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.NotFound);
+            withdrawalRequestService.Verify(x => x.CreateBumpRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("not-a-txid")]
+        [InlineData("")]
+        public async Task BumpWithdrawal_MalformedTxId_MapsToInvalidArgument(string txId)
+        {
+            //Arrange
+            var mockNodeGuardService = CreateNodeGuardService(withdrawalRequestService: new Mock<IWithdrawalRequestService>().Object);
+
+            //Act
+            var act = () => mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                TxId = txId,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            (await act.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.InvalidArgument);
+        }
+
+        [Fact]
+        public async Task BumpWithdrawal_WithoutTarget_MapsToInvalidArgument()
+        {
+            //Arrange
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            var mockNodeGuardService = CreateNodeGuardService(withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var act = () => mockNodeGuardService.BumpWithdrawal(new BumpWithdrawalRequest
+            {
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            (await act.Should().ThrowAsync<RpcException>()).Which.StatusCode.Should().Be(StatusCode.InvalidArgument);
+            withdrawalRequestService.Verify(x => x.CreateBumpRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()), Times.Never);
+        }
+
         /// <summary>A parseable one-in/one-out PSBT; PSBT.FromTransaction refuses a transaction without inputs.</summary>
         private static PSBT SamplePsbt()
         {

--- a/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
+++ b/test/NodeGuard.Tests/Rpc/NodeGuardServiceTests.cs
@@ -1026,6 +1026,91 @@ namespace NodeGuard.Rpc
             withdrawalRequestService.Verify(x => x.CreateBumpRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()), Times.Never);
         }
 
+        [Fact]
+        public async Task CancelWithdrawal_HotWallet_SchedulesTheReplacementAndReturnsItsTxid()
+        {
+            //Arrange
+            var cancel = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = true }, BumpingWalletWithdrawalRequestId = 10, IsRbfCancellation = true };
+            var psbt = SamplePsbt();
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateCancelRequestAsync(10, MempoolRecommendedFeesType.CustomFee, 10m)).ReturnsAsync(cancel);
+            withdrawalRequestService.Setup(x => x.ScheduleHotWalletWithdrawalAsync(11)).ReturnsAsync(psbt);
+
+            var mockNodeGuardService = CreateNodeGuardService(withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var resp = await mockNodeGuardService.CancelWithdrawal(new CancelWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            resp.RequestId.Should().Be(11);
+            resp.IsHotWallet.Should().BeTrue();
+            resp.Txid.Should().Be(psbt.GetGlobalTransaction().GetHash().ToString());
+            withdrawalRequestService.Verify(x => x.CreateBumpRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()), Times.Never,
+                "a cancellation must not be turned into a fee bump");
+        }
+
+        [Fact]
+        public async Task CancelWithdrawal_ByTxId_ResolvesTheRequestToCancel()
+        {
+            //Arrange
+            const string txId = "5f59c45bc3fa8362d5c38bce5c633bb901a57f268ec75e55548c00d2baec0d65";
+            var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+            walletWithdrawalRequestRepository.Setup(x => x.GetByTxHash(txId)).ReturnsAsync(new WalletWithdrawalRequest { Id = 10, TxId = txId });
+            var cancel = new WalletWithdrawalRequest { Id = 11, Wallet = new Wallet { IsHotWallet = false }, BumpingWalletWithdrawalRequestId = 10, IsRbfCancellation = true };
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService.Setup(x => x.CreateCancelRequestAsync(10, MempoolRecommendedFeesType.FastestFee, null)).ReturnsAsync(cancel);
+            var bitcoinService = new Mock<IBitcoinService>();
+            bitcoinService.Setup(x => x.GenerateTemplatePSBT(cancel)).ReturnsAsync(SamplePsbt());
+
+            var mockNodeGuardService = CreateNodeGuardService(
+                walletWithdrawalRequestRepository: walletWithdrawalRequestRepository.Object,
+                bitcoinService: bitcoinService.Object,
+                withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var resp = await mockNodeGuardService.CancelWithdrawal(new CancelWithdrawalRequest
+            {
+                TxId = txId,
+                MempoolFeeRate = FEES_TYPE.FastestFee,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            resp.RequestId.Should().Be(11);
+            resp.IsHotWallet.Should().BeFalse();
+            withdrawalRequestService.Verify(x => x.ScheduleHotWalletWithdrawalAsync(It.IsAny<int>()), Times.Never,
+                "a cold-wallet cancellation waits for the approvers' signatures");
+        }
+
+        [Fact]
+        public async Task CancelWithdrawal_RefusedByTheService_MapsTheReasonToAStatusCode()
+        {
+            //Arrange
+            var withdrawalRequestService = new Mock<IWithdrawalRequestService>();
+            withdrawalRequestService
+                .Setup(x => x.CreateCancelRequestAsync(It.IsAny<int>(), It.IsAny<MempoolRecommendedFeesType>(), It.IsAny<decimal?>()))
+                .ThrowsAsync(new BumpingException("already mined", BumpingErrorReason.AlreadyConfirmed));
+
+            var mockNodeGuardService = CreateNodeGuardService(withdrawalRequestService: withdrawalRequestService.Object);
+
+            //Act
+            var act = () => mockNodeGuardService.CancelWithdrawal(new CancelWithdrawalRequest
+            {
+                RequestId = 10,
+                MempoolFeeRate = FEES_TYPE.CustomFee,
+                CustomFeeRate = 10,
+            }, TestServerCallContext.Create());
+
+            //Assert
+            var exception = (await act.Should().ThrowAsync<RpcException>()).Which;
+            exception.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+            exception.Status.Detail.Should().Be("already mined");
+        }
+
         /// <summary>A parseable one-in/one-out PSBT; PSBT.FromTransaction refuses a transaction without inputs.</summary>
         private static PSBT SamplePsbt()
         {

--- a/test/NodeGuard.Tests/Services/WithdrawalRequestServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/WithdrawalRequestServiceTests.cs
@@ -1,0 +1,491 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.Models;
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
+using NodeGuard.Jobs;
+using Quartz;
+using Key = NodeGuard.Data.Models.Key;
+
+namespace NodeGuard.Services;
+
+/// <summary>
+/// WithdrawalRequestService carries the RBF bump flow shared by the Withdrawals page and the BumpWithdrawal gRPC
+/// method, and the hot-wallet execution step both use. The status assertions matter: PerformWithdrawal refuses anything
+/// but PSBTSignaturesPending / FinalizingPSBT, and a hot wallet has no approvers whose signatures would move a request
+/// there, so a hot-wallet request left in Pending fails inside the job.
+/// </summary>
+public class WithdrawalRequestServiceTests
+{
+    private const string Tpub =
+        "tpubDCfM7v7fKZ31gTGGggNMycfCr5cDGinyijveRZ44RYSgAgEARwhaBd6PPpWst8kKbhEVoqNasgjHFWZKrEQoJ9pzPVEmNZDNe92hShzEMDy";
+
+    private const string DestinationAddress = "bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal";
+    private const int OriginalId = 10;
+    private const int BumpId = 11;
+
+    private readonly Mock<IWalletWithdrawalRequestRepository> _requests = new();
+    private readonly Mock<IFMUTXORepository> _fmutxos = new();
+    private readonly Mock<ICoinSelectionService> _coinSelection = new();
+    private readonly Mock<INBXplorerService> _nbXplorer = new();
+    private readonly Mock<IBitcoinService> _bitcoin = new();
+    private readonly Mock<ISchedulerFactory> _schedulerFactory = new();
+    private readonly Mock<IScheduler> _scheduler = new();
+
+    private readonly uint256 _fundingTxId = uint256.Parse("3a9907ab1b965e1ad0024e7fe4466ddab0d3b1bf3bd15ab6416bf8f0c9032f84");
+    private readonly uint256 _originalTxId = uint256.Parse("f103e12f02ac1e5b8826831d4fc8fdb78a707bd00c4e1f191fe5d14458d63d5a");
+
+    private WalletWithdrawalRequest? _storedBump;
+
+    public WithdrawalRequestServiceTests()
+    {
+        _requests.Setup(x => x.AddAsync(It.IsAny<WalletWithdrawalRequest>()))
+            .Callback<WalletWithdrawalRequest>(r =>
+            {
+                r.Id = BumpId;
+                _storedBump = r;
+            })
+            .ReturnsAsync((true, (string?)null));
+        _requests.Setup(x => x.GetById(BumpId)).ReturnsAsync(() => _storedBump);
+        _requests.Setup(x => x.Update(It.IsAny<WalletWithdrawalRequest>())).Returns((true, (string?)null));
+
+        _fmutxos.Setup(x => x.GetLockedUTXOsByWithdrawalId(OriginalId))
+            .ReturnsAsync(new List<FMUTXO> { new() { TxId = _fundingTxId.ToString(), OutputIndex = 0, SatsAmount = 10_000_000 } });
+
+        _coinSelection.Setup(x => x.GetUTXOsByOutpointAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<List<OutPoint>>()))
+            .ReturnsAsync((DerivationStrategyBase _, List<OutPoint> outpoints) =>
+                outpoints.Select(o => new UTXO { Outpoint = o, Value = Money.Satoshis(10_000_000) }).ToList());
+
+        _schedulerFactory.Setup(x => x.GetScheduler(It.IsAny<CancellationToken>())).ReturnsAsync(_scheduler.Object);
+        _scheduler.Setup(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DateTimeOffset.UtcNow);
+
+        _bitcoin.Setup(x => x.GenerateTemplatePSBT(It.IsAny<WalletWithdrawalRequest>())).ReturnsAsync(EmptyPsbt());
+    }
+
+    private WithdrawalRequestService CreateService() => new(
+        new Mock<ILogger<WithdrawalRequestService>>().Object,
+        _requests.Object,
+        _fmutxos.Object,
+        _coinSelection.Object,
+        _nbXplorer.Object,
+        _bitcoin.Object,
+        _schedulerFactory.Object);
+
+    // ---- CreateBumpRequestAsync ----------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_HotWallet_CreatesTheBumpInPsbtSignaturesPending()
+    {
+        var original = SetupOriginal(HotWallet());
+
+        var bump = await CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        bump.Should().BeSameAs(_storedBump);
+        bump.Status.Should().Be(WalletWithdrawalRequestStatus.PSBTSignaturesPending,
+            "a hot wallet has no approvers, and PerformWithdrawal refuses a Pending request");
+        bump.BumpingWalletWithdrawalRequestId.Should().Be(OriginalId);
+        bump.WalletId.Should().Be(original.WalletId);
+        bump.Description.Should().Be($"Bump of request {OriginalId}: pay rent");
+        bump.MempoolRecommendedFeesType.Should().Be(MempoolRecommendedFeesType.CustomFee);
+        bump.CustomFeeRate.Should().Be(10m);
+        bump.Changeless.Should().Be(original.Changeless);
+        bump.WithdrawAllFunds.Should().Be(original.WithdrawAllFunds);
+        bump.UserRequestorId.Should().Be(original.UserRequestorId);
+        bump.RequestMetadata.Should().Be(original.RequestMetadata);
+        bump.WalletWithdrawalRequestDestinations.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Address = DestinationAddress, Amount = 0.01m });
+
+        // RBF: the bump spends exactly the inputs of the request it replaces.
+        _coinSelection.Verify(x => x.LockUTXOs(
+            It.Is<List<UTXO>>(l => l.Count == 1 && l[0].Outpoint == new OutPoint(_fundingTxId, 0)),
+            It.Is<IBitcoinRequest>(r => r.Id == BumpId),
+            BitcoinRequestType.WalletWithdrawal), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_ColdWallet_CreatesTheBumpPendingForApprovers()
+    {
+        SetupOriginal(ColdWallet());
+
+        var bump = await CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        bump.Status.Should().Be(WalletWithdrawalRequestStatus.Pending, "cold-wallet bumps must be re-signed by the approvers");
+        bump.BumpingWalletWithdrawalRequestId.Should().Be(OriginalId);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_BumpOfABump_KeepsASinglePrefix()
+    {
+        var original = SetupOriginal(HotWallet());
+        original.Description = "Bump of request 7: pay rent";
+
+        var bump = await CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        bump.Description.Should().Be($"Bump of request {OriginalId}: pay rent");
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_RecommendedFeeType_ResolvesTheRateFromNbxplorer()
+    {
+        SetupOriginal(HotWallet());
+        _nbXplorer.Setup(x => x.GetFeesByType(MempoolRecommendedFeesType.FastestFee, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(25m);
+
+        var bump = await CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.FastestFee, null);
+
+        bump.MempoolRecommendedFeesType.Should().Be(MempoolRecommendedFeesType.FastestFee);
+        bump.CustomFeeRate.Should().Be(25m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_UnknownRequest_IsRefused()
+    {
+        _requests.Setup(x => x.GetById(OriginalId)).ReturnsAsync((WalletWithdrawalRequest?)null);
+
+        await AssertRefusedAsync(BumpingErrorReason.RequestNotFound, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Theory]
+    [InlineData(WalletWithdrawalRequestStatus.Pending)]
+    [InlineData(WalletWithdrawalRequestStatus.PSBTSignaturesPending)]
+    [InlineData(WalletWithdrawalRequestStatus.OnChainConfirmed)]
+    [InlineData(WalletWithdrawalRequestStatus.Bumped)]
+    [InlineData(WalletWithdrawalRequestStatus.Failed)]
+    public async Task CreateBumpRequestAsync_NotPendingConfirmation_IsRefused(WalletWithdrawalRequestStatus status)
+    {
+        SetupOriginal(HotWallet(), status: status);
+
+        await AssertRefusedAsync(BumpingErrorReason.InvalidState, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_AlreadyMined_IsRefused()
+    {
+        SetupOriginal(HotWallet(), confirmations: 1);
+
+        await AssertRefusedAsync(BumpingErrorReason.AlreadyConfirmed, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_TransactionUnknownToNbxplorer_IsRefused()
+    {
+        SetupOriginal(HotWallet());
+        _nbXplorer.Setup(x => x.GetTransactionAsync(It.IsAny<uint256>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TransactionResult?)null);
+
+        await AssertRefusedAsync(BumpingErrorReason.TransactionNotFound, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_ChangelessWithSeveralDestinations_IsRefused()
+    {
+        SetupOriginal(HotWallet(), destinations: 2, changeless: true);
+
+        await AssertRefusedAsync(BumpingErrorReason.ChangelessMultipleDestinations, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(1)]
+    public async Task CreateBumpRequestAsync_FeeRateNotHigherThanTheCurrentOne_IsRefused(int newRate)
+    {
+        SetupOriginal(HotWallet(), customFeeRate: 2);
+
+        await AssertRefusedAsync(BumpingErrorReason.FeeRateNotHigher, MempoolRecommendedFeesType.CustomFee, newRate);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_CustomFeeWithoutARate_IsRefused()
+    {
+        SetupOriginal(HotWallet());
+
+        await AssertRefusedAsync(BumpingErrorReason.InvalidFeeRate, MempoolRecommendedFeesType.CustomFee, null);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_FeeExceedingTheInputs_IsRefused()
+    {
+        // Two destinations of 0.01 BTC funded by exactly 0.02 BTC: no room for a higher fee, let alone the change.
+        SetupOriginal(HotWallet(), destinations: 2, inputSats: 2_000_000);
+
+        await AssertRefusedAsync(BumpingErrorReason.FeeExceedsInputs, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_OriginalWithoutLockedUtxos_CancelsTheHalfCreatedBump()
+    {
+        SetupOriginal(HotWallet());
+        _fmutxos.Setup(x => x.GetLockedUTXOsByWithdrawalId(OriginalId)).ReturnsAsync(new List<FMUTXO>());
+
+        var act = () => CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        (await act.Should().ThrowAsync<BumpingException>()).Which.Reason.Should().Be(BumpingErrorReason.InvalidState);
+        _storedBump.Should().NotBeNull("the bump row had been inserted before the UTXO lookup");
+        _storedBump!.Status.Should().Be(WalletWithdrawalRequestStatus.Cancelled, "a half-prepared bump must not linger as a pending request");
+        _requests.Verify(x => x.Update(It.Is<WalletWithdrawalRequest>(r => r.Id == BumpId
+            && r.Status == WalletWithdrawalRequestStatus.Cancelled)), Times.Once);
+    }
+
+    // ---- ScheduleHotWalletWithdrawalAsync -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_PendingHotRequest_IsPromotedBeforeTheJobIsScheduled()
+    {
+        var request = HotRequest(WalletWithdrawalRequestStatus.Pending);
+        var events = new List<string>();
+        _requests.Setup(x => x.Update(It.IsAny<WalletWithdrawalRequest>()))
+            .Callback<WalletWithdrawalRequest>(r => events.Add($"update:{r.Id}:{r.Status}"))
+            .Returns((true, (string?)null));
+        _bitcoin.Setup(x => x.GenerateTemplatePSBT(It.IsAny<WalletWithdrawalRequest>()))
+            .Callback(() => events.Add("template"))
+            .ReturnsAsync(EmptyPsbt());
+        _scheduler.Setup(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
+            .Callback<IJobDetail, ITrigger, CancellationToken>((job, _, _) =>
+            {
+                job.JobType.Should().Be(typeof(PerformWithdrawalJob));
+                job.JobDataMap.GetInt("withdrawalRequestId").Should().Be(BumpId);
+                events.Add("schedule");
+            })
+            .ReturnsAsync(DateTimeOffset.UtcNow);
+
+        var psbt = await CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        psbt.Should().NotBeNull();
+        request.Status.Should().Be(WalletWithdrawalRequestStatus.PSBTSignaturesPending);
+        events.Should().Equal(new[] { $"update:{BumpId}:PSBTSignaturesPending", "template", "schedule" },
+            "PerformWithdrawalJob throws 'Invalid status' unless the request is already PSBTSignaturesPending when it runs");
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_RequestAlreadyPsbtSignaturesPending_DoesNotTouchItsStatus()
+    {
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending);
+
+        await CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        _requests.Verify(x => x.Update(It.IsAny<WalletWithdrawalRequest>()), Times.Never);
+        _scheduler.Verify(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_Bump_MarksTheReplacedRequestAsBumped()
+    {
+        var original = SetupOriginal(HotWallet());
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending, bumping: OriginalId);
+
+        await CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.Bumped);
+        _requests.Verify(x => x.Update(It.Is<WalletWithdrawalRequest>(r => r.Id == OriginalId
+            && r.Status == WalletWithdrawalRequestStatus.Bumped)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_SchedulingFails_RevertsTheReplacedRequestAndRethrows()
+    {
+        var original = SetupOriginal(HotWallet());
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending, bumping: OriginalId);
+        _scheduler.Setup(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("quartz down"));
+
+        var act = () => CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("quartz down");
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.OnChainConfirmationPending,
+            "an abandoned bump must give the replaced request back its pending-confirmation status");
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_TemplateGenerationFails_LeavesTheReplacedRequestUntouched()
+    {
+        var original = SetupOriginal(HotWallet());
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending, bumping: OriginalId);
+        _bitcoin.Setup(x => x.GenerateTemplatePSBT(It.IsAny<WalletWithdrawalRequest>()))
+            .ThrowsAsync(new NoUTXOsAvailableException());
+
+        var act = () => CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        await act.Should().ThrowAsync<NoUTXOsAvailableException>();
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.OnChainConfirmationPending);
+        _scheduler.Verify(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_ColdWallet_IsRefused()
+    {
+        var request = HotRequest(WalletWithdrawalRequestStatus.Pending);
+        request.Wallet = ColdWallet();
+
+        var act = () => CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _scheduler.Verify(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(WalletWithdrawalRequestStatus.Cancelled)]
+    [InlineData(WalletWithdrawalRequestStatus.Failed)]
+    [InlineData(WalletWithdrawalRequestStatus.OnChainConfirmationPending)]
+    public async Task ScheduleHotWalletWithdrawalAsync_WrongStatus_IsRefused(WalletWithdrawalRequestStatus status)
+    {
+        HotRequest(status);
+
+        var act = () => CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ---- MarkOriginalAsBumpedAsync / RevertOriginalAsync -------------------------------------------------------
+
+    [Fact]
+    public async Task RevertOriginalAsync_OnlyRevertsARequestThatIsBumped()
+    {
+        var original = SetupOriginal(HotWallet(), status: WalletWithdrawalRequestStatus.OnChainConfirmed);
+        var bump = HotRequest(WalletWithdrawalRequestStatus.Cancelled, bumping: OriginalId);
+
+        await CreateService().RevertOriginalAsync(bump);
+
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.OnChainConfirmed,
+            "a request that was never marked Bumped (or already confirmed) must not be pushed back to pending");
+        _requests.Verify(x => x.Update(It.IsAny<WalletWithdrawalRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkOriginalAsBumpedAsync_NotABump_IsANoOp()
+    {
+        var request = HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending);
+
+        await CreateService().MarkOriginalAsBumpedAsync(request);
+
+        _requests.Verify(x => x.Update(It.IsAny<WalletWithdrawalRequest>()), Times.Never);
+    }
+
+    // ---- fixtures ---------------------------------------------------------------------------------------------
+
+    private async Task AssertRefusedAsync(BumpingErrorReason reason, MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+    {
+        var act = () => CreateService().CreateBumpRequestAsync(OriginalId, feeType, customFeeRate);
+
+        (await act.Should().ThrowAsync<BumpingException>()).Which.Reason.Should().Be(reason);
+        _requests.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequest>()), Times.Never,
+            "a refused bump must not create a request");
+    }
+
+    private static Wallet HotWallet() => new()
+    {
+        Id = 3,
+        Name = "hot",
+        IsHotWallet = true,
+        MofN = 1,
+        WalletAddressType = WalletAddressType.NativeSegwit,
+        Keys = new List<Key> { new() { XPUB = Tpub } },
+    };
+
+    private static Wallet ColdWallet()
+    {
+        var wallet = HotWallet();
+        wallet.Id = 2;
+        wallet.Name = "cold";
+        wallet.IsHotWallet = false;
+        return wallet;
+    }
+
+    /// <summary>The request being replaced: broadcast, unconfirmed, with its inputs locked.</summary>
+    private WalletWithdrawalRequest SetupOriginal(Wallet wallet,
+        WalletWithdrawalRequestStatus status = WalletWithdrawalRequestStatus.OnChainConfirmationPending,
+        int confirmations = 0, int destinations = 1, bool changeless = false, decimal? customFeeRate = 2,
+        long inputSats = 10_000_000)
+    {
+        var original = new WalletWithdrawalRequest
+        {
+            Id = OriginalId,
+            Status = status,
+            TxId = _originalTxId.ToString(),
+            Wallet = wallet,
+            WalletId = wallet.Id,
+            Description = "pay rent",
+            Changeless = changeless,
+            WithdrawAllFunds = false,
+            MempoolRecommendedFeesType = MempoolRecommendedFeesType.CustomFee,
+            CustomFeeRate = customFeeRate,
+            UserRequestorId = "user-1",
+            RequestMetadata = "{\"userName\":\"alice\"}",
+            WalletWithdrawalRequestDestinations = Enumerable.Range(0, destinations)
+                .Select(_ => new WalletWithdrawalRequestDestination { Address = DestinationAddress, Amount = 0.01m })
+                .ToList(),
+            UTXOs = new List<FMUTXO> { new() { TxId = _fundingTxId.ToString(), OutputIndex = 0, SatsAmount = inputSats } },
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>(),
+        };
+
+        _requests.Setup(x => x.GetById(OriginalId)).ReturnsAsync(original);
+
+        var network = Network.RegTest;
+        var tx = network.CreateTransaction();
+        tx.Inputs.Add(new TxIn(new OutPoint(_fundingTxId, 0)) { Sequence = Sequence.OptInRBF });
+        foreach (var destination in original.WalletWithdrawalRequestDestinations)
+        {
+            tx.Outputs.Add(new TxOut(new Money(destination.Amount, MoneyUnit.BTC), BitcoinAddress.Create(destination.Address, network)));
+        }
+
+        _nbXplorer.Setup(x => x.GetTransactionAsync(_originalTxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionResult { Confirmations = confirmations, Transaction = tx });
+
+        return original;
+    }
+
+    /// <summary>The hot-wallet request to execute (a bump when <paramref name="bumping"/> is set).</summary>
+    private WalletWithdrawalRequest HotRequest(WalletWithdrawalRequestStatus status, int? bumping = null)
+    {
+        var request = new WalletWithdrawalRequest
+        {
+            Id = BumpId,
+            Status = status,
+            Wallet = HotWallet(),
+            WalletId = 3,
+            Description = "pay rent",
+            BumpingWalletWithdrawalRequestId = bumping,
+            WalletWithdrawalRequestDestinations = new List<WalletWithdrawalRequestDestination>
+            {
+                new() { Address = DestinationAddress, Amount = 0.01m },
+            },
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>(),
+            UTXOs = new List<FMUTXO>(),
+        };
+
+        _storedBump = request;
+        return request;
+    }
+
+    /// <summary>A parseable one-in/one-out PSBT; PSBT.FromTransaction refuses a transaction without inputs.</summary>
+    private static PSBT EmptyPsbt()
+    {
+        var network = Network.RegTest;
+        var tx = network.CreateTransaction();
+        tx.Inputs.Add(new TxIn(new OutPoint(uint256.One, 0)));
+        tx.Outputs.Add(new TxOut(Money.Coins(0.01m), BitcoinAddress.Create(DestinationAddress, network)));
+        return PSBT.FromTransaction(tx, network);
+    }
+}

--- a/test/NodeGuard.Tests/Services/WithdrawalRequestServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/WithdrawalRequestServiceTests.cs
@@ -43,6 +43,7 @@ public class WithdrawalRequestServiceTests
         "tpubDCfM7v7fKZ31gTGGggNMycfCr5cDGinyijveRZ44RYSgAgEARwhaBd6PPpWst8kKbhEVoqNasgjHFWZKrEQoJ9pzPVEmNZDNe92hShzEMDy";
 
     private const string DestinationAddress = "bcrt1q590shaxaf5u08ml8jwlzghz99dup3z9592vxal";
+    private const string ReturnAddress = "bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf";
     private const int OriginalId = 10;
     private const int BumpId = 11;
 
@@ -71,9 +72,6 @@ public class WithdrawalRequestServiceTests
         _requests.Setup(x => x.GetById(BumpId)).ReturnsAsync(() => _storedBump);
         _requests.Setup(x => x.Update(It.IsAny<WalletWithdrawalRequest>())).Returns((true, (string?)null));
 
-        _fmutxos.Setup(x => x.GetLockedUTXOsByWithdrawalId(OriginalId))
-            .ReturnsAsync(new List<FMUTXO> { new() { TxId = _fundingTxId.ToString(), OutputIndex = 0, SatsAmount = 10_000_000 } });
-
         _coinSelection.Setup(x => x.GetUTXOsByOutpointAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<List<OutPoint>>()))
             .ReturnsAsync((DerivationStrategyBase _, List<OutPoint> outpoints) =>
                 outpoints.Select(o => new UTXO { Outpoint = o, Value = Money.Satoshis(10_000_000) }).ToList());
@@ -83,6 +81,9 @@ public class WithdrawalRequestServiceTests
             .ReturnsAsync(DateTimeOffset.UtcNow);
 
         _bitcoin.Setup(x => x.GenerateTemplatePSBT(It.IsAny<WalletWithdrawalRequest>())).ReturnsAsync(EmptyPsbt());
+
+        _nbXplorer.Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), DerivationFeature.Deposit, 0, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new KeyPathInformation { Address = BitcoinAddress.Create(ReturnAddress, Network.RegTest) });
     }
 
     private WithdrawalRequestService CreateService() => new(
@@ -235,10 +236,21 @@ public class WithdrawalRequestServiceTests
     }
 
     [Fact]
-    public async Task CreateBumpRequestAsync_OriginalWithoutLockedUtxos_CancelsTheHalfCreatedBump()
+    public async Task CreateBumpRequestAsync_OriginalWithoutLockedUtxos_IsRefusedBeforeAnythingIsCreated()
     {
         SetupOriginal(HotWallet());
         _fmutxos.Setup(x => x.GetLockedUTXOsByWithdrawalId(OriginalId)).ReturnsAsync(new List<FMUTXO>());
+
+        await AssertRefusedAsync(BumpingErrorReason.InvalidState, MempoolRecommendedFeesType.CustomFee, 10m);
+    }
+
+    [Fact]
+    public async Task CreateBumpRequestAsync_UtxosNoLongerSpendable_CancelsTheHalfCreatedBump()
+    {
+        SetupOriginal(HotWallet());
+        // The inputs left NBXplorer's confirmed UTXO set (e.g. the original got mined in the meantime).
+        _coinSelection.Setup(x => x.GetUTXOsByOutpointAsync(It.IsAny<DerivationStrategyBase>(), It.IsAny<List<OutPoint>>()))
+            .ReturnsAsync(new List<UTXO>());
 
         var act = () => CreateService().CreateBumpRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
 
@@ -247,6 +259,73 @@ public class WithdrawalRequestServiceTests
         _storedBump!.Status.Should().Be(WalletWithdrawalRequestStatus.Cancelled, "a half-prepared bump must not linger as a pending request");
         _requests.Verify(x => x.Update(It.Is<WalletWithdrawalRequest>(r => r.Id == BumpId
             && r.Status == WalletWithdrawalRequestStatus.Cancelled)), Times.Once);
+    }
+
+    // ---- CreateCancelRequestAsync --------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateCancelRequestAsync_HotWallet_ReturnsTheFundsToTheWallet()
+    {
+        var original = SetupOriginal(HotWallet());
+
+        var cancel = await CreateService().CreateCancelRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        cancel.Should().BeSameAs(_storedBump);
+        cancel.IsRbfCancellation.Should().BeTrue();
+        cancel.BumpingWalletWithdrawalRequestId.Should().Be(OriginalId);
+        cancel.Status.Should().Be(WalletWithdrawalRequestStatus.PSBTSignaturesPending);
+        cancel.Description.Should().Be($"Cancel of request {OriginalId}: pay rent");
+        cancel.Changeless.Should().BeTrue("the single output absorbs the fee (GenerateTemplatePSBT's changeless branch)");
+        cancel.WithdrawAllFunds.Should().BeFalse();
+        cancel.CustomFeeRate.Should().Be(10m);
+        cancel.WalletWithdrawalRequestDestinations.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Address = ReturnAddress, Amount = 0.1m },
+                "everything the locked inputs hold goes back to a fresh address of the wallet");
+        cancel.WalletWithdrawalRequestDestinations.Single().Address.Should().NotBe(original.WalletWithdrawalRequestDestinations.Single().Address,
+            "the original destination must not be paid");
+
+        _coinSelection.Verify(x => x.LockUTXOs(
+            It.Is<List<UTXO>>(l => l.Count == 1 && l[0].Outpoint == new OutPoint(_fundingTxId, 0)),
+            It.Is<IBitcoinRequest>(r => r.Id == BumpId),
+            BitcoinRequestType.WalletWithdrawal), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCancelRequestAsync_ColdWallet_CreatesTheCancellationPendingForApprovers()
+    {
+        SetupOriginal(ColdWallet());
+
+        var cancel = await CreateService().CreateCancelRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        cancel.Status.Should().Be(WalletWithdrawalRequestStatus.Pending);
+        cancel.IsRbfCancellation.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateCancelRequestAsync_ChangelessOriginalWithSeveralDestinations_IsAllowed()
+    {
+        // A fee bump of this shape is refused (no change to take the fee from); a cancellation replaces every output.
+        SetupOriginal(HotWallet(), destinations: 2, changeless: true, inputSats: 2_000_000);
+
+        var cancel = await CreateService().CreateCancelRequestAsync(OriginalId, MempoolRecommendedFeesType.CustomFee, 10m);
+
+        cancel.WalletWithdrawalRequestDestinations.Should().ContainSingle().Which.Amount.Should().Be(0.02m);
+    }
+
+    [Fact]
+    public async Task CreateCancelRequestAsync_FeeRateNotHigherThanTheCurrentOne_IsRefused()
+    {
+        SetupOriginal(HotWallet(), customFeeRate: 2);
+
+        await AssertRefusedAsync(BumpingErrorReason.FeeRateNotHigher, MempoolRecommendedFeesType.CustomFee, 2m, cancellation: true);
+    }
+
+    [Fact]
+    public async Task CreateCancelRequestAsync_AlreadyMined_IsRefused()
+    {
+        SetupOriginal(HotWallet(), confirmations: 1);
+
+        await AssertRefusedAsync(BumpingErrorReason.AlreadyConfirmed, MempoolRecommendedFeesType.CustomFee, 10m, cancellation: true);
     }
 
     // ---- ScheduleHotWalletWithdrawalAsync -----------------------------------------------------------------------
@@ -301,6 +380,33 @@ public class WithdrawalRequestServiceTests
         original.Status.Should().Be(WalletWithdrawalRequestStatus.Bumped);
         _requests.Verify(x => x.Update(It.Is<WalletWithdrawalRequest>(r => r.Id == OriginalId
             && r.Status == WalletWithdrawalRequestStatus.Bumped)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_Cancellation_MarksTheReplacedRequestCancelledWithAReason()
+    {
+        var original = SetupOriginal(HotWallet());
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending, bumping: OriginalId, cancellation: true);
+
+        await CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.Cancelled, "the payment is not happening, it is not merely re-fed");
+        original.RejectCancelDescription.Should().Contain("RBF").And.Contain(BumpId.ToString());
+    }
+
+    [Fact]
+    public async Task ScheduleHotWalletWithdrawalAsync_CancellationSchedulingFails_RestoresTheReplacedRequest()
+    {
+        var original = SetupOriginal(HotWallet());
+        HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending, bumping: OriginalId, cancellation: true);
+        _scheduler.Setup(x => x.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("quartz down"));
+
+        var act = () => CreateService().ScheduleHotWalletWithdrawalAsync(BumpId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.OnChainConfirmationPending);
+        original.RejectCancelDescription.Should().BeNull();
     }
 
     [Fact]
@@ -374,20 +480,37 @@ public class WithdrawalRequestServiceTests
     }
 
     [Fact]
-    public async Task MarkOriginalAsBumpedAsync_NotABump_IsANoOp()
+    public async Task RevertOriginalAsync_CancellationByAnotherReplacement_IsLeftAlone()
+    {
+        var original = SetupOriginal(HotWallet(), status: WalletWithdrawalRequestStatus.Cancelled);
+        original.RejectCancelDescription = "Cancelled by RBF replacement request 99";
+        var cancel = HotRequest(WalletWithdrawalRequestStatus.Failed, bumping: OriginalId, cancellation: true);
+
+        await CreateService().RevertOriginalAsync(cancel);
+
+        original.Status.Should().Be(WalletWithdrawalRequestStatus.Cancelled);
+        _requests.Verify(x => x.Update(It.IsAny<WalletWithdrawalRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkOriginalAsReplacedAsync_NotAReplacement_IsANoOp()
     {
         var request = HotRequest(WalletWithdrawalRequestStatus.PSBTSignaturesPending);
 
-        await CreateService().MarkOriginalAsBumpedAsync(request);
+        await CreateService().MarkOriginalAsReplacedAsync(request);
 
         _requests.Verify(x => x.Update(It.IsAny<WalletWithdrawalRequest>()), Times.Never);
     }
 
     // ---- fixtures ---------------------------------------------------------------------------------------------
 
-    private async Task AssertRefusedAsync(BumpingErrorReason reason, MempoolRecommendedFeesType feeType, decimal? customFeeRate)
+    private async Task AssertRefusedAsync(BumpingErrorReason reason, MempoolRecommendedFeesType feeType, decimal? customFeeRate,
+        bool cancellation = false)
     {
-        var act = () => CreateService().CreateBumpRequestAsync(OriginalId, feeType, customFeeRate);
+        var service = CreateService();
+        var act = () => cancellation
+            ? service.CreateCancelRequestAsync(OriginalId, feeType, customFeeRate)
+            : service.CreateBumpRequestAsync(OriginalId, feeType, customFeeRate);
 
         (await act.Should().ThrowAsync<BumpingException>()).Which.Reason.Should().Be(reason);
         _requests.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequest>()), Times.Never,
@@ -441,6 +564,7 @@ public class WithdrawalRequestServiceTests
         };
 
         _requests.Setup(x => x.GetById(OriginalId)).ReturnsAsync(original);
+        _fmutxos.Setup(x => x.GetLockedUTXOsByWithdrawalId(OriginalId)).ReturnsAsync(original.UTXOs);
 
         var network = Network.RegTest;
         var tx = network.CreateTransaction();
@@ -457,7 +581,7 @@ public class WithdrawalRequestServiceTests
     }
 
     /// <summary>The hot-wallet request to execute (a bump when <paramref name="bumping"/> is set).</summary>
-    private WalletWithdrawalRequest HotRequest(WalletWithdrawalRequestStatus status, int? bumping = null)
+    private WalletWithdrawalRequest HotRequest(WalletWithdrawalRequestStatus status, int? bumping = null, bool cancellation = false)
     {
         var request = new WalletWithdrawalRequest
         {
@@ -467,6 +591,7 @@ public class WithdrawalRequestServiceTests
             WalletId = 3,
             Description = "pay rent",
             BumpingWalletWithdrawalRequestId = bumping,
+            IsRbfCancellation = cancellation,
             WalletWithdrawalRequestDestinations = new List<WalletWithdrawalRequestDestination>
             {
                 new() { Address = DestinationAddress, Amount = 0.01m },


### PR DESCRIPTION
## Why

PR #557 removed a redundant, untagged PSBT row that the Withdrawals page stored after generating a hot-wallet template. That row's insert had a hidden side effect in `WalletWithdrawalRequestPsbtRepository.AddAsync`: it moved the request to `PSBTSignaturesPending`, the only status `PerformWithdrawal` accepts. Without it, hot-wallet requests created from the page (fresh withdrawals from the datagrid and every RBF fee bump) stayed `Pending`, `PerformWithdrawalJob` threw "Invalid status", marked the bump `Failed` and reset the original, while the UI reported success. Transfer Funds and the gRPC `RequestWithdrawal` set the status explicitly, which is why the gRPC-driven E2E suite never caught it.

## What

- **`WithdrawalRequestService`** (new): owns the RBF replacement flow — fee bumps and cancellations — (validation, creation with the original's UTXOs locked, hot wallets created straight in `PSBTSignaturesPending`) and the hot-wallet execution step (promote status, template, mark the original `Bumped` / `Cancelled`, schedule `PerformWithdrawalJob`, revert on failure). `Withdrawals.razor` and `BumpfeeModal.razor` call it; the page no longer overwrites a replacement's fields with stale form state.
- **`BumpWithdrawal` gRPC method**: same orchestration over the API. The withdrawal is addressed by request id **or by the txid `RequestWithdrawal` returned** (`oneof target`). Refusals carry a typed `BumpingErrorReason`, mapped to `NotFound` / `FailedPrecondition` / `InvalidArgument`.
- **Cancel via RBF** (`CancelWithdrawal` gRPC method + "Cancel (RBF)" action next to "Bump fee" in the UI): replaces the unconfirmed transaction with one that spends the same inputs at a higher fee rate and returns everything to a fresh address of the wallet, so the destination is never paid. The original ends up `Cancelled` with a reason pointing at the replacement (restored to pending if the replacement is abandoned). New `IsRbfCancellation` column (migration `AddIsRbfCancellationToWalletWithdrawalRequest`) so the cold-wallet approval path and the failure paths treat the original correctly. Replacement requests skip the wallet-balance check on creation, since they re-spend inputs that are already locked.
- **Tests**: `WithdrawalRequestServiceTests` (bump/cancel creation, status promotion ordering, revert paths), `BumpWithdrawal` / `CancelWithdrawal` cases in `NodeGuardServiceTests` (hot/cold, error mapping, txid resolution), and `WithdrawalRbfBumpE2ETests` with two scenarios: bump by txid (same inputs and destination, original evicted and `WITHDRAWAL_BUMPED`, replacement settled once mined) and cancel by txid (single output back to the wallet, destination never paid, original `WITHDRAWAL_CANCELLED`, funds a spendable UTXO of the wallet again).
- E2E stack: `MONITOR_WITHDRAWALS_CRON` set to 10 s so settlement is observable.

## Verification

- `dotnet test --filter "Category!=E2E"`: 532 green.
- CI E2E (`run-e2e-tests`, [run 33898507472](https://github.com/Elenpay/NodeGuard/actions/runs/33898507472)): the whole suite green (23 tests), including both RBF scenarios — `BumpWithdrawal_ReplacesTheUnconfirmedHotWalletTransaction` (bump by txid) and `CancelWithdrawal_ReturnsTheFundsOfTheUnconfirmedHotWalletTransaction`.
- Note for local runs: the containerized stack needs an NBXplorer image with the `POST selectutxos` route.
