### PR TITLE
Enforce single template PSBT per request via unique index

### DIFF
--- a/src/Data/ApplicationDbContext.cs
+++ b/src/Data/ApplicationDbContext.cs
@@ -66,6 +66,26 @@ namespace NodeGuard.Data
             //There should be only one Liquidity Rule per Channel
             modelBuilder.Entity<LiquidityRule>().HasIndex(x => x.ChannelId).IsUnique();
 
+            // Exactly one template PSBT per request. The template is the trust anchor every approval is
+            // validated against (PsbtApprovalValidator); two concurrent GenerateTemplatePSBT calls used to
+            // persist two templates with different txids, so the approver signed a transaction the validator
+            // then rejected. Partial unique index: only rows tagged IsTemplatePSBT participate. The named
+            // overload is deliberate: HasIndex(props) alone would return and mutate the convention FK index
+            // instead of adding a second one.
+            // The plain FK indexes must be declared too: once any explicit index covers the FK property, EF no
+            // longer creates the convention one, and the migration would drop it.
+            modelBuilder.Entity<WalletWithdrawalRequestPSBT>().HasIndex(x => x.WalletWithdrawalRequestId);
+            modelBuilder.Entity<WalletWithdrawalRequestPSBT>()
+                .HasIndex(x => x.WalletWithdrawalRequestId, "IX_WalletWithdrawalRequestPSBTs_Template")
+                .IsUnique()
+                .HasFilter("\"IsTemplatePSBT\"");
+
+            modelBuilder.Entity<ChannelOperationRequestPSBT>().HasIndex(x => x.ChannelOperationRequestId);
+            modelBuilder.Entity<ChannelOperationRequestPSBT>()
+                .HasIndex(x => x.ChannelOperationRequestId, "IX_ChannelOperationRequestPSBTs_Template")
+                .IsUnique()
+                .HasFilter("\"IsTemplatePSBT\"");
+
             modelBuilder.Entity<ApplicationUser>().HasIndex(x => x.NormalizedUserName).IsUnique();
 
 

--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -161,6 +161,24 @@ namespace NodeGuard.Data.Models
         public int NumberOfSignaturesCollected => ChannelOperationRequestPsbts == null ? 0 : ChannelOperationRequestPsbts.Count(x => !x.IsFinalisedPSBT && !x.IsTemplatePSBT && !x.IsInternalWalletPSBT);
 
         /// <summary>
+        /// The single template PSBT of this request, or null when none has been generated yet.
+        /// The database enforces at most one (IX_ChannelOperationRequestPSBTs_Template); finding more is a
+        /// data-integrity fault and this throws rather than silently picking one.
+        /// </summary>
+        public ChannelOperationRequestPSBT? GetSingleTemplatePsbt()
+        {
+            try
+            {
+                return ChannelOperationRequestPsbts?.SingleOrDefault(x => x.IsTemplatePSBT);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(
+                    $"Channel operation request {Id} has more than one template PSBT, expected exactly one", e);
+            }
+        }
+
+        /// <summary>
         /// This indicates if the user requested a changeless operation by selecting UTXOs
         /// </summary>
         public bool Changeless { get; set; }
@@ -179,13 +197,13 @@ namespace NodeGuard.Data.Models
 
                 //We add the internal Wallet signature
                 if (Wallet != null && Wallet.IsHotWallet) return ChannelOperationRequestPsbts.Count(x => x.IsTemplatePSBT) == 1;
-                
+
                 //if it is a BIP39 or watch only wallet, we don't need to add the internal wallet signature
                 if (Wallet != null && (Wallet.IsBIP39Imported || Wallet.IsWatchOnly))
                 {
                     return userPSBTsCount == Wallet.MofN;
                 }
-                
+
                 userPSBTsCount++;
 
                 if (userPSBTsCount == Wallet.MofN)

--- a/src/Data/Models/ChannelOperationRequest.cs
+++ b/src/Data/Models/ChannelOperationRequest.cs
@@ -163,7 +163,8 @@ namespace NodeGuard.Data.Models
         /// <summary>
         /// The single template PSBT of this request, or null when none has been generated yet.
         /// The database enforces at most one (IX_ChannelOperationRequestPSBTs_Template); finding more is a
-        /// data-integrity fault and this throws rather than silently picking one.
+        /// data-integrity fault and this throws rather than silently picking one, because the template is
+        /// what every approval is validated against and what the internal wallet co-signs.
         /// </summary>
         public ChannelOperationRequestPSBT? GetSingleTemplatePsbt()
         {

--- a/src/Data/Models/WalletWithdrawalRequest.cs
+++ b/src/Data/Models/WalletWithdrawalRequest.cs
@@ -104,6 +104,25 @@ namespace NodeGuard.Data.Models
             !x.IsTemplatePSBT && !x.IsFinalisedPSBT && !x.IsInternalWalletPSBT);
 
         /// <summary>
+        /// The single template PSBT of this request, or null when none has been generated yet.
+        /// The database enforces at most one (IX_WalletWithdrawalRequestPSBTs_Template); finding more is a
+        /// data-integrity fault and this throws rather than silently picking one, because the template is
+        /// what every approval is validated against and what the internal wallet co-signs.
+        /// </summary>
+        public WalletWithdrawalRequestPSBT? GetSingleTemplatePsbt()
+        {
+            try
+            {
+                return WalletWithdrawalRequestPSBTs?.SingleOrDefault(x => x.IsTemplatePSBT);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(
+                    $"Withdrawal request {Id} has more than one template PSBT, expected exactly one", e);
+            }
+        }
+
+        /// <summary>
         /// This indicates if the user requested a changeless operation by selecting UTXOs
         /// </summary>
         public bool Changeless { get; set; }

--- a/src/Data/Repositories/ChannelOperationRequestPSBTRepository.cs
+++ b/src/Data/Repositories/ChannelOperationRequestPSBTRepository.cs
@@ -17,16 +17,22 @@
  *
  */
 
-﻿using NodeGuard.Data.Models;
+using NodeGuard.Data.Models;
 using NodeGuard.Data.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using NBitcoin;
 using NodeGuard.Helpers;
+using Npgsql;
 
 namespace NodeGuard.Data.Repositories
 {
     public class ChannelOperationRequestPSBTRepository : IChannelOperationRequestPSBTRepository
     {
+        /// <summary>
+        /// See WalletWithdrawalRequestPsbtRepository.TemplateAlreadyExists.
+        /// </summary>
+        public const string TemplateAlreadyExists = "A template PSBT already exists for this request.";
+
         private readonly IRepository<ChannelOperationRequestPSBT> _repository;
         private readonly ILogger<ChannelOperationRequestPSBTRepository> _logger;
         private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
@@ -45,6 +51,14 @@ namespace NodeGuard.Data.Repositories
             await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
 
             return await applicationDbContext.ChannelOperationRequestPSBTs.FirstOrDefaultAsync(x => x.Id == id);
+        }
+
+        public async Task<ChannelOperationRequestPSBT?> GetTemplateByRequestId(int channelOperationRequestId)
+        {
+            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            return await applicationDbContext.ChannelOperationRequestPSBTs
+                .SingleOrDefaultAsync(x => x.ChannelOperationRequestId == channelOperationRequestId && x.IsTemplatePSBT);
         }
 
         public async Task<List<ChannelOperationRequestPSBT>> GetAll()
@@ -75,9 +89,14 @@ namespace NodeGuard.Data.Repositories
                 return (false, validation.Error);
             }
 
+            if (type.IsTemplatePSBT)
+            {
+                return await AddTemplateAsync(type, applicationDbContext);
+            }
+
             try
             {
-                if (request != null && !type.IsTemplatePSBT)
+                if (request != null)
                 {
                     request.Status = ChannelOperationRequestStatus.PSBTSignaturesPending;
 
@@ -92,6 +111,40 @@ namespace NodeGuard.Data.Repositories
             }
 
             return await _repository.AddAsync(type, applicationDbContext);
+        }
+
+        /// <summary>
+        /// See WalletWithdrawalRequestPsbtRepository.AddTemplateAsync: surfaces the unique-index violation
+        /// (IX_ChannelOperationRequestPSBTs_Template) instead of the generic repository's (false, null).
+        /// </summary>
+        private async Task<(bool, string?)> AddTemplateAsync(ChannelOperationRequestPSBT type,
+            ApplicationDbContext applicationDbContext)
+        {
+            try
+            {
+                applicationDbContext.Add(type);
+                await applicationDbContext.SaveChangesAsync();
+
+                return (true, null);
+            }
+            catch (DbUpdateException e) when (e.InnerException is PostgresException
+            {
+                SqlState: PostgresErrorCodes.UniqueViolation
+            })
+            {
+                _logger.LogWarning(
+                    "Template PSBT for channel operation request {RequestId} already exists, a concurrent generation won the race",
+                    type.ChannelOperationRequestId);
+
+                return (false, TemplateAlreadyExists);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error saving template PSBT for channel operation request {RequestId}",
+                    type.ChannelOperationRequestId);
+
+                return (false, null);
+            }
         }
 
         public async Task<(bool, string?)> AddRangeAsync(List<ChannelOperationRequestPSBT> type)
@@ -154,8 +207,15 @@ namespace NodeGuard.Data.Repositories
                 .Select(x => x.PSBT)
                 .ToList() ?? new List<string>();
 
-            var template = request.ChannelOperationRequestPsbts?
-                .FirstOrDefault(x => x.IsTemplatePSBT)?.PSBT;
+            string? template;
+            try
+            {
+                template = request.GetSingleTemplatePsbt()?.PSBT;
+            }
+            catch (InvalidOperationException e)
+            {
+                return PsbtApprovalValidator.Result.Fail(e.Message);
+            }
 
             if (string.IsNullOrWhiteSpace(template))
             {

--- a/src/Data/Repositories/Interfaces/IChannelOperationRequestPSBTRepository.cs
+++ b/src/Data/Repositories/Interfaces/IChannelOperationRequestPSBTRepository.cs
@@ -17,13 +17,20 @@
  *
  */
 
-﻿using NodeGuard.Data.Models;
+using NodeGuard.Data.Models;
 
 namespace NodeGuard.Data.Repositories.Interfaces;
 
 public interface IChannelOperationRequestPSBTRepository
 {
     Task<ChannelOperationRequestPSBT?> GetById(int id);
+
+    /// <summary>
+    /// The persisted template PSBT of a request (the one approvals are validated against), or null. Reads
+    /// from the database rather than a navigation collection so that a caller who lost the generation race
+    /// sees the winner's row.
+    /// </summary>
+    Task<ChannelOperationRequestPSBT?> GetTemplateByRequestId(int channelOperationRequestId);
 
     Task<List<ChannelOperationRequestPSBT>> GetAll();
 

--- a/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestPsbtRepository.cs
+++ b/src/Data/Repositories/Interfaces/IWalletWithdrawalRequestPsbtRepository.cs
@@ -17,13 +17,20 @@
  *
  */
 
-﻿using NodeGuard.Data.Models;
+using NodeGuard.Data.Models;
 
 namespace NodeGuard.Data.Repositories.Interfaces;
 
 public interface IWalletWithdrawalRequestPsbtRepository
 {
     Task<WalletWithdrawalRequestPSBT?> GetById(int id);
+
+    /// <summary>
+    /// The persisted template PSBT of a request (the one approvals are validated against), or null. Reads
+    /// from the database rather than a navigation collection so that a caller who lost the generation race
+    /// sees the winner's row.
+    /// </summary>
+    Task<WalletWithdrawalRequestPSBT?> GetTemplateByRequestId(int walletWithdrawalRequestId);
     Task<List<WalletWithdrawalRequestPSBT>> GetAll();
     Task<(bool, string?)> AddAsync(WalletWithdrawalRequestPSBT type);
     Task<(bool, string?)> AddRangeAsync(List<WalletWithdrawalRequestPSBT> type);

--- a/src/Data/Repositories/WalletWithdrawalRequestPsbtRepository.cs
+++ b/src/Data/Repositories/WalletWithdrawalRequestPsbtRepository.cs
@@ -17,16 +17,23 @@
  *
  */
 
-﻿using NodeGuard.Data.Models;
+using NodeGuard.Data.Models;
 using NodeGuard.Data.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using NBitcoin;
 using NodeGuard.Helpers;
+using Npgsql;
 
 namespace NodeGuard.Data.Repositories
 {
     public class WalletWithdrawalRequestPsbtRepository : IWalletWithdrawalRequestPsbtRepository
     {
+        /// <summary>
+        /// Returned as the message when a template insert loses the race against another generator. The
+        /// database (IX_WalletWithdrawalRequestPSBTs_Template) is what rejects it; this just names it.
+        /// </summary>
+        public const string TemplateAlreadyExists = "A template PSBT already exists for this request.";
+
         private readonly IRepository<WalletWithdrawalRequestPSBT> _repository;
         private readonly ILogger<WalletWithdrawalRequestPsbtRepository> _logger;
         private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
@@ -45,6 +52,16 @@ namespace NodeGuard.Data.Repositories
             await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
 
             return await applicationDbContext.WalletWithdrawalRequestPSBTs.FirstOrDefaultAsync(x => x.Id == id);
+        }
+
+        public async Task<WalletWithdrawalRequestPSBT?> GetTemplateByRequestId(int walletWithdrawalRequestId)
+        {
+            await using var applicationDbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            // SingleOrDefault on purpose: the unique index guarantees at most one, and a second row must
+            // surface as an error rather than be papered over.
+            return await applicationDbContext.WalletWithdrawalRequestPSBTs
+                .SingleOrDefaultAsync(x => x.WalletWithdrawalRequestId == walletWithdrawalRequestId && x.IsTemplatePSBT);
         }
 
         public async Task<List<WalletWithdrawalRequestPSBT>> GetAll()
@@ -77,9 +94,14 @@ namespace NodeGuard.Data.Repositories
                 return (false, validation.Error);
             }
 
+            if (type.IsTemplatePSBT)
+            {
+                return await AddTemplateAsync(type, applicationDbContext);
+            }
+
             try
             {
-                if (request != null && !type.IsTemplatePSBT )
+                if (request != null)
                 {
                     request.Status = WalletWithdrawalRequestStatus.PSBTSignaturesPending;
 
@@ -94,6 +116,41 @@ namespace NodeGuard.Data.Repositories
             }
 
             return await _repository.AddAsync(type, applicationDbContext);
+        }
+
+        /// <summary>
+        /// Template inserts bypass the generic repository because it swallows every exception into
+        /// (false, null). GenerateTemplatePSBT needs to tell "lost the race, a template now exists" apart
+        /// from a genuine failure, so the unique-index violation is surfaced with a dedicated message.
+        /// </summary>
+        private async Task<(bool, string?)> AddTemplateAsync(WalletWithdrawalRequestPSBT type,
+            ApplicationDbContext applicationDbContext)
+        {
+            try
+            {
+                applicationDbContext.Add(type);
+                await applicationDbContext.SaveChangesAsync();
+
+                return (true, null);
+            }
+            catch (DbUpdateException e) when (e.InnerException is PostgresException
+            {
+                SqlState: PostgresErrorCodes.UniqueViolation
+            })
+            {
+                _logger.LogWarning(
+                    "Template PSBT for withdrawal request {RequestId} already exists, a concurrent generation won the race",
+                    type.WalletWithdrawalRequestId);
+
+                return (false, TemplateAlreadyExists);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error saving template PSBT for withdrawal request {RequestId}",
+                    type.WalletWithdrawalRequestId);
+
+                return (false, null);
+            }
         }
 
         public async Task<(bool, string?)> AddRangeAsync(List<WalletWithdrawalRequestPSBT> type)
@@ -144,8 +201,17 @@ namespace NodeGuard.Data.Repositories
                 .Select(x => x.PSBT)
                 .ToList() ?? new List<string>();
 
-            var template = request.WalletWithdrawalRequestPSBTs?
-                .FirstOrDefault(x => x.IsTemplatePSBT)?.PSBT;
+            string? template;
+            try
+            {
+                template = request.GetSingleTemplatePsbt()?.PSBT;
+            }
+            catch (InvalidOperationException e)
+            {
+                // Two templates means the approver may have signed a different transaction than the one we
+                // would compare against. Refuse rather than guess which template is "the" template.
+                return PsbtApprovalValidator.Result.Fail(e.Message);
+            }
 
             if (string.IsNullOrWhiteSpace(template))
             {

--- a/src/Migrations/20260907154220_EnforceSingleTemplatePsbtPerRequest.Designer.cs
+++ b/src/Migrations/20260907154220_EnforceSingleTemplatePsbtPerRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodeGuard.Data;
 using NodeGuard.Helpers;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NodeGuard.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260907154220_EnforceSingleTemplatePsbtPerRequest")]
+    partial class EnforceSingleTemplatePsbtPerRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/20260907154220_EnforceSingleTemplatePsbtPerRequest.cs
+++ b/src/Migrations/20260907154220_EnforceSingleTemplatePsbtPerRequest.cs
@@ -1,0 +1,119 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NodeGuard.Migrations
+{
+    /// <summary>
+    /// Enforces at most one template PSBT per withdrawal request and per channel operation request.
+    /// <para>
+    /// The template is the transaction every approval is validated against. Two concurrent
+    /// GenerateTemplatePSBT calls (a double click on Approve) used to persist two templates with different
+    /// txids, so an approver signed one while the validator compared against the other. Partial unique
+    /// indexes make a second template row impossible.
+    /// </para>
+    /// <para>
+    /// Existing duplicates are repaired here, in SQL, right before the indexes are created. For a request
+    /// that went through (it has a TxId) the template whose txid equals that TxId survives; the txid is
+    /// computed in SQL from the PSBT's unsigned transaction. For every other request (cancelled, rejected,
+    /// failed, or without a TxId) the oldest row survives. Removed rows are copied to
+    /// "&lt;Table&gt;_RemovedDuplicateTemplates", outside the EF model. A request that was still collecting
+    /// signatures is marked Failed, since the template its approvers were shown may be the one removed.
+    /// </para>
+    /// </summary>
+    public partial class EnforceSingleTemplatePsbtPerRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // WalletWithdrawalRequestStatus: Pending = 0, PSBTSignaturesPending = 3, FinalizingPSBT = 7, Failed = 6
+            migrationBuilder.Sql(Dedupe("WalletWithdrawalRequestPSBTs", "WalletWithdrawalRequestId", "WalletWithdrawalRequests",
+                activeStatuses: "0, 3, 7", failedStatus: 6));
+
+            // ChannelOperationRequestStatus: Pending = 4, PSBTSignaturesPending = 5, FinalizingPSBT = 9, Failed = 8
+            migrationBuilder.Sql(Dedupe("ChannelOperationRequestPSBTs", "ChannelOperationRequestId", "ChannelOperationRequests",
+                activeStatuses: "4, 5, 9", failedStatus: 8));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WalletWithdrawalRequestPSBTs_Template",
+                table: "WalletWithdrawalRequestPSBTs",
+                column: "WalletWithdrawalRequestId",
+                unique: true,
+                filter: "\"IsTemplatePSBT\"");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelOperationRequestPSBTs_Template",
+                table: "ChannelOperationRequestPSBTs",
+                column: "ChannelOperationRequestId",
+                unique: true,
+                filter: "\"IsTemplatePSBT\"");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_WalletWithdrawalRequestPSBTs_Template",
+                table: "WalletWithdrawalRequestPSBTs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChannelOperationRequestPSBTs_Template",
+                table: "ChannelOperationRequestPSBTs");
+
+            // Rows removed by Up stay in the *_RemovedDuplicateTemplates tables and are intentionally not restored.
+        }
+
+        /// <summary>
+        /// Removes all but one template PSBT per request. Survivor: the template whose txid equals the request's
+        /// TxId when there is one; otherwise the oldest row. The txid is the byte-reversed double SHA-256 of the
+        /// PSBT's unsigned transaction, which in a NodeGuard-built PSBT is the first global map entry: 5-byte
+        /// magic, key length 0x01, key type 0x00, compact-size value length, transaction bytes. A PSBT that does
+        /// not have that shape yields a NULL txid and simply never wins on the txid rule.
+        /// </summary>
+        private static string Dedupe(string psbtTable, string requestIdColumn, string requestTable,
+            string activeStatuses, int failedStatus) => $@"
+CREATE TABLE IF NOT EXISTS ""{psbtTable}_RemovedDuplicateTemplates"" AS
+SELECT p.*, now() AS ""RemovedAt"" FROM ""{psbtTable}"" p WHERE false;
+
+CREATE TEMP TABLE dup_templates ON COMMIT DROP AS
+WITH t AS (
+    SELECT p.""Id"", p.""{requestIdColumn}"" AS req, r.""TxId"", decode(p.""PSBT"", 'base64') AS b
+    FROM ""{psbtTable}"" p
+    JOIN ""{requestTable}"" r ON r.""Id"" = p.""{requestIdColumn}""
+    WHERE p.""IsTemplatePSBT""
+      AND p.""{requestIdColumn}"" IN (
+          SELECT ""{requestIdColumn}"" FROM ""{psbtTable}"" WHERE ""IsTemplatePSBT"" GROUP BY 1 HAVING count(*) > 1)
+), tx AS (
+    SELECT ""Id"", req, ""TxId"",
+        CASE WHEN octet_length(b) < 12
+                  OR substring(b from 1 for 5) <> '\x70736274ff'::bytea
+                  OR get_byte(b, 5) <> 1 OR get_byte(b, 6) <> 0 THEN NULL
+             WHEN get_byte(b, 7) < 253 THEN substring(b from 9 for get_byte(b, 7))
+             WHEN get_byte(b, 7) = 253 THEN substring(b from 11 for get_byte(b, 8) + 256 * get_byte(b, 9))
+             WHEN get_byte(b, 7) = 254 THEN substring(b from 13 for get_byte(b, 8) + 256 * get_byte(b, 9)
+                                                              + 65536 * get_byte(b, 10) + 16777216 * get_byte(b, 11))
+        END AS unsigned_tx
+    FROM t
+), h AS (
+    SELECT ""Id"", req, ""TxId"", encode(sha256(sha256(unsigned_tx)), 'hex') AS le FROM tx
+), ranked AS (
+    SELECT ""Id"", req,
+        row_number() OVER (
+            PARTITION BY req
+            ORDER BY ((SELECT string_agg(substr(le, 65 - 2 * i, 2), '') FROM generate_series(1, 32) i) = ""TxId"") DESC NULLS LAST,
+                     ""Id"") AS rn
+    FROM h
+)
+SELECT ""Id"", req FROM ranked WHERE rn > 1;
+
+INSERT INTO ""{psbtTable}_RemovedDuplicateTemplates""
+SELECT p.*, now() FROM ""{psbtTable}"" p WHERE p.""Id"" IN (SELECT ""Id"" FROM dup_templates);
+
+DELETE FROM ""{psbtTable}"" WHERE ""Id"" IN (SELECT ""Id"" FROM dup_templates);
+
+UPDATE ""{requestTable}"" SET ""Status"" = {failedStatus}, ""UpdateDatetime"" = now()
+WHERE ""Id"" IN (SELECT DISTINCT req FROM dup_templates) AND ""Status"" IN ({activeStatuses});
+
+DROP TABLE dup_templates;";
+    }
+}

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -254,7 +254,7 @@
             </DataGridColumn>
             <DataGridCommandColumn TItem="ChannelOperationRequest" Caption="Actions" Displayable="true">
                 <EditCommandTemplate>
-                    <Button Color="Color.Primary" hidden=@(!_isFinanceManager) Clicked="@(() => ShowModal(context.Item))">Approve</Button>
+                    <Button Color="Color.Primary" hidden=@(!_isFinanceManager) Disabled="@_approvalInFlight" Clicked="@(() => ShowModal(context.Item))">Approve</Button>
                     @{
                         if (LoggedUser?.Id == context.Item.UserId)
                         {
@@ -630,6 +630,9 @@
     private string? _selectedStatusActionString;
     private bool _isFinanceManager = false;
     private bool _isNodeManager = false;
+    // Guards template generation against re-entry (double click) on this circuit; cross-circuit races are
+    // handled by the database unique index on template PSBTs.
+    private bool _approvalInFlight;
     private ConfirmationModal _approveOperationConfirmationModal;
     private ConfirmationModal _markRequestAsFailedConfirmationModal;
     private UTXOSelectorModal _utxoSelectorModalRef;
@@ -1000,27 +1003,37 @@
 
     private async Task ShowModal(ChannelOperationRequest channelOperationRequest)
     {
-        _selectedRequest = channelOperationRequest;
-        _psbt = string.Empty;
-        if (_selectedRequest != null && !_selectedRequest.AreAllRequiredHumanSignaturesCollected)
+        if (_approvalInFlight) return;
+        _approvalInFlight = true;
+
+        try
         {
-            var (templatePsbt,noUtxosAvailable) = (await LightningService.GenerateTemplatePSBT(_selectedRequest));
-            if (templatePsbt != null)
+            _selectedRequest = channelOperationRequest;
+            _psbt = string.Empty;
+            if (_selectedRequest != null && !_selectedRequest.AreAllRequiredHumanSignaturesCollected)
             {
-                _templatePSBTString = templatePsbt.ToBase64();
-                await _psbtSignRef.ShowModal();
-            }
-            else
-            {
-                if (noUtxosAvailable)
+                var (templatePsbt,noUtxosAvailable) = (await LightningService.GenerateTemplatePSBT(_selectedRequest));
+                if (templatePsbt != null)
                 {
-                    ToastService.ShowError("No UTXOs found for this wallet, please wait for other requests to be confirmed or fund the wallet with more UTXOs");
+                    _templatePSBTString = templatePsbt.ToBase64();
+                    await _psbtSignRef.ShowModal();
                 }
                 else
                 {
-                    ToastService.ShowError("Something went wrong");
+                    if (noUtxosAvailable)
+                    {
+                        ToastService.ShowError("No UTXOs found for this wallet, please wait for other requests to be confirmed or fund the wallet with more UTXOs");
+                    }
+                    else
+                    {
+                        ToastService.ShowError("Something went wrong");
+                    }
                 }
             }
+        }
+        finally
+        {
+            _approvalInFlight = false;
         }
     }
 
@@ -1105,6 +1118,21 @@
     }
 
     private async Task ApproveOperationSubmitConfirmationModal()
+    {
+        if (_approvalInFlight) return;
+        _approvalInFlight = true;
+
+        try
+        {
+            await ApproveOperationSubmitConfirmationModalCore();
+        }
+        finally
+        {
+            _approvalInFlight = false;
+        }
+    }
+
+    private async Task ApproveOperationSubmitConfirmationModalCore()
     {
         if (_selectedRequest != null)
         {

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -62,7 +62,7 @@
             <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Field="@nameof(WalletWithdrawalRequest.Id)" Caption="#" Sortable="false" Displayable="true"/>
             <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Caption="Actions" Sortable="false" Displayable="true">
                 <DisplayTemplate>
-                    <Button Color="Color.Success" hidden="@(!_isFinanceManager)" Clicked="() => ShowApprovalModal(context)">Approve</Button>
+                    <Button Color="Color.Success" hidden="@(!_isFinanceManager)" Disabled="@_approvalInFlight" Clicked="() => ShowApprovalModal(context)">Approve</Button>
                 </DisplayTemplate>
             </DataGridColumn>
             <DataGridColumn TItem="WalletWithdrawalRequest" Filterable="false" Caption="" Sortable="false" Displayable="true">
@@ -545,6 +545,9 @@
     private bool _bumpIsCancellation;
     private string _signedPSBT;
     private string? _templatePsbtString;
+    // Guards ShowApprovalModal against re-entry (double click, repeated render dispatch) while the template
+    // PSBT is being generated. Cross-user/cross-circuit races are handled by the database unique index.
+    private bool _approvalInFlight;
     private int? _selectedWalletId;
     private static readonly decimal _minimumWithdrawalAmount = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
 
@@ -896,14 +899,34 @@
 
     private async Task ShowApprovalModal(WalletWithdrawalRequest walletWithdrawalRequest)
     {
+        if (_approvalInFlight) return;
+        _approvalInFlight = true;
+
+        try
+        {
+            await ShowApprovalModalCore(walletWithdrawalRequest);
+        }
+        finally
+        {
+            _approvalInFlight = false;
+        }
+    }
+
+    private async Task ShowApprovalModalCore(WalletWithdrawalRequest walletWithdrawalRequest)
+    {
         _selectedRequest = await WalletWithdrawalRequestRepository.GetById(walletWithdrawalRequest.Id);
 
         //PSBT Generation
         try
         {
+            // GenerateTemplatePSBT persists the template and returns the persisted one (also when a
+            // concurrent generation won), so what the approver sees here is what the validator will
+            // compare their signature against.
             var templatePSBT = await BitcoinService.GenerateTemplatePSBT(walletWithdrawalRequest);
 
-            //TODO Save template PSBT (?)
+            // Re-read so the request carries the template row for the later duplicate/threshold checks.
+            _selectedRequest = await WalletWithdrawalRequestRepository.GetById(walletWithdrawalRequest.Id) ?? _selectedRequest;
+
             _templatePsbtString = templatePSBT.ToBase64();
             if (_psbtSignRef != null) await _psbtSignRef.ShowModal();
         }

--- a/src/Services/BitcoinService.cs
+++ b/src/Services/BitcoinService.cs
@@ -112,10 +112,9 @@ namespace NodeGuard.Services
             }
 
             //If there is already a PSBT as template with the inputs as still valid UTXOs we avoid generating the whole process again to
-            //avoid non-deterministic issues (e.g. Input order and other potential errors)
-            var templatePSBT = walletWithdrawalRequest.WalletWithdrawalRequestPSBTs.Where(x => x.IsTemplatePSBT)
-                .OrderBy(x => x.Id)
-                .LastOrDefault(); //We take the oldest
+            //avoid non-deterministic issues (e.g. Input order and other potential errors).
+            //There is exactly one template per request (IX_WalletWithdrawalRequestPSBTs_Template); two rows is a fault and this throws.
+            var templatePSBT = walletWithdrawalRequest.GetSingleTemplatePsbt();
 
             if (templatePSBT != null && PSBT.TryParse(templatePSBT.PSBT, CurrentNetworkHelper.GetCurrentNetwork(),
                     out var parsedTemplatePSBT))
@@ -310,7 +309,9 @@ namespace NodeGuard.Services
                 selectedUTXOs, scriptCoins, _logger);
 
 
-            // We "lock" the PSBT to the channel operation request by adding to its UTXOs collection for later checking
+            // We "lock" the PSBT to the channel operation request by adding to its UTXOs collection for later checking.
+            // If two generators race, both reach here with the same coin selection (same available set, no
+            // locked UTXOs yet) and AddUTXOs de-duplicates by Except, so the loser leaves no stray UTXO rows.
             var utxos = selectedUTXOs.Select(x => _mapper.Map<UTXO, FMUTXO>(x)).ToList();
 
             var addUTXOSOperation = await _walletWithdrawalRequestRepository.AddUTXOs(walletWithdrawalRequest, utxos);
@@ -338,14 +339,33 @@ namespace NodeGuard.Services
             };
 
             var addPsbtResult = await _walletWithdrawalRequestPsbtRepository.AddAsync(psbt);
-
-            if (addPsbtResult.Item1 == false)
+            if (addPsbtResult.Item1)
             {
-                _logger.LogError("Error while saving template PSBT to wallet withdrawal request: {RequestId}",
-                    walletWithdrawalRequest.Id);
+                return originalPSBT;
             }
 
-            return originalPSBT;
+            // Never hand out an unpersisted PSBT. Approvals are validated against the stored template, so a
+            // PSBT that is not the stored one can never be approved: the signer would sign something the
+            // validator then rejects. If a concurrent generation won the race (unique index violation), the
+            // stored row is the template for this request and is what the caller gets.
+            var persistedTemplate =
+                await _walletWithdrawalRequestPsbtRepository.GetTemplateByRequestId(walletWithdrawalRequest.Id);
+
+            if (persistedTemplate != null && PSBT.TryParse(persistedTemplate.PSBT,
+                    CurrentNetworkHelper.GetCurrentNetwork(), out var persistedPsbt))
+            {
+                _logger.LogWarning(
+                    "Template PSBT for withdrawal request {RequestId} was persisted concurrently ({Reason}), returning the stored template",
+                    walletWithdrawalRequest.Id, addPsbtResult.Item2 ?? "unknown error");
+
+                return persistedPsbt;
+            }
+
+            var error =
+                $"Could not persist the template PSBT for withdrawal request {walletWithdrawalRequest.Id} and no template exists";
+            _logger.LogError(error);
+
+            throw new Exception(error);
         }
 
         public async Task PerformWithdrawal(WalletWithdrawalRequest walletWithdrawalRequest)
@@ -382,10 +402,13 @@ namespace NodeGuard.Services
             //If it is a hot wallet or a BIP39 imported wallet, we dont need to combine the PSBTs
             if (walletWithdrawalRequest.Wallet.IsHotWallet || walletWithdrawalRequest.Wallet.IsBIP39Imported)
             {
-                psbtToSign = PSBT.Parse(walletWithdrawalRequest.WalletWithdrawalRequestPSBTs
-                        .Single(x => x.IsTemplatePSBT)
-                        .PSBT,
-                    CurrentNetworkHelper.GetCurrentNetwork());
+                // GetSingleTemplatePsbt throws on two rows: a request with more than one template must never
+                // be signed, since it is unknowable which transaction was approved.
+                var singleTemplate = walletWithdrawalRequest.GetSingleTemplatePsbt()
+                                     ?? throw new InvalidOperationException(
+                                         $"No template PSBT found for withdrawal request:{walletWithdrawalRequest.Id}");
+
+                psbtToSign = PSBT.Parse(singleTemplate.PSBT, CurrentNetworkHelper.GetCurrentNetwork());
             }
             else //If it is a cold multisig wallet, we need to combine the PSBTs
             {
@@ -413,8 +436,7 @@ namespace NodeGuard.Services
                 // internal wallet applies its signature. Matching the template's txid transitively guarantees
                 // the destinations and amounts are those the request was approved for, since NodeGuard built
                 // that template itself from WalletWithdrawalRequestDestinations.
-                var templatePsbtString = walletWithdrawalRequest.WalletWithdrawalRequestPSBTs
-                    ?.FirstOrDefault(x => x.IsTemplatePSBT)?.PSBT;
+                var templatePsbtString = walletWithdrawalRequest.GetSingleTemplatePsbt()?.PSBT;
 
                 if (string.IsNullOrWhiteSpace(templatePsbtString))
                 {

--- a/src/Services/LightningService.cs
+++ b/src/Services/LightningService.cs
@@ -1199,8 +1199,8 @@ namespace NodeGuard.Services
 
             //If there is already a PSBT as template with the inputs as still valid UTXOs we avoid generating the whole process again to
             //avoid non-deterministic issues (e.g. Input order and other potential errors)
-            var templatePSBT =
-                channelOperationRequest.ChannelOperationRequestPsbts.Where(x => x.IsTemplatePSBT).MaxBy(x => x.Id);
+            //There is exactly one template per request (IX_ChannelOperationRequestPSBTs_Template); two rows is a fault and this throws.
+            var templatePSBT = channelOperationRequest.GetSingleTemplatePsbt();
 
             if (templatePSBT != null && PSBT.TryParse(templatePSBT.PSBT, CurrentNetworkHelper.GetCurrentNetwork(),
                     out var parsedTemplatePSBT))
@@ -1340,8 +1340,26 @@ namespace NodeGuard.Services
 
                 if (addPsbtResult.Item1 == false)
                 {
-                    _logger.LogError("Error while saving template PSBT to channel operation request: {RequestId}",
+                    // Never hand out an unpersisted PSBT (see BitcoinService.GenerateTemplatePSBT). If a
+                    // concurrent generation won the race, its stored row is the template for this request.
+                    var persistedTemplate =
+                        await _channelOperationRequestPsbtRepository.GetTemplateByRequestId(channelOperationRequest.Id);
+
+                    if (persistedTemplate != null && PSBT.TryParse(persistedTemplate.PSBT,
+                            CurrentNetworkHelper.GetCurrentNetwork(), out var persistedPsbt))
+                    {
+                        _logger.LogWarning(
+                            "Template PSBT for channel operation request {RequestId} was persisted concurrently ({Reason}), returning the stored template",
+                            channelOperationRequest.Id, addPsbtResult.Item2 ?? "unknown error");
+
+                        return (persistedPsbt, false);
+                    }
+
+                    _logger.LogError(
+                        "Error while saving template PSBT to channel operation request: {RequestId} and no template exists",
                         channelOperationRequest.Id);
+
+                    return (null, false);
                 }
             }
 
@@ -2042,7 +2060,7 @@ namespace NodeGuard.Services
             {
                 string errorMessages = string.Join("; ", response.FailedUpdates);
                 _logger.LogError("Failed to update max htlc for channel {ChanPoint}: [{Errors}]", lndChannel.ChannelPoint, errorMessages);
-                
+
                 throw new Exception($"Failed to update max htlc for channel: {lndChannel.ChannelPoint}");
             }
 

--- a/test/NodeGuard.Tests/Data/Models/ChannelOperationRequestTests.cs
+++ b/test/NodeGuard.Tests/Data/Models/ChannelOperationRequestTests.cs
@@ -1,0 +1,69 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using NodeGuard.Data.Models;
+
+namespace NodeGuard.Tests;
+
+public class ChannelOperationRequestTests
+{
+    [Fact]
+    public void GetSingleTemplatePsbt_NoRows_ReturnsNull()
+    {
+        new ChannelOperationRequest().GetSingleTemplatePsbt().Should().BeNull();
+        new ChannelOperationRequest { ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>() }
+            .GetSingleTemplatePsbt().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSingleTemplatePsbt_OneTemplateAmongApprovals_ReturnsIt()
+    {
+        var template = new ChannelOperationRequestPSBT { Id = 2, IsTemplatePSBT = true, PSBT = "template" };
+        var request = new ChannelOperationRequest
+        {
+            ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>
+            {
+                new() { Id = 1, PSBT = "approval" },
+                template,
+                new() { Id = 3, IsInternalWalletPSBT = true, PSBT = "internal" },
+            },
+        };
+
+        request.GetSingleTemplatePsbt().Should().BeSameAs(template);
+    }
+
+    [Fact]
+    public void GetSingleTemplatePsbt_TwoTemplates_Throws()
+    {
+        var request = new ChannelOperationRequest
+        {
+            Id = 704,
+            ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>
+            {
+                new() { Id = 1, IsTemplatePSBT = true, PSBT = "a" },
+                new() { Id = 2, IsTemplatePSBT = true, PSBT = "b" },
+            },
+        };
+
+        request.Invoking(r => r.GetSingleTemplatePsbt())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*704*more than one template*");
+    }
+}

--- a/test/NodeGuard.Tests/Data/Models/WalletWithdrawalRequestTests.cs
+++ b/test/NodeGuard.Tests/Data/Models/WalletWithdrawalRequestTests.cs
@@ -8,7 +8,7 @@ public class WalletWithdrawalRequestTests
     [Fact]
     public async Task SignatureCounter_Positive_RequiresInternalwallet()
     {
-       
+
 
         var request = new WalletWithdrawalRequest
         {
@@ -31,11 +31,11 @@ public class WalletWithdrawalRequestTests
         // Act
 
         request.Wallet.MofN = 3;
-        
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
-        
+
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsTemplatePSBT = false);
+
         request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
 
         // Assert
@@ -43,7 +43,7 @@ public class WalletWithdrawalRequestTests
         request.AreAllRequiredHumanSignaturesCollected.Should().Be(true);
         request.NumberOfSignaturesCollected.Should().Be(2);
     }
-    
+
     [Fact]
     public async Task SignatureCounter_Positive_NotRequiresInternalwallet()
     {
@@ -70,11 +70,11 @@ public class WalletWithdrawalRequestTests
         // Act
 
         request.Wallet.MofN = 2;
-        
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
-        
+
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsTemplatePSBT = false);
+
         request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
 
         // Assert
@@ -82,7 +82,7 @@ public class WalletWithdrawalRequestTests
         request.AreAllRequiredHumanSignaturesCollected.Should().Be(true);
         request.NumberOfSignaturesCollected.Should().Be(2);
     }
-   
+
     [Fact]
     public async Task SignatureCount_Negative_NotRequiresInternalWallet()
     {
@@ -109,10 +109,10 @@ public class WalletWithdrawalRequestTests
 
         request.Wallet.IsHotWallet = false;
         request.Wallet.MofN = 2;
-        
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsTemplatePSBT = false);
 
         request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
         request.WalletWithdrawalRequestPSBTs.Last().IsFinalisedPSBT = true;
@@ -122,7 +122,7 @@ public class WalletWithdrawalRequestTests
         request.AreAllRequiredHumanSignaturesCollected.Should().BeFalse();
         request.NumberOfSignaturesCollected.Should().Be(1);
     }
-    
+
     [Fact]
     public async Task SignatureCount_Negative_RequiresInternalWallet()
     {
@@ -148,10 +148,10 @@ public class WalletWithdrawalRequestTests
         // Act
         request.Wallet.IsHotWallet = false;
         request.Wallet.MofN = 3;
-        
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsInternalWalletPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsFinalisedPSBT = false);
-        request.WalletWithdrawalRequestPSBTs.ForEach(x=> x.IsTemplatePSBT = false);
+
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsInternalWalletPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsFinalisedPSBT = false);
+        request.WalletWithdrawalRequestPSBTs.ForEach(x => x.IsTemplatePSBT = false);
 
         request.WalletWithdrawalRequestPSBTs.First().IsTemplatePSBT = true;
         request.WalletWithdrawalRequestPSBTs.Last().IsFinalisedPSBT = true;
@@ -161,7 +161,51 @@ public class WalletWithdrawalRequestTests
         request.AreAllRequiredHumanSignaturesCollected.Should().BeFalse();
         request.NumberOfSignaturesCollected.Should().Be(1);
     }
-    
-   
-    
+
+    [Fact]
+    public void GetSingleTemplatePsbt_NoRows_ReturnsNull()
+    {
+        new WalletWithdrawalRequest().GetSingleTemplatePsbt().Should().BeNull();
+        new WalletWithdrawalRequest { WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>() }
+            .GetSingleTemplatePsbt().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSingleTemplatePsbt_OneTemplateAmongApprovals_ReturnsIt()
+    {
+        var template = new WalletWithdrawalRequestPSBT { Id = 2, IsTemplatePSBT = true, PSBT = "template" };
+        var request = new WalletWithdrawalRequest
+        {
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>
+            {
+                new() { Id = 1, PSBT = "approval" },
+                template,
+                new() { Id = 3, IsFinalisedPSBT = true, PSBT = "final" },
+            },
+        };
+
+        request.GetSingleTemplatePsbt().Should().BeSameAs(template);
+    }
+
+    /// <summary>
+    /// Two templates means it is unknowable which transaction was approved. The database forbids it
+    /// (IX_WalletWithdrawalRequestPSBTs_Template); the model refuses to guess if it ever sees it.
+    /// </summary>
+    [Fact]
+    public void GetSingleTemplatePsbt_TwoTemplates_Throws()
+    {
+        var request = new WalletWithdrawalRequest
+        {
+            Id = 5107,
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>
+            {
+                new() { Id = 9612, IsTemplatePSBT = true, PSBT = "a" },
+                new() { Id = 9613, IsTemplatePSBT = true, PSBT = "b" },
+            },
+        };
+
+        request.Invoking(r => r.GetSingleTemplatePsbt())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*5107*more than one template*");
+    }
 }

--- a/test/NodeGuard.Tests/Data/Repositories/WalletWithdrawalRequestPsbtRepositoryTests.cs
+++ b/test/NodeGuard.Tests/Data/Repositories/WalletWithdrawalRequestPsbtRepositoryTests.cs
@@ -1,0 +1,186 @@
+/*
+ * NodeGuard
+ * Copyright (C) 2023  Elenpay
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBitcoin;
+using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories.Interfaces;
+using NodeGuard.Helpers;
+
+namespace NodeGuard.Data.Repositories;
+
+/// <summary>
+/// Template handling in the PSBT repository. The unique index itself cannot be exercised here (the EF
+/// InMemory provider ignores IsUnique and HasFilter); that lives in the E2E suite. What is covered is
+/// everything around it: templates skip the approval validator and are inserted directly, the template
+/// reader, and the validator refusing to anchor an approval when two templates exist.
+/// </summary>
+public class WalletWithdrawalRequestPsbtRepositoryTests
+{
+    private readonly Random _random = new();
+
+    private Mock<IDbContextFactory<ApplicationDbContext>> SetupDbContextFactory()
+    {
+        var dbContextFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "WalletWithdrawalRequestPsbtRepositoryTests" + _random.Next())
+            .Options;
+        var context = () => new ApplicationDbContext(options);
+        dbContextFactory.Setup(x => x.CreateDbContext()).Returns(context);
+        dbContextFactory.Setup(x => x.CreateDbContextAsync(default)).ReturnsAsync(context);
+        return dbContextFactory;
+    }
+
+    private static WalletWithdrawalRequestPsbtRepository CreateRepository(
+        Mock<IDbContextFactory<ApplicationDbContext>> factory, Mock<IRepository<WalletWithdrawalRequestPSBT>>? generic = null)
+        => new((generic ?? new Mock<IRepository<WalletWithdrawalRequestPSBT>>()).Object,
+            NullLogger<WalletWithdrawalRequestPsbtRepository>.Instance, factory.Object);
+
+    private static string UnsignedPsbt(int seed)
+    {
+        var network = CurrentNetworkHelper.GetCurrentNetwork();
+        var tx = network.CreateTransaction();
+        tx.Inputs.Add(new TxIn(new OutPoint(uint256.Parse(seed.ToString("x").PadLeft(64, '0')), 0)));
+        tx.Outputs.Add(new TxOut(Money.Coins(0.01m),
+            BitcoinAddress.Create("bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf", network)));
+        return PSBT.FromTransaction(tx, network).ToBase64();
+    }
+
+    private static async Task<int> SeedRequestAsync(ApplicationDbContext context, params WalletWithdrawalRequestPSBT[] psbts)
+    {
+        var request = new WalletWithdrawalRequest
+        {
+            Description = "psbt repository test",
+            Status = WalletWithdrawalRequestStatus.Pending,
+            WalletWithdrawalRequestPSBTs = psbts.ToList(),
+        };
+        await context.WalletWithdrawalRequests.AddAsync(request);
+        await context.SaveChangesAsync();
+        return request.Id;
+    }
+
+    [Fact]
+    public async Task AddAsync_Template_IsInsertedWithoutRunningTheApprovalValidator()
+    {
+        var factory = SetupDbContextFactory();
+        var generic = new Mock<IRepository<WalletWithdrawalRequestPSBT>>();
+        int requestId;
+        await using (var context = await factory.Object.CreateDbContextAsync())
+        {
+            requestId = await SeedRequestAsync(context);
+        }
+
+        var repository = CreateRepository(factory, generic);
+
+        var result = await repository.AddAsync(new WalletWithdrawalRequestPSBT
+        {
+            WalletWithdrawalRequestId = requestId,
+            IsTemplatePSBT = true,
+            PSBT = UnsignedPsbt(1),
+        });
+
+        result.Item1.Should().BeTrue();
+        result.Item2.Should().BeNull();
+
+        // Direct insert: the generic repository (which would swallow a unique violation) is not involved.
+        generic.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>(), It.IsAny<ApplicationDbContext>()), Times.Never);
+
+        await using var verify = await factory.Object.CreateDbContextAsync();
+        var stored = await verify.WalletWithdrawalRequestPSBTs.Where(x => x.WalletWithdrawalRequestId == requestId).ToListAsync();
+        stored.Should().ContainSingle(x => x.IsTemplatePSBT);
+
+        // A template never moves the request to PSBTSignaturesPending; only a human approval does.
+        (await verify.WalletWithdrawalRequests.SingleAsync(x => x.Id == requestId)).Status
+            .Should().Be(WalletWithdrawalRequestStatus.Pending);
+    }
+
+    [Fact]
+    public async Task GetTemplateByRequestId_ReturnsTheTemplateRowOnly()
+    {
+        var factory = SetupDbContextFactory();
+        int requestId;
+        await using (var context = await factory.Object.CreateDbContextAsync())
+        {
+            requestId = await SeedRequestAsync(context,
+                new WalletWithdrawalRequestPSBT { PSBT = UnsignedPsbt(1) },
+                new WalletWithdrawalRequestPSBT { IsTemplatePSBT = true, PSBT = UnsignedPsbt(2) },
+                new WalletWithdrawalRequestPSBT { IsInternalWalletPSBT = true, PSBT = UnsignedPsbt(3) });
+        }
+
+        var template = await CreateRepository(factory).GetTemplateByRequestId(requestId);
+
+        template.Should().NotBeNull();
+        template!.IsTemplatePSBT.Should().BeTrue();
+        template.PSBT.Should().Be(UnsignedPsbt(2));
+
+        (await CreateRepository(factory).GetTemplateByRequestId(requestId + 1000)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTemplateByRequestId_TwoTemplates_Throws()
+    {
+        var factory = SetupDbContextFactory();
+        int requestId;
+        await using (var context = await factory.Object.CreateDbContextAsync())
+        {
+            requestId = await SeedRequestAsync(context,
+                new WalletWithdrawalRequestPSBT { IsTemplatePSBT = true, PSBT = UnsignedPsbt(1) },
+                new WalletWithdrawalRequestPSBT { IsTemplatePSBT = true, PSBT = UnsignedPsbt(2) });
+        }
+
+        await CreateRepository(factory).Invoking(r => r.GetTemplateByRequestId(requestId))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// With two templates the approver may have signed either; the repository must not pick one and
+    /// validate against it. Guarding what the unique index already forbids costs nothing and keeps the
+    /// failure explicit if the index is ever dropped.
+    /// </summary>
+    [Fact]
+    public async Task AddAsync_Approval_WhenRequestHasTwoTemplates_IsRejected()
+    {
+        var factory = SetupDbContextFactory();
+        var generic = new Mock<IRepository<WalletWithdrawalRequestPSBT>>();
+        int requestId;
+        await using (var context = await factory.Object.CreateDbContextAsync())
+        {
+            requestId = await SeedRequestAsync(context,
+                new WalletWithdrawalRequestPSBT { IsTemplatePSBT = true, PSBT = UnsignedPsbt(1) },
+                new WalletWithdrawalRequestPSBT { IsTemplatePSBT = true, PSBT = UnsignedPsbt(2) });
+        }
+
+        var result = await CreateRepository(factory, generic).AddAsync(new WalletWithdrawalRequestPSBT
+        {
+            WalletWithdrawalRequestId = requestId,
+            PSBT = UnsignedPsbt(1),
+            SignerId = "someone",
+        });
+
+        result.Item1.Should().BeFalse();
+        result.Item2.Should().Contain("more than one template");
+        generic.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>(), It.IsAny<ApplicationDbContext>()), Times.Never);
+
+        await using var verify = await factory.Object.CreateDbContextAsync();
+        (await verify.WalletWithdrawalRequests.SingleAsync(x => x.Id == requestId)).Status
+            .Should().Be(WalletWithdrawalRequestStatus.Pending, "a rejected approval must not advance the request");
+    }
+}

--- a/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/BitcoinServiceTests.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentAssertions;
 using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories;
 using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.Helpers;
 using NodeGuard.TestHelpers;
@@ -1753,5 +1754,179 @@ public class BitcoinServiceTests
                 },
             },
         };
+    }
+
+    // ---- template persistence race -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Builds a pending single-sig request with no template and every mock needed to run the full generation
+    /// path; the PSBT repository mock is returned so each test can script the insert outcome.
+    /// </summary>
+    private (BitcoinService Service, WalletWithdrawalRequest Request, Mock<IWalletWithdrawalRequestPsbtRepository> PsbtRepository)
+        SetupGenerationWithoutTemplate()
+    {
+        var wallet = CreateWallet.SingleSig(_internalWallet);
+        var withdrawalRequest = new WalletWithdrawalRequest
+        {
+            Id = 1,
+            Status = WalletWithdrawalRequestStatus.Pending,
+            Wallet = wallet,
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>(),
+            WalletWithdrawalRequestDestinations = new List<WalletWithdrawalRequestDestination>
+            {
+                new() { Address = "bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf", Amount = 0.01m },
+            },
+        };
+
+        var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+        var walletWithdrawalRequestPsbtRepository = new Mock<IWalletWithdrawalRequestPsbtRepository>();
+        var fmutxoRepository = new Mock<IFMUTXORepository>();
+        var nbXplorerService = new Mock<INBXplorerService>();
+        var utxoTagRepository = new Mock<IUTXOTagRepository>();
+        var mapper = new Mock<IMapper>();
+        walletWithdrawalRequestRepository.Setup(w => w.GetById(It.IsAny<int>())).ReturnsAsync(withdrawalRequest);
+        walletWithdrawalRequestRepository
+            .Setup(w => w.AddUTXOs(It.IsAny<WalletWithdrawalRequest>(), It.IsAny<List<FMUTXO>>()))
+            .ReturnsAsync((true, null));
+        nbXplorerService.Setup(x => x.GetStatusAsync(default)).ReturnsAsync(new StatusResult { IsFullySynched = true });
+        nbXplorerService
+            .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), DerivationFeature.Change, 0, false, default))
+            .ReturnsAsync(new KeyPathInformation
+            {
+                Address = BitcoinAddress.Create("bcrt1q83ml8tve8vh672wsm83getxfzetaquq352jr6t423tdwjvdz3f3qe4r4t7", Network.RegTest),
+            });
+        nbXplorerService
+            .Setup(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default))
+            .ReturnsAsync(new UTXOChanges
+            {
+                Confirmed = new UTXOChange
+                {
+                    UTXOs = new List<UTXO>
+                    {
+                        new()
+                        {
+                            Value = new Money((long)10000000),
+                            ScriptPubKey = (wallet.GetDerivationStrategy() as StandardDerivationStrategyBase)!
+                                .GetDerivation(KeyPath.Parse("0/0")).ScriptPubKey,
+                            KeyPath = KeyPath.Parse("0/0"),
+                        },
+                    },
+                },
+            });
+        fmutxoRepository.Setup(x => x.GetLockedUTXOs(null, null)).ReturnsAsync(new List<FMUTXO>());
+        utxoTagRepository.Setup(x => x.GetByKeyValue(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new List<UTXOTag>());
+
+        var coinSelectionService = new CoinSelectionService(_logger, mapper.Object, fmutxoRepository.Object,
+            nbXplorerService.Object, null, walletWithdrawalRequestRepository.Object, utxoTagRepository.Object);
+
+        var bitcoinService = new BitcoinService(_logger, mapper.Object, walletWithdrawalRequestRepository.Object,
+            walletWithdrawalRequestPsbtRepository.Object, null, null, nbXplorerService.Object, coinSelectionService);
+
+        return (bitcoinService, withdrawalRequest, walletWithdrawalRequestPsbtRepository);
+    }
+
+    /// <summary>
+    /// Two approvers click Approve at once. Both build a template; the database accepts one. The loser must
+    /// hand its caller the STORED template, not the one it built: approvals are validated against the stored
+    /// row, so showing the unstored PSBT makes the approver sign something that is then rejected.
+    /// </summary>
+    [Fact]
+    async Task GenerateTemplatePSBT_WhenTemplateInsertIsRejected_ReturnsThePersistedTemplate()
+    {
+        // Arrange
+        var (bitcoinService, withdrawalRequest, psbtRepository) = SetupGenerationWithoutTemplate();
+
+        // The winner's template: same shape as the one about to be built, different input, so different txid.
+        var network = CurrentNetworkHelper.GetCurrentNetwork();
+        var winnerTx = network.CreateTransaction();
+        winnerTx.Inputs.Add(new TxIn(new OutPoint(uint256.Parse("ab".PadLeft(64, '0')), 0)));
+        winnerTx.Outputs.Add(new TxOut(Money.Coins(0.01m),
+            BitcoinAddress.Create("bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf", network)));
+        var winnerTemplate = PSBT.FromTransaction(winnerTx, network).ToBase64();
+
+        psbtRepository
+            .Setup(x => x.AddAsync(It.Is<WalletWithdrawalRequestPSBT>(p => p.IsTemplatePSBT)))
+            .ReturnsAsync((false, WalletWithdrawalRequestPsbtRepository.TemplateAlreadyExists));
+        psbtRepository
+            .Setup(x => x.GetTemplateByRequestId(withdrawalRequest.Id))
+            .ReturnsAsync(new WalletWithdrawalRequestPSBT
+            {
+                Id = 42,
+                WalletWithdrawalRequestId = withdrawalRequest.Id,
+                IsTemplatePSBT = true,
+                PSBT = winnerTemplate,
+            });
+
+        // Act
+        var result = await bitcoinService.GenerateTemplatePSBT(withdrawalRequest);
+
+        // Assert
+        result.ToBase64().Should().Be(winnerTemplate, "the caller must only ever see the persisted template");
+        psbtRepository.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>()), Times.Once);
+        psbtRepository.Verify(x => x.GetTemplateByRequestId(withdrawalRequest.Id), Times.Once);
+    }
+
+    [Fact]
+    async Task GenerateTemplatePSBT_WhenTemplateInsertFailsAndNoTemplateExists_Throws()
+    {
+        // Arrange
+        var (bitcoinService, withdrawalRequest, psbtRepository) = SetupGenerationWithoutTemplate();
+
+        psbtRepository
+            .Setup(x => x.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>()))
+            .ReturnsAsync((false, null));
+        psbtRepository
+            .Setup(x => x.GetTemplateByRequestId(withdrawalRequest.Id))
+            .ReturnsAsync((WalletWithdrawalRequestPSBT?)null);
+
+        // Act
+        var act = () => bitcoinService.GenerateTemplatePSBT(withdrawalRequest);
+
+        // Assert: an unpersisted PSBT is never returned.
+        await act.Should().ThrowAsync<Exception>().WithMessage("*Could not persist the template PSBT*");
+    }
+
+    /// <summary>
+    /// Complements <see cref="PerformWithdrawal_WithDuplicateTemplateRows_FailsLoudly"/> on the generation
+    /// side: a request that already carries two templates is refused before any coin selection or NBXplorer
+    /// call, instead of silently reusing one of them.
+    /// </summary>
+    [Fact]
+    async Task GenerateTemplatePSBT_WithDuplicateTemplateRows_FailsLoudly()
+    {
+        // Arrange
+        var wallet = CreateWallet.SingleSig(_internalWallet);
+        var withdrawalRequest = new WalletWithdrawalRequest
+        {
+            Id = 1,
+            Status = WalletWithdrawalRequestStatus.Pending,
+            Wallet = wallet,
+            WalletWithdrawalRequestPSBTs = new List<WalletWithdrawalRequestPSBT>
+            {
+                new() { Id = 1, IsTemplatePSBT = true, PSBT = "a" },
+                new() { Id = 2, IsTemplatePSBT = true, PSBT = "b" },
+            },
+            WalletWithdrawalRequestDestinations = new List<WalletWithdrawalRequestDestination>
+            {
+                new() { Address = "bcrt1q8k3av6q5yp83rn332lx8a90k6kukhg28hs5qw7krdq95t629hgsqk6ztmf", Amount = 0.01m },
+            },
+        };
+
+        var walletWithdrawalRequestRepository = new Mock<IWalletWithdrawalRequestRepository>();
+        walletWithdrawalRequestRepository.Setup(w => w.GetById(It.IsAny<int>())).ReturnsAsync(withdrawalRequest);
+        var nbXplorerService = new Mock<INBXplorerService>();
+        nbXplorerService.Setup(x => x.GetStatusAsync(default)).ReturnsAsync(new StatusResult { IsFullySynched = true });
+        var psbtRepository = new Mock<IWalletWithdrawalRequestPsbtRepository>();
+
+        var bitcoinService = new BitcoinService(_logger, null, walletWithdrawalRequestRepository.Object,
+            psbtRepository.Object, null, null, nbXplorerService.Object, null);
+
+        // Act
+        var act = () => bitcoinService.GenerateTemplatePSBT(withdrawalRequest);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*more than one template*");
+        nbXplorerService.Verify(x => x.GetUTXOsAsync(It.IsAny<DerivationStrategyBase>(), default), Times.Never);
+        psbtRepository.Verify(x => x.AddAsync(It.IsAny<WalletWithdrawalRequestPSBT>()), Times.Never);
     }
 }

--- a/test/NodeGuard.Tests/Services/LightningServiceTests.cs
+++ b/test/NodeGuard.Tests/Services/LightningServiceTests.cs
@@ -21,6 +21,7 @@ using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using NodeGuard.Data;
 using NodeGuard.Data.Models;
+using NodeGuard.Data.Repositories;
 using NodeGuard.Data.Repositories.Interfaces;
 using NodeGuard.TestHelpers;
 using NBXplorer.Models;
@@ -2982,6 +2983,141 @@ namespace NodeGuard.Services
             auditService.Verify(x => x.LogSystemAsync(
                 It.IsAny<AuditActionType>(), It.IsAny<AuditEventType>(), It.IsAny<AuditObjectType>(),
                 It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+        }
+
+        // ---- template persistence race ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Mirror of BitcoinServiceTests.GenerateTemplatePSBT_WhenTemplateInsertIsRejected_ReturnsThePersistedTemplate
+        /// for channel opens: when the template insert loses the race (unique index), the caller receives the
+        /// STORED template, never the freshly built one it could not persist.
+        /// </summary>
+        [Fact]
+        public async Task GenerateTemplatePSBT_WhenTemplateInsertIsRejected_ReturnsThePersistedTemplate()
+        {
+            // Arrange
+            var network = CurrentNetworkHelper.GetCurrentNetwork();
+            var wallet = CreateWallet.SingleSig(_internalWallet);
+            var walletScript = (wallet.GetDerivationStrategy() as StandardDerivationStrategyBase)!
+                .GetDerivation(KeyPath.Parse("0/0")).ScriptPubKey;
+
+            var request = new ChannelOperationRequest
+            {
+                Id = 7,
+                RequestType = OperationRequestType.Open,
+                Status = ChannelOperationRequestStatus.Pending,
+                Wallet = wallet,
+                WalletId = wallet.Id,
+                SatsAmount = 1_000_000,
+                FeeRate = 2,
+                ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>(),
+            };
+
+            var fundingTx = network.CreateTransaction();
+            fundingTx.Outputs.Add(new TxOut(Money.Coins(0.1m), walletScript));
+            var coin = new Coin(fundingTx, 0U);
+            var utxo = new UTXO
+            {
+                Outpoint = coin.Outpoint,
+                Value = coin.Amount,
+                ScriptPubKey = walletScript,
+                KeyPath = KeyPath.Parse("0/0"),
+            };
+
+            var channelOperationRequestRepository = new Mock<IChannelOperationRequestRepository>();
+            channelOperationRequestRepository.Setup(x => x.GetById(request.Id)).ReturnsAsync(request);
+
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService.Setup(x => x.GetStatusAsync(default)).ReturnsAsync(new StatusResult { IsFullySynched = true });
+            nbXplorerService.Setup(x => x.GetFeesByType(It.IsAny<MempoolRecommendedFeesType>(), default)).ReturnsAsync(2m);
+            nbXplorerService
+                .Setup(x => x.GetUnusedAsync(It.IsAny<DerivationStrategyBase>(), DerivationFeature.Change, 0, false, default))
+                .ReturnsAsync(new KeyPathInformation
+                {
+                    Address = BitcoinAddress.Create("bcrt1q83ml8tve8vh672wsm83getxfzetaquq352jr6t423tdwjvdz3f3qe4r4t7", Network.RegTest),
+                });
+
+            var coinSelectionService = new Mock<ICoinSelectionService>();
+            coinSelectionService
+                .Setup(x => x.GetLockedUTXOsForRequest(request, BitcoinRequestType.ChannelOperation))
+                .ReturnsAsync(new List<UTXO>());
+            coinSelectionService
+                .Setup(x => x.GetAvailableUTXOsAsync(It.IsAny<DerivationStrategyBase>()))
+                .ReturnsAsync(new List<UTXO> { utxo });
+            coinSelectionService
+                .Setup(x => x.GetTxInputCoins(It.IsAny<List<UTXO>>(), request, It.IsAny<DerivationStrategyBase>()))
+                .ReturnsAsync((new List<ICoin> { coin }, new List<UTXO> { utxo }));
+
+            // The winner's template: a different transaction than the one about to be built.
+            var winnerTx = network.CreateTransaction();
+            winnerTx.Inputs.Add(new TxIn(new NBitcoin.OutPoint(uint256.Parse("cd".PadLeft(64, '0')), 0)));
+            var winnerTemplate = PSBT.FromTransaction(winnerTx, network).ToBase64();
+
+            var psbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
+            psbtRepository
+                .Setup(x => x.AddAsync(It.Is<ChannelOperationRequestPSBT>(p => p.IsTemplatePSBT)))
+                .ReturnsAsync((false, ChannelOperationRequestPSBTRepository.TemplateAlreadyExists));
+            psbtRepository
+                .Setup(x => x.GetTemplateByRequestId(request.Id))
+                .ReturnsAsync(new ChannelOperationRequestPSBT
+                {
+                    Id = 42,
+                    ChannelOperationRequestId = request.Id,
+                    IsTemplatePSBT = true,
+                    PSBT = winnerTemplate,
+                });
+
+            var lightningService = new LightningService(_logger, channelOperationRequestRepository.Object, null,
+                new Mock<IDbContextFactory<ApplicationDbContext>>().Object, psbtRepository.Object, null, null,
+                nbXplorerService.Object, coinSelectionService.Object, null, null, null);
+
+            // Act
+            var (result, noUtxos) = await lightningService.GenerateTemplatePSBT(request);
+
+            // Assert
+            noUtxos.Should().BeFalse();
+            result.Should().NotBeNull();
+            result!.ToBase64().Should().Be(winnerTemplate, "the caller must only ever see the persisted template");
+            psbtRepository.Verify(x => x.AddAsync(It.IsAny<ChannelOperationRequestPSBT>()), Times.Once);
+            psbtRepository.Verify(x => x.GetTemplateByRequestId(request.Id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateTemplatePSBT_WithDuplicateTemplateRows_FailsLoudly()
+        {
+            // Arrange
+            var wallet = CreateWallet.SingleSig(_internalWallet);
+            var request = new ChannelOperationRequest
+            {
+                Id = 704,
+                RequestType = OperationRequestType.Open,
+                Status = ChannelOperationRequestStatus.Pending,
+                Wallet = wallet,
+                ChannelOperationRequestPsbts = new List<ChannelOperationRequestPSBT>
+                {
+                    new() { Id = 1, IsTemplatePSBT = true, PSBT = "a" },
+                    new() { Id = 2, IsTemplatePSBT = true, PSBT = "b" },
+                },
+            };
+
+            var channelOperationRequestRepository = new Mock<IChannelOperationRequestRepository>();
+            channelOperationRequestRepository.Setup(x => x.GetById(request.Id)).ReturnsAsync(request);
+            var nbXplorerService = new Mock<INBXplorerService>();
+            nbXplorerService.Setup(x => x.GetStatusAsync(default)).ReturnsAsync(new StatusResult { IsFullySynched = true });
+            var coinSelectionService = new Mock<ICoinSelectionService>();
+            var psbtRepository = new Mock<IChannelOperationRequestPSBTRepository>();
+
+            var lightningService = new LightningService(_logger, channelOperationRequestRepository.Object, null,
+                new Mock<IDbContextFactory<ApplicationDbContext>>().Object, psbtRepository.Object, null, null,
+                nbXplorerService.Object, coinSelectionService.Object, null, null, null);
+
+            // Act
+            var act = () => lightningService.GenerateTemplatePSBT(request);
+
+            // Assert
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*704*more than one template*");
+            coinSelectionService.Verify(x => x.GetAvailableUTXOsAsync(It.IsAny<DerivationStrategyBase>()), Times.Never);
+            psbtRepository.Verify(x => x.AddAsync(It.IsAny<ChannelOperationRequestPSBT>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
Add partial unique indexes on WalletWithdrawalRequestPSBT and ChannelOperationRequestPSBT filtered on IsTemplatePSBT so concurrent GenerateTemplatePSBT calls can no longer persist two templates with different txids, which caused the approver to sign a transaction that PsbtApprovalValidator subsequently rejected.

Introduce GetSingleTemplatePsbt() helpers that throw on data-integrity violations instead of silently picking one, and preserve the convention FK indexes that would otherwise be dropped once an explicit index covers the FK column.