### PR TITLE
Prevent double-submit on channel and withdrawal request creation

### DIFF
--- a/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
+++ b/src/Data/Repositories/WalletWithdrawalRequestRepository.cs
@@ -288,9 +288,11 @@ namespace NodeGuard.Data.Repositories
         {
             using var applicationDbContext = _dbContextFactory.CreateDbContext();
 
+            // Stamp before mapping, otherwise the stripped copy that is persisted keeps the old UpdateDatetime.
+            type.SetUpdateDatetime();
+
             //Automapper to remove collections
             var strippedType = _mapper.Map<WalletWithdrawalRequest, WalletWithdrawalRequest>(type);
-            type.SetUpdateDatetime();
 
             return _repository.Update(strippedType, applicationDbContext);
         }

--- a/src/Pages/ChannelRequests.razor
+++ b/src/Pages/ChannelRequests.razor
@@ -277,7 +277,7 @@
                     <Button Color="Color.Primary" hidden></Button>
                 </DeleteCommandTemplate>
                 <SaveCommandTemplate>
-                    <Button Color="Color.Primary" Clicked="@(async () => await CreateChannelRequest())">Save</Button>
+                    <Button Color="Color.Primary" Disabled="@_createInFlight" Clicked="@(async () => await CreateChannelRequest())">Save</Button>
                 </SaveCommandTemplate>
             </DataGridCommandColumn>
             <DataGridColumn TItem="ChannelOperationRequest" Field="@nameof(ChannelOperationRequest.CreationDatetime)" Sortable="true" Displayable="false" SortDirection="SortDirection.Descending">
@@ -633,6 +633,8 @@
     // Guards template generation against re-entry (double click) on this circuit; cross-circuit races are
     // handled by the database unique index on template PSBTs.
     private bool _approvalInFlight;
+    // Same guard for the Save button of a new channel request.
+    private bool _createInFlight;
     private ConfirmationModal _approveOperationConfirmationModal;
     private ConfirmationModal _markRequestAsFailedConfirmationModal;
     private UTXOSelectorModal _utxoSelectorModalRef;
@@ -850,6 +852,22 @@
     }
 
     private async Task CreateChannelRequest()
+    {
+        if (LoggedUser == null) return;
+        if (_createInFlight) return;
+        _createInFlight = true;
+
+        try
+        {
+            await CreateChannelRequestCore();
+        }
+        finally
+        {
+            _createInFlight = false;
+        }
+    }
+
+    private async Task CreateChannelRequestCore()
     {
         if (LoggedUser == null) return;
 

--- a/src/Pages/Withdrawals.razor
+++ b/src/Pages/Withdrawals.razor
@@ -498,6 +498,7 @@
     Title="Are you sure?"
     Body="You selected a hot wallet. This means that the system will automatically use the funds in it without the need of manual approval. Are you sure you want to perform this operation?"
     OkLabel="Yes, I am sure"
+    OkDisabled="@_createInFlight"
     OnCancel="@CloseConfirmationModal"
     OnSubmit="@SubmitConfirmationModal"/>
 
@@ -548,6 +549,8 @@
     // Guards ShowApprovalModal against re-entry (double click, repeated render dispatch) while the template
     // PSBT is being generated. Cross-user/cross-circuit races are handled by the database unique index.
     private bool _approvalInFlight;
+    // Same guard for the New-withdrawal confirmation, which creates the request (and schedules it on hot wallets).
+    private bool _createInFlight;
     private int? _selectedWalletId;
     private static readonly decimal _minimumWithdrawalAmount = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
 
@@ -1275,6 +1278,21 @@
     }
 
     private async Task SubmitConfirmationModal()
+    {
+        if (_createInFlight) return;
+        _createInFlight = true;
+
+        try
+        {
+            await SubmitConfirmationModalCore();
+        }
+        finally
+        {
+            _createInFlight = false;
+        }
+    }
+
+    private async Task SubmitConfirmationModalCore()
     {
         async Task CleanUp(string errorMessage)
         {

--- a/src/Shared/ConfirmationModal.razor
+++ b/src/Shared/ConfirmationModal.razor
@@ -10,7 +10,7 @@
         <ModalFooter>
             <Button Color="Color.Secondary" Clicked="@OnCancel">@CancelLabel</Button>
             @if (OnSubmit.HasDelegate) {
-                <Button Color="Color.Primary" Clicked="@OnSubmit">
+                <Button Color="Color.Primary" Clicked="@OnSubmit" Disabled="@OkDisabled">
                     @OkLabel
                 </Button>
             }
@@ -37,6 +37,13 @@
     public EventCallback OnCancel { get; set; }
     [Parameter]
     public EventCallback OnSubmit { get; set; }
+
+    /// <summary>
+    /// Lets the owner disable the Ok button while its submit handler is running, so a double click cannot
+    /// re-enter a handler that creates requests or moves funds.
+    /// </summary>
+    [Parameter]
+    public bool OkDisabled { get; set; }
 
     private Dictionary<string, object> _data = new();
 

--- a/src/Shared/TransferFundsModal.razor
+++ b/src/Shared/TransferFundsModal.razor
@@ -177,7 +177,7 @@
         <ModalFooter>
             <Button Color="@Color.Secondary" Clicked="@CloseAndCleanTransferFundsModal">Close</Button>
             <Button Color="@Color.Primary" Clicked="@ValidateAndSelectConfirmModal"
-                    Disabled="@(_sourceTransferWallet == null || _availableUTXOs.Count == 0)">Transfer</Button>
+                    Disabled="@(_sourceTransferWallet == null || _availableUTXOs.Count == 0 || _transferInFlight)">Transfer</Button>
         </ModalFooter>
     </ModalContent>
 </Modal>
@@ -187,7 +187,7 @@
                    CancelLabel="Yes, understood" OnCancel="CloseMultisigTransferModal" />
 <ConfirmationModal @ref="_hotWalletTransferModal" Title="Are you sure?"
                    Body="You're about to transfer funds from this wallet. This means that the system will automatically use the funds in it without the need of manual approval. Are you sure you want to perform this operation?"
-                   OkLabel="Yes, understood" OnCancel="CloseHotWalletTransferModal" OnSubmit="TransferFundsHotWallet" />
+                   OkLabel="Yes, understood" OkDisabled="@_transferInFlight" OnCancel="CloseHotWalletTransferModal" OnSubmit="TransferFundsHotWallet" />
 <UTXOSelectorModal @ref="_utxoSelectorModalRef" OnClose="@OnCloseCoinSelectionModal"
                    IsWalletWithdrawalValidation="true" />
 
@@ -214,6 +214,9 @@
     private List<UTXO> _availableUTXOs = new();
 
     private bool _transferAllFunds;
+    // Re-entry guard for the Transfer and "Yes, understood" buttons on this circuit: a multi-click used to create
+    // one withdrawal request per click. Cross-circuit template races are handled by the DB unique index.
+    private bool _transferInFlight;
     private decimal _amountToTransfer;
     private decimal _maxWithdrawal = Constants.MAXIMUM_WITHDRAWAL_BTC_AMOUNT;
     private decimal _minWithdrawal = Constants.MINIMUM_WITHDRAWAL_BTC_AMOUNT;
@@ -415,6 +418,21 @@ _amountToTransfer;
 
     private async Task ValidateAndSelectConfirmModal()
     {
+        if (_transferInFlight) return;
+        _transferInFlight = true;
+
+        try
+        {
+            await ValidateAndSelectConfirmModalCore();
+        }
+        finally
+        {
+            _transferInFlight = false;
+        }
+    }
+
+    private async Task ValidateAndSelectConfirmModalCore()
+    {
         try
         {
             if (!await _transferFundsValidations.ValidateAll())
@@ -456,6 +474,22 @@ _amountToTransfer;
     }
 
     private async Task TransferFundsHotWallet()
+    {
+        // This handler creates the request AND schedules the transfer, so a second click here would move funds twice.
+        if (_transferInFlight) return;
+        _transferInFlight = true;
+
+        try
+        {
+            await TransferFundsHotWalletCore();
+        }
+        finally
+        {
+            _transferInFlight = false;
+        }
+    }
+
+    private async Task TransferFundsHotWalletCore()
     {
         try
         {


### PR DESCRIPTION
Add in-flight guards to disable Save/OK buttons while channel and withdrawal request creation is in progress, preventing duplicate submissions from double-clicks. Also fix WalletWithdrawalRequest update to stamp UpdateDatetime before AutoMapper strips it, ensuring the persisted copy reflects the new timestamp.